### PR TITLE
chore: Not trigger switch when user do nothing on input

### DIFF
--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -282,6 +282,7 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
   const [inputProps, { focused, typing }] = usePickerInput({
     blurToCancel: needConfirmButton,
     open: mergedOpen,
+    value: text,
     triggerOpen,
     forwardKeyDown,
     isClickOutside: target =>

--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -242,15 +242,12 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
     }
   };
 
-  const triggerOpen = (newOpen: boolean, preventChangeEvent: boolean = false) => {
+  const triggerOpen = (newOpen: boolean) => {
     if (disabled && newOpen) {
       return;
     }
 
     triggerInnerOpen(newOpen);
-    if (!newOpen && !preventChangeEvent) {
-      triggerChange(selectedValue);
-    }
   };
 
   const forwardKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
@@ -295,12 +292,12 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
       }
 
       triggerChange(selectedValue);
-      triggerOpen(false, true);
+      triggerOpen(false);
       resetText();
       return true;
     },
     onCancel: () => {
-      triggerOpen(false, true);
+      triggerOpen(false);
       setSelectedValue(mergedValue);
       resetText();
     },
@@ -400,7 +397,7 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
           e.preventDefault();
           e.stopPropagation();
           triggerChange(null);
-          triggerOpen(false, true);
+          triggerOpen(false);
         }}
         className={`${prefixCls}-clear`}
       >
@@ -422,7 +419,7 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
     if (type === 'submit' || (type !== 'key' && !needConfirmButton)) {
       // triggerChange will also update selected values
       triggerChange(date);
-      triggerOpen(false, true);
+      triggerOpen(false);
     }
   };
   const popupPlacement = direction === 'rtl' ? 'bottomRight' : 'bottomLeft';

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -556,11 +556,13 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
   const [startInputProps, { focused: startFocused, typing: startTyping }] = usePickerInput({
     ...getSharedInputHookProps(0, resetStartText),
     open: startOpen,
+    value: startText,
   });
 
   const [endInputProps, { focused: endFocused, typing: endTyping }] = usePickerInput({
     ...getSharedInputHookProps(1, resetEndText),
     open: endOpen,
+    value: endText,
   });
 
   // ============================= Sync ==============================

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -541,11 +541,6 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
     },
     triggerOpen: (newOpen: boolean) => {
       triggerOpen(newOpen, index);
-
-      // Only blur will close open
-      if (!newOpen && mergedOpen !== newOpen && mergedActivePickerIndex === index) {
-        triggerChange(selectedValue, index);
-      }
     },
     onSubmit: () => {
       triggerChange(selectedValue, index);

--- a/src/hooks/usePickerInput.ts
+++ b/src/hooks/usePickerInput.ts
@@ -99,8 +99,9 @@ export default function usePickerInput({
             onCancel();
           }
         }, 0);
-      } else {
+      } else if (open) {
         triggerOpen(false);
+        onSubmit();
       }
       setFocused(false);
 

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -1289,5 +1289,14 @@ describe('Picker.Range', () => {
       wrapper.closePicker(0);
       expect(wrapper.isOpen()).toBeFalsy();
     });
+
+    it('not change: start not to end', () => {
+      const wrapper = mount(
+        <MomentRangePicker defaultValue={[getMoment('1989-01-01'), getMoment('1990-01-01')]} />,
+      );
+      wrapper.openPicker(0);
+      wrapper.closePicker(0);
+      expect(wrapper.isOpen()).toBeFalsy();
+    });
   });
 });


### PR DESCRIPTION
调整了一下逻辑。
如果用户在 RangePicker 里打开了面板但是没做其他操作，那么关闭面板时不会触发第二个面板的开启。