### PR TITLE
chore: more friendly tips

### DIFF
--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -477,6 +477,7 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
               autoFocus={autoFocus}
               placeholder={placeholder}
               ref={inputRef}
+              title={text}
               {...inputProps}
               size={getInputSize(picker, formatList[0])}
               {...getDataOrAriaProps(props)}

--- a/tests/__snapshots__/picker.spec.tsx.snap
+++ b/tests/__snapshots__/picker.spec.tsx.snap
@@ -7,6 +7,7 @@ exports[`Picker.Basic icon 1`] = `
   <input
     readonly=""
     size="12"
+    title="1990-09-03"
     value="1990-09-03"
   />
   <span
@@ -39,6 +40,7 @@ exports[`Picker.Basic pass data- & aria- & role 1`] = `
       readonly=""
       role="search"
       size="12"
+      title=""
       value=""
     />
   </div>
@@ -55,6 +57,7 @@ exports[`Picker.Basic should render correctly in rtl 1`] = `
     <input
       readonly=""
       size="12"
+      title=""
       value=""
     />
   </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22393991/75618472-cc18cf00-5ba9-11ea-916b-2d1ca5364675.png)

当时间选择框比较短的时候加个title会有个更友好的交互，能看到选择到的时间。