### PR TITLE
fix: rangePicker footer hide when empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "rc-trigger": "^4.0.0-alpha.6",
     "rc-util": "^4.17.0"
   },
+  "engines": {
+    "node": ">=8.x"
+  },
   "devDependencies": {
     "@types/classnames": "^2.2.9",
     "@types/enzyme": "^3.10.3",

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -852,10 +852,12 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
         }}
       >
         <div className={`${prefixCls}-panels`}>{panels}</div>
-        <div className={`${prefixCls}-footer`}>
-          {extraNode}
-          {rangesNode}
-        </div>
+        {(extraNode || rangesNode) && (
+          <div className={`${prefixCls}-footer`}>
+            {extraNode}
+            {rangesNode}
+          </div>
+        )}
       </div>
     );
   }

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -124,6 +124,7 @@ describe('Picker.Range', () => {
     it('year', () => {
       const wrapper = mount(<MomentRangePicker picker="year" />);
       wrapper.openPicker();
+      expect(wrapper.exists('.rc-picker-footer')).toBeFalsy();
       expect(
         wrapper
           .find('.rc-picker-header-view')

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -138,6 +138,29 @@ describe('Picker.Range', () => {
           .text(),
       ).toEqual('2000-2009');
     });
+
+    it('year with footer', () => {
+      const wrapper = mount(
+        <MomentRangePicker
+          renderExtraFooter={() => <p>footer</p>}
+          picker="year"
+        />,
+      );
+      wrapper.openPicker();
+      expect(wrapper.find('.rc-picker-footer').text()).toEqual('footer');
+      expect(
+        wrapper
+          .find('.rc-picker-header-view')
+          .first()
+          .text(),
+      ).toEqual('1990-1999');
+      expect(
+        wrapper
+          .find('.rc-picker-header-view')
+          .last()
+          .text(),
+      ).toEqual('2000-2009');
+    });
   });
 
   it('endDate can not click before startDate', () => {


### PR DESCRIPTION
ref: https://github.com/ant-design/ant-design/pull/20736#issuecomment-572344743