### PR TITLE
chore: Adjust open picker logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rc-picker
+# rc-picker 
 
 [![NPM version][npm-image]][npm-url]
 [![build status][circleci-image]][circleci-url]

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -534,7 +534,6 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
 
       // Only blur will close open
       if (!newOpen && mergedActivePickerIndex === index) {
-        console.log('Trigger change!!!');
         triggerChange(selectedValue, index);
       }
     },

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -239,7 +239,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
   const [mergedValue, setInnerValue] = useMergedState<RangeValue<DateType>>(null, {
     value,
     defaultValue,
-    postState: (values) =>
+    postState: values =>
       picker === 'time' && !order ? values : reorderValues(values, generateConfig),
   });
 
@@ -254,7 +254,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
 
   // ========================= Select Values =========================
   const [selectedValue, setSelectedValue] = useMergedState(mergedValue, {
-    postState: (values) => {
+    postState: values => {
       let postValues = values;
 
       if (mergedDisabled[0] && mergedDisabled[1]) {
@@ -314,8 +314,8 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
   const [mergedOpen, triggerInnerOpen] = useMergedState(false, {
     value: open,
     defaultValue: defaultOpen,
-    postState: (postOpen) => (mergedDisabled[mergedActivePickerIndex] ? false : postOpen),
-    onChange: (newOpen) => {
+    postState: postOpen => (mergedDisabled[mergedActivePickerIndex] ? false : postOpen),
+    onChange: newOpen => {
       if (onOpenChange) {
         onOpenChange(newOpen);
       }
@@ -445,7 +445,9 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
       // Delay to focus to avoid input blur trigger expired selectedValues
       setTimeout(() => {
         const inputRef = [startInputRef, endInputRef][nextOpenIndex];
-        inputRef.current?.focus();
+        if (inputRef.current) {
+          inputRef.current.focus();
+        }
       }, 0);
     } else {
       triggerOpen(false, sourceIndex);
@@ -499,12 +501,12 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
 
   const [startText, triggerStartTextChange, resetStartText] = useTextValueMapping<DateType>({
     valueTexts: startValueTexts,
-    onTextChange: (newText) => onTextChange(newText, 0),
+    onTextChange: newText => onTextChange(newText, 0),
   });
 
   const [endText, triggerEndTextChange, resetEndText] = useTextValueMapping<DateType>({
     valueTexts: endValueTexts,
-    onTextChange: (newText) => onTextChange(newText, 1),
+    onTextChange: newText => onTextChange(newText, 1),
   });
 
   // ============================= Input =============================
@@ -625,7 +627,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
   // ============================ Ranges =============================
   const rangeLabels = Object.keys(ranges || {});
 
-  const rangeList = rangeLabels.map((label) => {
+  const rangeList = rangeLabels.map(label => {
     const range = ranges![label];
     const newValues = typeof range === 'function' ? range() : range;
 
@@ -699,7 +701,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
           style={undefined}
           direction={direction}
           disabledDate={mergedActivePickerIndex === 0 ? disabledStartDate : disabledEndDate}
-          disabledTime={(date) => {
+          disabledTime={date => {
             if (disabledTime) {
               return disabledTime(date, mergedActivePickerIndex === 0 ? 'start' : 'end');
             }
@@ -786,13 +788,13 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
       const showDoublePanel = currentMode === picker;
       const leftPanel = renderPanel(showDoublePanel ? 'left' : false, {
         pickerValue: viewDate,
-        onPickerValueChange: (newViewDate) => {
+        onPickerValueChange: newViewDate => {
           setViewDate(newViewDate, mergedActivePickerIndex);
         },
       });
       const rightPanel = renderPanel('right', {
         pickerValue: nextViewDate,
-        onPickerValueChange: (newViewDate) => {
+        onPickerValueChange: newViewDate => {
           setViewDate(
             getClosingViewDate(newViewDate, picker, generateConfig, -1),
             mergedActivePickerIndex,
@@ -824,7 +826,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
         className={`${prefixCls}-panel-container`}
         style={{ marginLeft: panelLeft }}
         ref={panelDivRef}
-        onMouseDown={(e) => {
+        onMouseDown={e => {
           e.preventDefault();
         }}
       >
@@ -864,11 +866,11 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
   ) {
     clearNode = (
       <span
-        onMouseDown={(e) => {
+        onMouseDown={e => {
           e.preventDefault();
           e.stopPropagation();
         }}
-        onMouseUp={(e) => {
+        onMouseUp={e => {
           e.preventDefault();
           e.stopPropagation();
           let values = mergedValue;
@@ -964,7 +966,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
               disabled={mergedDisabled[0]}
               readOnly={inputReadOnly || !startTyping}
               value={startText}
-              onChange={(e) => {
+              onChange={e => {
                 triggerStartTextChange(e.target.value);
               }}
               autoFocus={autoFocus}
@@ -988,7 +990,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
               disabled={mergedDisabled[1]}
               readOnly={inputReadOnly || !endTyping}
               value={endText}
-              onChange={(e) => {
+              onChange={e => {
                 triggerEndTextChange(e.target.value);
               }}
               placeholder={getValue(placeholder, 1) || ''}

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -383,6 +383,9 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
         // Clean up end date when start date is after end date
         values = [startValue, null];
         endValue = null;
+
+        // Clean up cache since invalidate
+        openRecordsRef.current = {};
       } else if (picker !== 'time' || order !== false) {
         // Reorder when in same date
         values = reorderValues(values, generateConfig);

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -502,12 +502,12 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
     }
   };
 
-  const [startText, triggerStartTextChange, resetStartText] = useTextValueMapping<DateType>({
+  const [startText, triggerStartTextChange, resetStartText] = useTextValueMapping({
     valueTexts: startValueTexts,
     onTextChange: newText => onTextChange(newText, 0),
   });
 
-  const [endText, triggerEndTextChange, resetEndText] = useTextValueMapping<DateType>({
+  const [endText, triggerEndTextChange, resetEndText] = useTextValueMapping({
     valueTexts: endValueTexts,
     onTextChange: newText => onTextChange(newText, 1),
   });
@@ -533,7 +533,8 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
       triggerOpen(newOpen, index);
 
       // Only blur will close open
-      if (!newOpen && activePickerIndex === index) {
+      if (!newOpen && mergedActivePickerIndex === index) {
+        console.log('Trigger change!!!');
         triggerChange(selectedValue, index);
       }
     },
@@ -775,7 +776,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
       onOk: () => {
         if (getValue(selectedValue, mergedActivePickerIndex)) {
           // triggerChangeOld(selectedValue);
-          triggerChange(selectedValue, null);
+          triggerChange(selectedValue, mergedActivePickerIndex);
           if (onOk) {
             onOk(selectedValue);
           }

--- a/src/hooks/useTextValueMapping.ts
+++ b/src/hooks/useTextValueMapping.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export default function useTextValueMapping<ValueType>({
+export default function useTextValueMapping({
   valueTexts,
   onTextChange,
 }: {

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -782,6 +782,8 @@ describe('Picker.Range', () => {
       Object.defineProperty(clickEvent, 'target', {
         get: () => document.body,
       });
+
+      const current = onOpenChange.mock.calls.length;
       act(() => {
         window.dispatchEvent(clickEvent);
         wrapper
@@ -789,9 +791,10 @@ describe('Picker.Range', () => {
           .first()
           .simulate('blur');
       });
+      const next = onOpenChange.mock.calls.length;
 
       // Maybe not good since onOpenChange trigger twice
-      expect(onOpenChange).toHaveBeenCalledTimes((i + 1) * 2);
+      expect(current < next).toBeTruthy();
     }
     act(() => {
       jest.runAllTimers();
@@ -1200,5 +1203,57 @@ describe('Picker.Range', () => {
         .last()
         .prop('value'),
     ).toEqual('19901128');
+  });
+
+  describe('auto open', () => {
+    it('empty: start -> end -> close', () => {
+      const wrapper = mount(<MomentRangePicker />);
+      wrapper.openPicker(0);
+      wrapper.inputValue('1990-11-28');
+      wrapper.closePicker(0);
+
+      expect(wrapper.isOpen()).toBeTruthy();
+
+      wrapper.inputValue('1991-01-01');
+      wrapper.closePicker(1);
+      expect(wrapper.isOpen()).toBeFalsy();
+    });
+
+    it('valued: start -> end', () => {
+      const wrapper = mount(
+        <MomentRangePicker defaultValue={[getMoment('1989-01-01'), getMoment('1990-01-01')]} />,
+      );
+      wrapper.openPicker(0);
+      wrapper.inputValue('1990-11-28');
+      wrapper.closePicker(0);
+
+      expect(wrapper.isOpen()).toBeTruthy();
+    });
+
+    it('empty: end -> start', () => {
+      const wrapper = mount(<MomentRangePicker />);
+      wrapper.openPicker(1);
+      wrapper.inputValue('1990-11-28', 1);
+      wrapper.closePicker(1);
+
+      expect(wrapper.isOpen()).toBeTruthy();
+    });
+
+    it('empty: end before start -> start -> end', () => {
+      const wrapper = mount(<MomentRangePicker />);
+
+      wrapper.openPicker(1);
+      wrapper.inputValue('1990-11-28', 1);
+      wrapper.closePicker(1);
+      expect(wrapper.isOpen()).toBeTruthy();
+
+      wrapper.inputValue('1991-01-01', 0);
+      wrapper.closePicker(0);
+      expect(wrapper.isOpen()).toBeTruthy();
+
+      wrapper.inputValue('1992-01-01', 1);
+      wrapper.closePicker(1);
+      expect(wrapper.isOpen()).toBeFalsy();
+    });
   });
 });

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -1175,12 +1175,6 @@ describe('Picker.Range', () => {
         },
       });
     wrapper.closePicker();
-    expect(
-      wrapper
-        .find('input')
-        .first()
-        .prop('value'),
-    ).toEqual('19890903');
 
     // end date
     wrapper.openPicker(1);
@@ -1193,6 +1187,13 @@ describe('Picker.Range', () => {
         },
       });
     wrapper.closePicker(1);
+
+    expect(
+      wrapper
+        .find('input')
+        .first()
+        .prop('value'),
+    ).toEqual('19890903');
     expect(
       wrapper
         .find('input')

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -74,4 +74,9 @@ Object.assign(Enzyme.ReactWrapper.prototype, {
       .at(index)
       .simulate('keydown', { ...info, which });
   },
+  inputValue(text, index = 0) {
+    this.find('input')
+      .at(index)
+      .simulate('change', { target: { value: text } });
+  },
 });

--- a/tests/util/commonUtil.tsx
+++ b/tests/util/commonUtil.tsx
@@ -4,11 +4,7 @@ import moment, { Moment, unitOfTime } from 'moment';
 import Picker, { PickerProps, PickerPanel } from '../../src';
 import momentGenerateConfig from '../../src/generate/moment';
 import enUS from '../../src/locale/en_US';
-import {
-  PickerBaseProps,
-  PickerDateProps,
-  PickerTimeProps,
-} from '../../src/Picker';
+import { PickerBaseProps, PickerDateProps, PickerTimeProps } from '../../src/Picker';
 import {
   PickerPanelBaseProps,
   PickerPanelDateProps,
@@ -32,11 +28,10 @@ export type Wrapper = ReactWrapper & {
   clearValue: (index?: number) => void;
   keyDown: (which: number, info?: object, index?: number) => void;
   clickButton: (type: 'prev' | 'next' | 'super-prev' | 'super-next') => Wrapper;
+  inputValue: (text: string, index?: number) => Wrapper;
 };
 
-export const mount = originMount as (
-  ...args: Parameters<typeof originMount>
-) => Wrapper;
+export const mount = originMount as (...args: Parameters<typeof originMount>) => Wrapper;
 
 export function getMoment(str: string): Moment {
   const formatList = [FULL_FORMAT, 'YYYY-MM-DD', 'HH:mm:ss', 'YYYY'];
@@ -49,11 +44,7 @@ export function getMoment(str: string): Moment {
   throw new Error(`Format not match with: ${str}`);
 }
 
-export function isSame(
-  date: Moment | null,
-  dateStr: string,
-  type: unitOfTime.StartOf = 'date',
-) {
+export function isSame(date: Moment | null, dateStr: string, type: unitOfTime.StartOf = 'date') {
   if (!date) {
     return false;
   }
@@ -62,9 +53,7 @@ export function isSame(
     return true;
   }
 
-  throw new Error(
-    `${date.format(FULL_FORMAT)} is not same as expected: ${dateStr}`,
-  );
+  throw new Error(`${date.format(FULL_FORMAT)} is not same as expected: ${dateStr}`);
 }
 
 interface MomentDefaultProps {
@@ -72,8 +61,7 @@ interface MomentDefaultProps {
   generateConfig?: PickerProps<Moment>['generateConfig'];
 }
 
-type InjectDefaultProps<Props> = Omit<Props, 'locale' | 'generateConfig'> &
-  MomentDefaultProps;
+type InjectDefaultProps<Props> = Omit<Props, 'locale' | 'generateConfig'> & MomentDefaultProps;
 
 // Moment Picker
 export type MomentPickerProps =
@@ -103,11 +91,7 @@ export type MomentPickerPanelProps =
   | InjectDefaultProps<PickerPanelTimeProps<Moment>>;
 
 export const MomentPickerPanel = (props: MomentPickerPanelProps) => (
-  <PickerPanel<Moment>
-    generateConfig={momentGenerateConfig}
-    locale={enUS}
-    {...props}
-  />
+  <PickerPanel<Moment> generateConfig={momentGenerateConfig} locale={enUS} {...props} />
 );
 
 // Moment Range Picker


### PR DESCRIPTION
> 1. 选结束时间直接关闭浮层，完成选择。
> 2. 选开始时间会保持浮层，需要再点结束时间，这样和初始选择的习惯保持一致。

发现还有一些边界情况，调整为：

* 开始时间关闭，如果结束时间可以输入则打开结束时间。
* 结束时间关闭，如果开始时间为空则打开开始时间。
  * 结束时间打开的开始时间，关闭后不打开结束时间
  * 结束时间打开的开始时间，如果开始时间晚于结束时间，则重置结束时间，同时再次打开结束时间 

ref https://github.com/ant-design/ant-design/issues/25120