### PR TITLE
Add date fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "@babel/runtime": "^7.10.1",
     "classnames": "^2.2.1",
-    "date-fns": "^2.14.0",
     "moment": "^2.24.0",
     "rc-trigger": "^4.0.0",
     "rc-util": "^5.0.1",
@@ -59,6 +58,7 @@
     "@umijs/fabric": "^2.0.8",
     "coveralls": "^3.0.6",
     "cross-env": "^7.0.2",
+    "date-fns": "2.14.0",
     "dayjs": "^1.8.18",
     "enzyme": "^3.0.0",
     "enzyme-adapter-react-16": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@babel/runtime": "^7.10.1",
     "classnames": "^2.2.1",
+    "date-fns": "^2.14.0",
     "moment": "^2.24.0",
     "rc-trigger": "^4.0.0",
     "rc-util": "^5.0.1",

--- a/src/generate/date-fn.ts
+++ b/src/generate/date-fn.ts
@@ -1,0 +1,102 @@
+/* eslint-disable */
+import { noteOnce } from 'rc-util/lib/warning';
+import {
+  getYear,
+  getMonth,
+  getDate,
+  getHours,
+  getMinutes,
+  getSeconds,
+  addYears,
+  addMonths,
+  addDays,
+  setYear,
+  setMonth,
+  setDate,
+  setHours,
+  setMinutes,
+  setSeconds,
+  isAfter,
+  isValid,
+  getDay,
+  setDay,
+  format,
+  parse,
+  toDate,
+} from 'date-fns';
+
+import { GenerateConfig } from '.';
+
+const localeMap = {
+  en_GB: 'en-gb',
+  en_US: 'en',
+  zh_CN: 'zh-cn',
+  zh_TW: 'zh-tw',
+};
+
+const parseLocale = function parseLocale(locale: string) {
+  const mapLocale = localeMap[locale];
+  return mapLocale || locale.split('_')[0];
+};
+
+const config: GenerateConfig<Date> = {
+  getNow() {
+    return new Date();
+  },
+  getWeekDay(date) {
+    return getDay(date);
+  },
+  getYear,
+  getMonth,
+  getDate,
+  getHour: getHours,
+  getMinute: getMinutes,
+  getSecond: getSeconds,
+  addYear: addYears,
+  addMonth: addMonths,
+  addDate: addDays,
+  setYear,
+  setMonth,
+  setDate,
+  setHour: setHours,
+  setMinute: setMinutes,
+  setSecond: setSeconds,
+  isAfter,
+  isValidate: isValid,
+  locale: {
+    getWeekFirstDay(locale) {
+      return getDay(setDay(new Date(new Date().toLocaleDateString(locale)), 1));
+    },
+    getWeek(locale, date) {
+      return getDay(new Date(new Date(date).toLocaleDateString(locale)));
+    },
+    format(locale, date, _format) {
+      return format(new Date(date.toLocaleDateString(locale)), _format);
+    },
+    parse(locale, text, formats) {
+      const fallbackFormatList: string[] = [];
+      for (let _format of formats) {
+        let formatText = text;
+        if (/[Ww]o/g.test(_format)) {
+          _format = _format.replace(/wo/g, 'w').replace(/Wo/g, 'W');
+          const matchFormat = _format.match(/[-YyMmDdHhSsWwGg]+/g);
+          const matchText = formatText.match(/[-\d]+/g);
+          if (matchFormat && matchText) {
+            _format = matchFormat.join('');
+            formatText = matchText.join('');
+          } else {
+            fallbackFormatList.push(_format.replace(/o/g, ''));
+          }
+        }
+
+        const date = format(new Date(formatText), _format, { locale: { code: locale } });
+        if (isValid(date)) {
+          return new Date(new Date(formatText).toLocaleDateString(locale));
+        }
+      }
+      return null;
+    },
+  },
+};
+
+export default config;

--- a/src/generate/date-fns.ts
+++ b/src/generate/date-fns.ts
@@ -30,12 +30,35 @@ import { enUS, zhCN, zhTW, enGB } from 'date-fns/locale';
 
 import { GenerateConfig } from '.';
 
-// TODO: should be export interface let user import supported locale
+// hack for zh_CN and zh_TW week display
+function chineseLocalizeReplace(fn: Locale['localize']['ordinalNumber']) {
+  return (dirtyNumber: string, dirtyOptions: { unit?: any }) => {
+    const unit = String(dirtyOptions.unit);
+    if (unit === 'week') {
+      return `${+dirtyNumber}周`;
+    } else {
+      return fn(dirtyNumber, dirtyOptions);
+    }
+  };
+}
+
 const localeMap = {
   en_GB: enGB,
   en_US: enUS,
-  zh_CN: zhCN,
-  zh_TW: zhTW,
+  zh_CN: {
+    ...zhCN,
+    localize: {
+      ...zhCN.localize,
+      ordinalNumber: chineseLocalizeReplace(zhCN.localize.ordinalNumber),
+    },
+  },
+  zh_TW: {
+    ...zhTW,
+    localize: {
+      ...zhTW.localize,
+      ordinalNumber: chineseLocalizeReplace(zhTW.localize.ordinalNumber),
+    },
+  },
 };
 
 const parseLocale = function parseLocale(locale: string) {

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -1,6 +1,7 @@
 import MockDate from 'mockdate';
 import momentGenerateConfig from '../src/generate/moment';
 import dayjsGenerateConfig from '../src/generate/dayjs';
+import dateFnsGenerateConfig from '../src/generate/date-fn';
 import { getMoment } from './util/commonUtil';
 
 import 'dayjs/locale/zh-cn';
@@ -18,6 +19,7 @@ describe('Picker.Generate', () => {
   const list: { name: string; generateConfig: GenerateConfig<any> }[] = [
     { name: 'moment', generateConfig: momentGenerateConfig },
     { name: 'dayjs', generateConfig: dayjsGenerateConfig },
+    { name: 'date-fns', generateConfig: dateFnsGenerateConfig },
   ];
 
   list.forEach(({ name, generateConfig }) => {
@@ -87,14 +89,14 @@ describe('Picker.Generate', () => {
                 'gggg-wo',
               ),
             ).toEqual('2019-1st');
-
-            expect(
-              generateConfig.locale.format(
-                'zh_CN',
-                generateConfig.locale.parse('zh_CN', '2019-45周', ['gggg-wo'])!,
-                'gggg-wo',
-              ),
-            ).toEqual('2019-45周');
+            // Date fns still now support 周 in the locale
+            // expect(
+            //   generateConfig.locale.format(
+            //     'zh_CN',
+            //     generateConfig.locale.parse('zh_CN', '2019-45周', ['gggg-wo'])!,
+            //     'gggg-wo',
+            //   ),
+            // ).toEqual('2019-45周');
           });
         });
       });
@@ -126,12 +128,11 @@ describe('Picker.Generate', () => {
       });
 
       it('Parse format Wo', () => {
-        expect(
-          generateConfig.locale.parse('en_US', '2012-51st', ['YYYY-Wo'])?.format('Wo'),
-        ).toEqual('51st');
-        expect(generateConfig.locale.parse('zh_CN', '2012-1周', ['YYYY-Wo'])?.format('Wo')).toEqual(
-          '1周',
-        );
+        const basic = generateConfig.locale.parse('en_US', '2012-51st', ['YYYY-Wo']);
+        expect(generateConfig.locale.format('en_US', basic, 'Wo')).toEqual('51st');
+        // expect(generateConfig.locale.parse('zh_CN', '2012-1周', ['YYYY-Wo'])?.format('Wo')).toEqual(
+        //   '1周',
+        // );
       });
 
       it('Parse format faild', () => {

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -90,13 +90,13 @@ describe('Picker.Generate', () => {
               ),
             ).toEqual('2019-1st');
             // Date fns still now support 周 in the locale
-            // expect(
-            //   generateConfig.locale.format(
-            //     'zh_CN',
-            //     generateConfig.locale.parse('zh_CN', '2019-45周', ['gggg-wo'])!,
-            //     'gggg-wo',
-            //   ),
-            // ).toEqual('2019-45周');
+            expect(
+              generateConfig.locale.format(
+                'zh_CN',
+                generateConfig.locale.parse('zh_CN', '2019-45周', ['gggg-wo'])!,
+                'gggg-wo',
+              ),
+            ).toEqual('2019-45周');
           });
         });
       });
@@ -128,11 +128,10 @@ describe('Picker.Generate', () => {
       });
 
       it('Parse format Wo', () => {
-        const basic = generateConfig.locale.parse('en_US', '2012-51st', ['YYYY-Wo']);
+        let basic = generateConfig.locale.parse('en_US', '2012-51st', ['YYYY-Wo']);
         expect(generateConfig.locale.format('en_US', basic, 'Wo')).toEqual('51st');
-        // expect(generateConfig.locale.parse('zh_CN', '2012-1周', ['YYYY-Wo'])?.format('Wo')).toEqual(
-        //   '1周',
-        // );
+        basic = generateConfig.locale.parse('zh_CN', '2012-1周', ['YYYY-Wo']);
+        expect(generateConfig.locale.format('zh_CN', basic, 'Wo')).toEqual('1周');
       });
 
       it('Parse format faild', () => {

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -75,8 +75,11 @@ describe('Picker.Generate', () => {
             ['2000-01-02', '02/01/2000'].forEach(str => {
               const date = generateConfig.locale.parse('en_US', str, ['YYYY-MM-DD', 'DD/MM/YYYY']);
 
-              expect(generateConfig.locale.format('en_US', date!, 'YYYY-MM-DD')).toEqual(
-                '2000-01-02',
+              expect(generateConfig.locale.format('en_US', date!, 'YYYY-MM-Do')).toEqual(
+                '2000-01-2nd',
+              );
+              expect(generateConfig.locale.format('zh_CN', date!, 'YYYY-MM-Do')).toEqual(
+                '2000-01-2日',
               );
             });
           });

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -1,7 +1,7 @@
 import MockDate from 'mockdate';
 import momentGenerateConfig from '../src/generate/moment';
 import dayjsGenerateConfig from '../src/generate/dayjs';
-import dateFnsGenerateConfig from '../src/generate/date-fn';
+import dateFnsGenerateConfig from '../src/generate/date-fns';
 import { getMoment } from './util/commonUtil';
 
 import 'dayjs/locale/zh-cn';
@@ -89,7 +89,7 @@ describe('Picker.Generate', () => {
                 'gggg-wo',
               ),
             ).toEqual('2019-1st');
-            // Date fns still now support 周 in the locale
+
             expect(
               generateConfig.locale.format(
                 'zh_CN',


### PR DESCRIPTION
I added date-fns to the generate support, and I find the format of `wo` cannot transform to `周` correctly. Thus, I did some hacking stuff in the generate.

And for the testing script, because of date-fns doesn't support chaining function like `.format`,  I made some changes to it.