### PR TITLE
Ant V3 -> V4 Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ render(<Picker />, mountNode);
 | showTime | Boolean \| Object | [showTime options](#showTime-options) | to provide an additional time selection |
 | picker | time \| date \| week \| month \| year |  | control which kind of panel should be shown |
 | format | String \| String[] | depends on whether you set timePicker and your locale | use to format/parse date(without time) value to/from input. When an array is provided, all values are used for parsing and first value for display |
+| formatHours | String | depends on whether you set timePicker and your locale | use to format picker panel hours column |
 | use12Hours | Boolean | false | 12 hours display mode |
 | value | moment |  | current value like input's value |
 | defaultValue | moment |  | defaultValue like input's defaultValue |
@@ -130,6 +131,7 @@ render(<Picker />, mountNode);
 | Property            | Type    | Default | Description                        |
 | ------------------- | ------- | ------- | ---------------------------------- |
 | format              | String  |         | moment format                      |
+| formatHours         | String  |         | moment format for hours in column  |
 | showHour            | Boolean | true    | whether show hour                  |
 | showMinute          | Boolean | true    | whether show minute                |
 | showSecond          | Boolean | true    | whether show second                |

--- a/examples/basic.tsx
+++ b/examples/basic.tsx
@@ -117,6 +117,10 @@ export default () => {
           <Picker<Moment> {...sharedProps} locale={zhCN} picker="time" use12Hours />
         </div>
         <div style={{ margin: '0 8px' }}>
+          <h3>Time Hours Format</h3>
+          <Picker<Moment> {...sharedProps} locale={enUS} picker="time" formatHours="h A" />
+        </div>
+        <div style={{ margin: '0 8px' }}>
           <h3>Year</h3>
           <Picker<Moment> {...sharedProps} locale={zhCN} picker="year" />
         </div>

--- a/examples/panel.tsx
+++ b/examples/panel.tsx
@@ -100,6 +100,19 @@ export default () => {
           />
         </div>
         <div style={{ margin: '0 8px' }}>
+          <h3>Formatted Hours</h3>
+          <PickerPanel<Moment>
+            {...sharedProps}
+            locale={enUS}
+            picker="time"
+            showTime={{
+              showSecond: false,
+              format: 'h:mm A',
+              formatHours: 'h A',
+            }}
+          />
+        </div>
+        <div style={{ margin: '0 8px' }}>
           <h3>Datetime</h3>
           <PickerPanel<Moment> {...sharedProps} locale={zhCN} showTime />
         </div>

--- a/examples/rtl.tsx
+++ b/examples/rtl.tsx
@@ -41,10 +41,7 @@ export default () => {
 
   return (
     <div dir="rtl">
-      <h2>
-        Value:{' '}
-        {value ? `${formatDate(value[0])} ~ ${formatDate(value[1])}` : 'null'}
-      </h2>
+      <h2>Value: {value ? `${formatDate(value[0])} ~ ${formatDate(value[1])}` : 'null'}</h2>
 
       <div style={{ display: 'flex', flexWrap: 'wrap' }}>
         <div style={{ margin: '0 8px' }}>
@@ -104,6 +101,19 @@ export default () => {
           />
         </div>
         <div style={{ margin: '0 8px' }}>
+          <h3>Time Hours Format</h3>
+          <PickerPanel<Moment>
+            {...sharedProps}
+            locale={enUS}
+            mode="time"
+            showTime={{
+              showSecond: false,
+              format: 'h:mm A',
+              formatHours: 'h A',
+            }}
+          />
+        </div>
+        <div style={{ margin: '0 8px' }}>
           <h3>Datetime</h3>
           <PickerPanel<Moment> {...sharedProps} locale={zhCN} showTime />
         </div>
@@ -116,11 +126,7 @@ export default () => {
         </div>
         <div style={{ margin: '0 8px' }}>
           <h3>Uncontrolled</h3>
-          <Picker<Moment>
-            generateConfig={momentGenerateConfig}
-            locale={zhCN}
-            allowClear
-          />
+          <Picker<Moment> generateConfig={momentGenerateConfig} locale={zhCN} allowClear />
         </div>
         <div style={{ margin: '0 8px' }}>
           <h3>Datetime</h3>
@@ -172,11 +178,7 @@ export default () => {
         </div>
         <div style={{ margin: '0 8px' }}>
           <h3>Week</h3>
-          <Picker<Moment>
-            generateConfig={momentGenerateConfig}
-            locale={zhCN}
-            picker="week"
-          />
+          <Picker<Moment> generateConfig={momentGenerateConfig} locale={zhCN} picker="week" />
         </div>
         <div style={{ margin: '0 8px' }}>
           <h3>Time</h3>
@@ -184,12 +186,7 @@ export default () => {
         </div>
         <div style={{ margin: '0 8px' }}>
           <h3>Time 12</h3>
-          <Picker<Moment>
-            {...sharedProps}
-            locale={zhCN}
-            picker="time"
-            use12Hours
-          />
+          <Picker<Moment> {...sharedProps} locale={zhCN} picker="time" use12Hours />
         </div>
         <div style={{ margin: '0 8px' }}>
           <h3>Year</h3>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-picker",
-  "version": "1.4.2",
+  "version": "1.4.2-getaround.1",
   "description": "React date & time picker",
   "keywords": [
     "react",
@@ -19,7 +19,7 @@
   "homepage": "https://react-component.github.io/picker",
   "repository": {
     "type": "git",
-    "url": "git@github.com:react-component/picker.git"
+    "url": "git@github.com:Getaround/picker.git"
   },
   "bugs": {
     "url": "http://github.com/react-component/picker/issues"

--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -26,11 +26,7 @@ import { isEqual } from './utils/dateUtil';
 import getDataOrAriaProps, { toArray } from './utils/miscUtil';
 import PanelContext, { ContextOperationRefProps } from './PanelContext';
 import { PickerMode } from './interface';
-import {
-  getDefaultFormat,
-  getInputSize,
-  elementsContains,
-} from './utils/uiUtil';
+import { getDefaultFormat, getInputSize, elementsContains } from './utils/uiUtil';
 import usePickerInput from './hooks/usePickerInput';
 import useTextValueMapping from './hooks/useTextValueMapping';
 import useValueTexts from './hooks/useValueTexts';
@@ -56,6 +52,7 @@ export interface PickerSharedProps<DateType> extends React.AriaAttributes {
 
   // Value
   format?: string | string[];
+  formatHours?: string;
 
   // Render
   suffixIcon?: React.ReactNode;
@@ -120,9 +117,7 @@ export type PickerProps<DateType> =
 
 interface MergedPickerProps<DateType>
   extends Omit<
-    PickerBaseProps<DateType> &
-      PickerDateProps<DateType> &
-      PickerTimeProps<DateType>,
+    PickerBaseProps<DateType> & PickerDateProps<DateType> & PickerTimeProps<DateType>,
     'picker'
   > {
   picker?: PickerMode;
@@ -173,13 +168,10 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
 
   const inputRef = React.useRef<HTMLInputElement>(null);
 
-  const needConfirmButton: boolean =
-    (picker === 'date' && !!showTime) || picker === 'time';
+  const needConfirmButton: boolean = (picker === 'date' && !!showTime) || picker === 'time';
 
   // ============================= State =============================
-  const formatList = toArray(
-    getDefaultFormat(format, picker, showTime, use12Hours),
-  );
+  const formatList = toArray(getDefaultFormat(format, picker, showTime, use12Hours));
 
   // Panel ref
   const panelDivRef = React.useRef<HTMLDivElement>(null);
@@ -192,9 +184,7 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
   });
 
   // Selected value
-  const [selectedValue, setSelectedValue] = React.useState<DateType | null>(
-    mergedValue,
-  );
+  const [selectedValue, setSelectedValue] = React.useState<DateType | null>(mergedValue);
 
   // Operation ref
   const operationRef: React.MutableRefObject<ContextOperationRefProps | null> = React.useRef<
@@ -227,11 +217,7 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
   const [text, triggerTextChange, resetText] = useTextValueMapping({
     valueTexts,
     onTextChange: newText => {
-      const inputDate = generateConfig.locale.parse(
-        locale.locale,
-        newText,
-        formatList,
-      );
+      const inputDate = generateConfig.locale.parse(locale.locale, newText, formatList);
       if (inputDate && (!disabledDate || !disabledDate(inputDate))) {
         setSelectedValue(inputDate);
       }
@@ -246,17 +232,12 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
     if (onChange && !isEqual(generateConfig, mergedValue, newValue)) {
       onChange(
         newValue,
-        newValue
-          ? generateConfig.locale.format(locale.locale, newValue, formatList[0])
-          : '',
+        newValue ? generateConfig.locale.format(locale.locale, newValue, formatList[0]) : '',
       );
     }
   };
 
-  const triggerOpen = (
-    newOpen: boolean,
-    preventChangeEvent: boolean = false,
-  ) => {
+  const triggerOpen = (newOpen: boolean, preventChangeEvent: boolean = false) => {
     triggerInnerOpen(newOpen);
     if (!newOpen && !preventChangeEvent) {
       triggerChange(selectedValue);
@@ -280,9 +261,7 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
     }
   };
 
-  const onInternalMouseUp: React.MouseEventHandler<HTMLDivElement> = (
-    ...args
-  ) => {
+  const onInternalMouseUp: React.MouseEventHandler<HTMLDivElement> = (...args) => {
     if (onMouseUp) {
       onMouseUp(...args);
     }
@@ -300,10 +279,7 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
     triggerOpen,
     forwardKeyDown,
     isClickOutside: target =>
-      !elementsContains(
-        [panelDivRef.current, inputDivRef.current],
-        target as HTMLElement,
-      ),
+      !elementsContains([panelDivRef.current, inputDivRef.current], target as HTMLElement),
     onSubmit: () => {
       triggerChange(selectedValue);
       triggerOpen(false, true);
@@ -428,10 +404,7 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
   }
 
   // ============================ Return =============================
-  const onContextSelect = (
-    date: DateType,
-    type: 'key' | 'mouse' | 'submit',
-  ) => {
+  const onContextSelect = (date: DateType, type: 'key' | 'mouse' | 'submit') => {
     if (type === 'submit' || (type !== 'key' && !needConfirmButton)) {
       // triggerChange will also update selected values
       triggerChange(date);

--- a/src/panels/TimePanel/TimeUnitColumn.tsx
+++ b/src/panels/TimePanel/TimeUnitColumn.tsx
@@ -19,14 +19,7 @@ export interface TimeUnitColumnProps {
 }
 
 function TimeUnitColumn(props: TimeUnitColumnProps) {
-  const {
-    prefixCls,
-    units,
-    onSelect,
-    value,
-    active,
-    hideDisabledOptions,
-  } = props;
+  const { prefixCls, units, onSelect, value, active, hideDisabledOptions } = props;
   const cellPrefixCls = `${prefixCls}-cell`;
   const { open } = React.useContext(PanelContext);
 
@@ -37,7 +30,8 @@ function TimeUnitColumn(props: TimeUnitColumnProps) {
   React.useLayoutEffect(() => {
     const li = liRefs.current.get(value!);
     if (li && open !== false) {
-      scrollTo(ulRef.current!, li.offsetTop, 120);
+      const ul = ulRef.current!;
+      scrollTo(ul, li.offsetTop + li.offsetHeight / 2 - ul.offsetHeight / 2, 120);
     }
   }, [value]);
 
@@ -45,7 +39,8 @@ function TimeUnitColumn(props: TimeUnitColumnProps) {
     if (open) {
       const li = liRefs.current.get(value!);
       if (li) {
-        scrollTo(ulRef.current!, li.offsetTop, 0);
+        const ul = ulRef.current!;
+        scrollTo(ulRef.current!, li.offsetTop + li.offsetHeight / 2 - ul.offsetHeight / 2, 0);
       }
     }
   }, [open]);

--- a/src/panels/TimePanel/index.tsx
+++ b/src/panels/TimePanel/index.tsx
@@ -7,6 +7,7 @@ import { createKeyDownHandler } from '../../utils/uiUtil';
 
 export interface SharedTimeProps<DateType> extends DisabledTimes {
   format?: string;
+  formatHours?: string;
   showHour?: boolean;
   showMinute?: boolean;
   showSecond?: boolean;
@@ -22,6 +23,7 @@ export interface TimePanelProps<DateType>
   extends PanelSharedProps<DateType>,
     SharedTimeProps<DateType> {
   format?: string;
+  formatHours?: string;
   active?: boolean;
 }
 
@@ -32,6 +34,7 @@ function TimePanel<DateType>(props: TimePanelProps<DateType>) {
   const {
     generateConfig,
     format = 'HH:mm:ss',
+    formatHours,
     prefixCls,
     active,
     operationRef,
@@ -47,20 +50,13 @@ function TimePanel<DateType>(props: TimePanelProps<DateType>) {
 
   // ======================= Keyboard =======================
   const [activeColumnIndex, setActiveColumnIndex] = React.useState(-1);
-  const columnsCount = countBoolean([
-    showHour,
-    showMinute,
-    showSecond,
-    use12Hours,
-  ]);
+  const columnsCount = countBoolean([showHour, showMinute, showSecond, use12Hours]);
 
   operationRef.current = {
     onKeyDown: event =>
       createKeyDownHandler(event, {
         onLeftRight: diff => {
-          setActiveColumnIndex(
-            (activeColumnIndex + diff + columnsCount) % columnsCount,
-          );
+          setActiveColumnIndex((activeColumnIndex + diff + columnsCount) % columnsCount);
         },
         onUpDown: diff => {
           if (activeColumnIndex === -1) {
@@ -92,6 +88,7 @@ function TimePanel<DateType>(props: TimePanelProps<DateType>) {
         prefixCls={prefixCls}
         activeColumnIndex={activeColumnIndex}
         operationRef={bodyOperationRef}
+        formatHours={formatHours}
       />
     </div>
   );


### PR DESCRIPTION
## What this does
Implements https://github.com/Getaround/time-picker/pull/1 and https://github.com/Getaround/time-picker/pull/2, in this repo. Since Ant changed the underlying TimePicker repo, let's bring that functionality back and see if we can get it merged at some point into the main repo.

## How I tested it
- Clone this repo
- Run `npm install`
- Run `npm start`, and you can see some stories in Storybook

## What it looks like

TimePicker selection before:

![2020-04-01 17 56 30](https://user-images.githubusercontent.com/6894781/78210405-f7b7ff00-745e-11ea-85c8-296e43e2cdea.gif)

TimePicker selection after:

![2020-04-01 17 57 49](https://user-images.githubusercontent.com/6894781/78210425-056d8480-745f-11ea-8dff-27fe89d7a396.gif)

TimePicker hours format before:

![2020-04-01 21 25 16](https://user-images.githubusercontent.com/6894781/78210533-55e4e200-745f-11ea-8e93-a1bb14882184.gif)

TimePicker hours format after:

![2020-04-01 21 24 33](https://user-images.githubusercontent.com/6894781/78210543-5b422c80-745f-11ea-98e4-c828309f6447.gif)
