### PR TITLE
fix: Safari cannot select date in first open

### DIFF
--- a/src/hooks/usePickerInput.ts
+++ b/src/hooks/usePickerInput.ts
@@ -136,9 +136,9 @@ export default function usePickerInput({
           preventBlurRef.current = true;
 
           // Always set back in case `onBlur` prevented by user
-          window.setTimeout(() => {
+          requestAnimationFrame(() => {
             preventBlurRef.current = false;
-          }, 0);
+          });
         } else if (!focused) {
           triggerOpen(false);
         }


### PR DESCRIPTION
Safari 版本13.1 (15609.1.20.111.8) 下。

https://picker.react-component.now.sh/?path=/story/rc-picker--basic
https://ant.design/components/date-picker/

点开 DatePicker 后，第一次选择日期大概率失效。