### PR TITLE
Update to current hour, minute and second

### DIFF
--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -357,6 +357,7 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
     style: undefined,
     pickerValue: undefined,
     onPickerValueChange: undefined,
+    mergedOpen,
   };
 
   const panel = (

--- a/src/PickerPanel.tsx
+++ b/src/PickerPanel.tsx
@@ -117,6 +117,7 @@ type OmitType<DateType> = Omit<PickerPanelBaseProps<DateType>, 'picker'> &
   Omit<PickerPanelTimeProps<DateType>, 'picker'>;
 interface MergedPickerPanelProps<DateType> extends OmitType<DateType> {
   picker?: PickerMode;
+  mergedOpen: boolean;
 }
 
 function PickerPanel<DateType>(props: PickerPanelProps<DateType>) {

--- a/src/PickerPanel.tsx
+++ b/src/PickerPanel.tsx
@@ -105,6 +105,7 @@ export interface PickerPanelTimeProps<DateType>
     SharedTimeProps<DateType> {
   picker: 'time';
   mergedOpen: boolean;
+  mergedActivePickerIndex: number;
 }
 
 export type PickerPanelProps<DateType> =

--- a/src/PickerPanel.tsx
+++ b/src/PickerPanel.tsx
@@ -104,6 +104,7 @@ export interface PickerPanelTimeProps<DateType>
   extends PickerPanelSharedProps<DateType>,
     SharedTimeProps<DateType> {
   picker: 'time';
+  mergedOpen: boolean;
 }
 
 export type PickerPanelProps<DateType> =
@@ -117,7 +118,6 @@ type OmitType<DateType> = Omit<PickerPanelBaseProps<DateType>, 'picker'> &
   Omit<PickerPanelTimeProps<DateType>, 'picker'>;
 interface MergedPickerPanelProps<DateType> extends OmitType<DateType> {
   picker?: PickerMode;
-  mergedOpen: boolean;
 }
 
 function PickerPanel<DateType>(props: PickerPanelProps<DateType>) {

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -780,6 +780,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
           defaultValue={undefined}
           defaultPickerValue={undefined}
           mergedOpen={mergedOpen}
+          mergedActivePickerIndex={mergedActivePickerIndex}
         />
       </RangeContext.Provider>
     );

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -779,6 +779,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
           onChange={undefined}
           defaultValue={undefined}
           defaultPickerValue={undefined}
+          mergedOpen={mergedOpen}
         />
       </RangeContext.Provider>
     );

--- a/src/panels/DatetimePanel/index.tsx
+++ b/src/panels/DatetimePanel/index.tsx
@@ -24,6 +24,7 @@ export interface DatetimePanelProps<DateType>
   disabledTime?: DisabledTime<DateType>;
   showTime?: boolean | SharedTimeProps<DateType>;
   defaultValue?: DateType;
+  mergedOpen: boolean;
 }
 
 const ACTIVE_PANEL = tuple('date', 'time');
@@ -39,14 +40,18 @@ function DatetimePanel<DateType>(props: DatetimePanelProps<DateType>) {
     disabledTime,
     showTime,
     onSelect,
+    mergedOpen,
   } = props;
   const panelPrefixCls = `${prefixCls}-datetime-panel`;
   const [activePanel, setActivePanel] = React.useState<ActivePanelType | null>(null);
+  const [temporaryStorageTime, setTemporaryStorageTime] = React.useState<DateType | null>(null);
 
   const dateOperationRef = React.useRef<PanelRefProps>({});
   const timeOperationRef = React.useRef<PanelRefProps>({});
 
   const timeProps = typeof showTime === 'object' ? { ...showTime } : {};
+  // temporaryStorageTime change if mergedOpen change
+  React.useMemo(() => setTemporaryStorageTime(null), [mergedOpen]);
 
   // ======================= Keyboard =======================
   function getNextActive(offset: number) {
@@ -126,6 +131,7 @@ function DatetimePanel<DateType>(props: DatetimePanelProps<DateType>) {
     if (onSelect) {
       onSelect(selectedDate, 'mouse');
     }
+    return selectedDate;
   };
 
   // ======================== Render ========================
@@ -142,7 +148,7 @@ function DatetimePanel<DateType>(props: DatetimePanelProps<DateType>) {
         operationRef={dateOperationRef}
         active={activePanel === 'date'}
         onSelect={date => {
-          const dateNow = generateConfig.getNow();
+          const dateNow = temporaryStorageTime || generateConfig.getNow();
           onInternalSelect(
             setTime(
               generateConfig,
@@ -164,7 +170,7 @@ function DatetimePanel<DateType>(props: DatetimePanelProps<DateType>) {
         operationRef={timeOperationRef}
         active={activePanel === 'time'}
         onSelect={date => {
-          onInternalSelect(date, 'time');
+          setTemporaryStorageTime(onInternalSelect(date, 'time'));
         }}
       />
     </div>

--- a/src/panels/DatetimePanel/index.tsx
+++ b/src/panels/DatetimePanel/index.tsx
@@ -25,6 +25,7 @@ export interface DatetimePanelProps<DateType>
   showTime?: boolean | SharedTimeProps<DateType>;
   defaultValue?: DateType;
   mergedOpen: boolean;
+  mergedActivePickerIndex: number;
 }
 
 const ACTIVE_PANEL = tuple('date', 'time');
@@ -41,6 +42,7 @@ function DatetimePanel<DateType>(props: DatetimePanelProps<DateType>) {
     showTime,
     onSelect,
     mergedOpen,
+    mergedActivePickerIndex,
   } = props;
   const panelPrefixCls = `${prefixCls}-datetime-panel`;
   const [activePanel, setActivePanel] = React.useState<ActivePanelType | null>(null);
@@ -51,7 +53,7 @@ function DatetimePanel<DateType>(props: DatetimePanelProps<DateType>) {
 
   const timeProps = typeof showTime === 'object' ? { ...showTime } : {};
   // temporaryStorageTime change if mergedOpen change
-  React.useMemo(() => setTemporaryStorageTime(null), [mergedOpen]);
+  React.useMemo(() => setTemporaryStorageTime(null), [mergedOpen, mergedActivePickerIndex]);
 
   // ======================= Keyboard =======================
   function getNextActive(offset: number) {

--- a/src/panels/DatetimePanel/index.tsx
+++ b/src/panels/DatetimePanel/index.tsx
@@ -12,6 +12,10 @@ function setTime<DateType>(
   date: DateType,
   defaultDate: NullableDateType<DateType>,
 ) {
+  if (!defaultDate) {
+    return date;
+  }
+
   let newDate = date;
   newDate = generateConfig.setHour(newDate, generateConfig.getHour(defaultDate));
   newDate = generateConfig.setMinute(newDate, generateConfig.getMinute(defaultDate));

--- a/src/panels/DatetimePanel/index.tsx
+++ b/src/panels/DatetimePanel/index.tsx
@@ -151,7 +151,7 @@ function DatetimePanel<DateType>(props: DatetimePanelProps<DateType>) {
             setTime(
               generateConfig,
               date,
-              showTime && typeof showTime === 'object' ? showTime.defaultValue : dateNow,
+              showTime && typeof showTime === 'object' ? showTime.defaultValue || null : dateNow,
             ),
             'date',
           );

--- a/src/panels/DatetimePanel/index.tsx
+++ b/src/panels/DatetimePanel/index.tsx
@@ -174,13 +174,14 @@ function DatetimePanel<DateType>(props: DatetimePanelProps<DateType>) {
         operationRef={dateOperationRef}
         active={activePanel === 'date'}
         onSelect={date => {
+          const dateNow = generateConfig.getNow();
           onInternalSelect(
             setTime(
               generateConfig,
               date,
               showTime && typeof showTime === 'object'
                 ? showTime.defaultValue
-                : null,
+                : dateNow,
             ),
             'date',
           );

--- a/src/panels/DatetimePanel/index.tsx
+++ b/src/panels/DatetimePanel/index.tsx
@@ -12,31 +12,15 @@ function setTime<DateType>(
   date: DateType,
   defaultDate: NullableDateType<DateType>,
 ) {
-  if (!defaultDate) {
-    return date;
-  }
-
   let newDate = date;
-  newDate = generateConfig.setHour(
-    newDate,
-    generateConfig.getHour(defaultDate),
-  );
-  newDate = generateConfig.setMinute(
-    newDate,
-    generateConfig.getMinute(defaultDate),
-  );
-  newDate = generateConfig.setSecond(
-    newDate,
-    generateConfig.getSecond(defaultDate),
-  );
+  newDate = generateConfig.setHour(newDate, generateConfig.getHour(defaultDate));
+  newDate = generateConfig.setMinute(newDate, generateConfig.getMinute(defaultDate));
+  newDate = generateConfig.setSecond(newDate, generateConfig.getSecond(defaultDate));
   return newDate;
 }
 
 export interface DatetimePanelProps<DateType>
-  extends Omit<
-    DatePanelProps<DateType>,
-    'disabledHours' | 'disabledMinutes' | 'disabledSeconds'
-  > {
+  extends Omit<DatePanelProps<DateType>, 'disabledHours' | 'disabledMinutes' | 'disabledSeconds'> {
   disabledTime?: DisabledTime<DateType>;
   showTime?: boolean | SharedTimeProps<DateType>;
   defaultValue?: DateType;
@@ -57,9 +41,7 @@ function DatetimePanel<DateType>(props: DatetimePanelProps<DateType>) {
     onSelect,
   } = props;
   const panelPrefixCls = `${prefixCls}-datetime-panel`;
-  const [activePanel, setActivePanel] = React.useState<ActivePanelType | null>(
-    null,
-  );
+  const [activePanel, setActivePanel] = React.useState<ActivePanelType | null>(null);
 
   const dateOperationRef = React.useRef<PanelRefProps>({});
   const timeOperationRef = React.useRef<PanelRefProps>({});
@@ -96,8 +78,7 @@ function DatetimePanel<DateType>(props: DatetimePanelProps<DateType>) {
 
       // Operate on current active panel
       if (activePanel) {
-        const ref =
-          activePanel === 'date' ? dateOperationRef : timeOperationRef;
+        const ref = activePanel === 'date' ? dateOperationRef : timeOperationRef;
 
         if (ref.current && ref.current.onKeyDown) {
           ref.current.onKeyDown(event);
@@ -107,11 +88,7 @@ function DatetimePanel<DateType>(props: DatetimePanelProps<DateType>) {
       }
 
       // Switch first active panel if operate without panel
-      if (
-        [KeyCode.LEFT, KeyCode.RIGHT, KeyCode.UP, KeyCode.DOWN].includes(
-          event.which,
-        )
-      ) {
+      if ([KeyCode.LEFT, KeyCode.RIGHT, KeyCode.UP, KeyCode.DOWN].includes(event.which)) {
         setActivePanel('date');
         return true;
       }
@@ -141,18 +118,9 @@ function DatetimePanel<DateType>(props: DatetimePanelProps<DateType>) {
         generateConfig.getSecond(timeProps.defaultValue),
       );
     } else if (source === 'time' && !value && defaultValue) {
-      selectedDate = generateConfig.setYear(
-        selectedDate,
-        generateConfig.getYear(defaultValue),
-      );
-      selectedDate = generateConfig.setMonth(
-        selectedDate,
-        generateConfig.getMonth(defaultValue),
-      );
-      selectedDate = generateConfig.setDate(
-        selectedDate,
-        generateConfig.getDate(defaultValue),
-      );
+      selectedDate = generateConfig.setYear(selectedDate, generateConfig.getYear(defaultValue));
+      selectedDate = generateConfig.setMonth(selectedDate, generateConfig.getMonth(defaultValue));
+      selectedDate = generateConfig.setDate(selectedDate, generateConfig.getDate(defaultValue));
     }
 
     if (onSelect) {
@@ -179,9 +147,7 @@ function DatetimePanel<DateType>(props: DatetimePanelProps<DateType>) {
             setTime(
               generateConfig,
               date,
-              showTime && typeof showTime === 'object'
-                ? showTime.defaultValue
-                : dateNow,
+              showTime && typeof showTime === 'object' ? showTime.defaultValue : dateNow,
             ),
             'date',
           );

--- a/src/panels/DatetimePanel/index.tsx
+++ b/src/panels/DatetimePanel/index.tsx
@@ -12,10 +12,6 @@ function setTime<DateType>(
   date: DateType,
   defaultDate: NullableDateType<DateType>,
 ) {
-  if (!defaultDate) {
-    return date;
-  }
-
   let newDate = date;
   newDate = generateConfig.setHour(newDate, generateConfig.getHour(defaultDate));
   newDate = generateConfig.setMinute(newDate, generateConfig.getMinute(defaultDate));
@@ -151,7 +147,9 @@ function DatetimePanel<DateType>(props: DatetimePanelProps<DateType>) {
             setTime(
               generateConfig,
               date,
-              showTime && typeof showTime === 'object' ? showTime.defaultValue || null : dateNow,
+              showTime && typeof showTime === 'object' && showTime.defaultValue
+                ? showTime.defaultValue
+                : dateNow,
             ),
             'date',
           );

--- a/tests/panel.spec.tsx
+++ b/tests/panel.spec.tsx
@@ -242,12 +242,23 @@ describe('Picker.Panel', () => {
   it('showtime is true', () => {
     const onSelect = jest.fn();
     const wrapper = mount(<MomentPickerPanel showTime value={null} onSelect={onSelect} />);
+    const timerGame = () => {
+      setTimeout(() => {
+        MockDate.set(getMoment('1990-09-03 01:10:10').toDate());
+      }, 1000);
+    };
 
-    MockDate.set(getMoment('1990-09-03 01:10:10').toDate());
-
+    jest.useFakeTimers();
+    timerGame();
     // first click on date
     wrapper.selectCell(5);
-    expect(isSame(onSelect.mock.calls[0][0], '1990-09-05 01:10:10', 'second')).toBeTruthy();
+    expect(isSame(onSelect.mock.calls[0][0], '1990-09-05 00:00:00', 'second')).toBeTruthy();
+
+    // then click on date
+    onSelect.mockReset();
+    jest.runAllTimers();
+    wrapper.selectCell(8);
+    expect(isSame(onSelect.mock.calls[0][0], '1990-09-08 01:10:10', 'second')).toBeTruthy();
 
     // then click on time
     onSelect.mockReset();

--- a/tests/panel.spec.tsx
+++ b/tests/panel.spec.tsx
@@ -239,6 +239,30 @@ describe('Picker.Panel', () => {
     expect(isSame(onSelect.mock.calls[0][0], '2001-01-02 11:00:00')).toBeTruthy();
   });
 
+  // This test is safe to remove
+  it('showtime is true', () => {
+    const onSelect = jest.fn();
+    const wrapper = mount(<MomentPickerPanel showTime value={null} onSelect={onSelect} />);
+
+    // Click on date
+    wrapper.selectCell(5);
+    expect(
+      isSame(onSelect.mock.calls[0][0], `1990-09-05 ${moment().format('hh:mm:ss')}`),
+    ).toBeTruthy();
+
+    // Click on time
+    onSelect.mockReset();
+    wrapper
+      .find('ul')
+      .first()
+      .find('li')
+      .at(11)
+      .simulate('click');
+    expect(
+      isSame(onSelect.mock.calls[0][0], `1990-09-03 11:${moment().format('mm:ss')}`),
+    ).toBeTruthy();
+  });
+
   describe('not trigger onSelect when cell disabled', () => {
     it('time', () => {
       const onSelect = jest.fn();

--- a/tests/panel.spec.tsx
+++ b/tests/panel.spec.tsx
@@ -198,99 +198,68 @@ describe('Picker.Panel', () => {
   });
 
   // This test is safe to remove
-  describe('showtime', () => {
-    it('object', () => {
-      const onSelect = jest.fn();
-      const wrapper = mount(
-        <MomentPickerPanel
-          showTime={{
-            hideDisabledOptions: true,
-            showSecond: false,
-            defaultValue: getMoment('2001-01-02 01:03:07'),
-            disabledHours: () => [0, 1, 2, 3],
-          }}
-          defaultValue={getMoment('2001-01-02 01:03:07')}
-          value={null}
-          onSelect={onSelect}
-        />,
-      );
+  it('showtime', () => {
+    const onSelect = jest.fn();
+    const wrapper = mount(
+      <MomentPickerPanel
+        showTime={{
+          hideDisabledOptions: true,
+          showSecond: false,
+          defaultValue: getMoment('2001-01-02 01:03:07'),
+          disabledHours: () => [0, 1, 2, 3],
+        }}
+        defaultValue={getMoment('2001-01-02 01:03:07')}
+        value={null}
+        onSelect={onSelect}
+      />,
+    );
 
-      expect(wrapper.find('.rc-picker-time-panel-column')).toHaveLength(2);
-      expect(
-        wrapper
-          .find('.rc-picker-time-panel-column')
-          .first()
-          .find('li')
-          .first()
-          .text(),
-      ).toEqual('04');
-
-      // Click on date
-      wrapper.selectCell(5);
-      expect(isSame(onSelect.mock.calls[0][0], '1990-09-05 01:03:07')).toBeTruthy();
-
-      // Click on time
-      onSelect.mockReset();
+    expect(wrapper.find('.rc-picker-time-panel-column')).toHaveLength(2);
+    expect(
       wrapper
-        .find('ul')
+        .find('.rc-picker-time-panel-column')
         .first()
         .find('li')
-        .at(11)
-        .simulate('click');
-      expect(isSame(onSelect.mock.calls[0][0], '2001-01-02 11:00:00')).toBeTruthy();
-    });
-
-    it('object have no defaultValue', () => {
-      const onSelect = jest.fn();
-      const wrapper = mount(
-        <MomentPickerPanel
-          showTime={{}}
-          defaultValue={getMoment('2001-01-02 01:03:07')}
-          value={null}
-          onSelect={onSelect}
-        />,
-      );
-
-      // Click on date
-      wrapper.selectCell(8);
-      expect(
-        isSame(onSelect.mock.calls[0][0], `1990-09-08 ${moment().format('hh:mm:ss')}`),
-      ).toBeTruthy();
-
-      // Click on time
-      onSelect.mockReset();
-      wrapper
-        .find('ul')
         .first()
-        .find('li')
-        .at(10)
-        .simulate('click');
-      expect(
-        isSame(onSelect.mock.calls[0][0], `2001-01-02 10:${moment().format('mm:ss')}`),
-      ).toBeTruthy();
-    });
+        .text(),
+    ).toEqual('04');
 
-    it('true', () => {
-      const onSelect = jest.fn();
-      const wrapper = mount(<MomentPickerPanel showTime onSelect={onSelect} />);
+    // Click on date
+    wrapper.selectCell(5);
+    expect(isSame(onSelect.mock.calls[0][0], '1990-09-05 01:03:07')).toBeTruthy();
 
-      // Click on date
+    // Click on time
+    onSelect.mockReset();
+    wrapper
+      .find('ul')
+      .first()
+      .find('li')
+      .at(11)
+      .simulate('click');
+    expect(isSame(onSelect.mock.calls[0][0], '2001-01-02 11:00:00')).toBeTruthy();
+  });
+
+  // This test is safe to remove
+  it('showtime is true', () => {
+    const onSelect = jest.fn();
+    const wrapper = mount(<MomentPickerPanel showTime value={null} onSelect={onSelect} />);
+
+    const timerGame = new Promise(resolve =>
+      setTimeout(() => {
+        MockDate.set(getMoment('1990-09-03 01:10:10').toDate());
+        resolve();
+      }, 1000),
+    );
+
+    // Click on date
+    wrapper.selectCell(5);
+    expect(isSame(onSelect.mock.calls[0][0], `1990-09-05 00:00:00`, 'seconds')).toBeTruthy();
+
+    // Click on date
+    timerGame.then(() => {
       wrapper.selectCell(10);
       expect(
-        isSame(onSelect.mock.calls[0][0], `1990-09-10 ${moment().format('hh:mm:ss')}`),
-      ).toBeTruthy();
-
-      // Click on time
-      onSelect.mockReset();
-      wrapper.selectCell(8);
-      wrapper
-        .find('ul')
-        .first()
-        .find('li')
-        .at(10)
-        .simulate('click');
-      expect(
-        isSame(onSelect.mock.calls[0][0], `1990-09-08 10:${moment().format('mm:ss')}`),
+        isSame(onSelect.mock.calls[0][0], `1990-09-10 ${moment().format('hh:mm:ss')}`, 'seconds'),
       ).toBeTruthy();
     });
   });

--- a/tests/panel.spec.tsx
+++ b/tests/panel.spec.tsx
@@ -252,6 +252,7 @@ describe('Picker.Panel', () => {
 
     // Click on time
     onSelect.mockReset();
+    wrapper.selectCell(8);
     wrapper
       .find('ul')
       .first()
@@ -259,7 +260,7 @@ describe('Picker.Panel', () => {
       .at(11)
       .simulate('click');
     expect(
-      isSame(onSelect.mock.calls[0][0], `1990-09-03 11:${moment().format('mm:ss')}`),
+      isSame(onSelect.mock.calls[0][0], `1990-09-08 11:${moment().format('mm:ss')}`),
     ).toBeTruthy();
   });
 

--- a/tests/panel.spec.tsx
+++ b/tests/panel.spec.tsx
@@ -239,29 +239,30 @@ describe('Picker.Panel', () => {
     expect(isSame(onSelect.mock.calls[0][0], '2001-01-02 11:00:00')).toBeTruthy();
   });
 
-  // This test is safe to remove
   it('showtime is true', () => {
     const onSelect = jest.fn();
     const wrapper = mount(<MomentPickerPanel showTime value={null} onSelect={onSelect} />);
 
-    const timerGame = new Promise(resolve =>
-      setTimeout(() => {
-        MockDate.set(getMoment('1990-09-03 01:10:10').toDate());
-        resolve();
-      }, 1000),
-    );
+    MockDate.set(getMoment('1990-09-03 01:10:10').toDate());
 
-    // Click on date
+    // first click on date
     wrapper.selectCell(5);
-    expect(isSame(onSelect.mock.calls[0][0], `1990-09-05 00:00:00`, 'seconds')).toBeTruthy();
+    expect(isSame(onSelect.mock.calls[0][0], '1990-09-05 01:10:10', 'second')).toBeTruthy();
 
-    // Click on date
-    timerGame.then(() => {
-      wrapper.selectCell(10);
-      expect(
-        isSame(onSelect.mock.calls[0][0], `1990-09-10 ${moment().format('hh:mm:ss')}`, 'seconds'),
-      ).toBeTruthy();
-    });
+    // then click on time
+    onSelect.mockReset();
+    wrapper
+      .find('ul')
+      .first()
+      .find('li')
+      .at(11)
+      .simulate('click');
+    expect(isSame(onSelect.mock.calls[0][0], '1990-09-03 11:00:00', 'second')).toBeTruthy();
+
+    // then click on date
+    onSelect.mockReset();
+    wrapper.selectCell(6);
+    expect(isSame(onSelect.mock.calls[0][0], '1990-09-06 11:00:00', 'second')).toBeTruthy();
   });
 
   describe('not trigger onSelect when cell disabled', () => {

--- a/tests/panel.spec.tsx
+++ b/tests/panel.spec.tsx
@@ -198,70 +198,101 @@ describe('Picker.Panel', () => {
   });
 
   // This test is safe to remove
-  it('showtime', () => {
-    const onSelect = jest.fn();
-    const wrapper = mount(
-      <MomentPickerPanel
-        showTime={{
-          hideDisabledOptions: true,
-          showSecond: false,
-          defaultValue: getMoment('2001-01-02 01:03:07'),
-          disabledHours: () => [0, 1, 2, 3],
-        }}
-        defaultValue={getMoment('2001-01-02 01:03:07')}
-        value={null}
-        onSelect={onSelect}
-      />,
-    );
+  describe('showtime', () => {
+    it('object', () => {
+      const onSelect = jest.fn();
+      const wrapper = mount(
+        <MomentPickerPanel
+          showTime={{
+            hideDisabledOptions: true,
+            showSecond: false,
+            defaultValue: getMoment('2001-01-02 01:03:07'),
+            disabledHours: () => [0, 1, 2, 3],
+          }}
+          defaultValue={getMoment('2001-01-02 01:03:07')}
+          value={null}
+          onSelect={onSelect}
+        />,
+      );
 
-    expect(wrapper.find('.rc-picker-time-panel-column')).toHaveLength(2);
-    expect(
+      expect(wrapper.find('.rc-picker-time-panel-column')).toHaveLength(2);
+      expect(
+        wrapper
+          .find('.rc-picker-time-panel-column')
+          .first()
+          .find('li')
+          .first()
+          .text(),
+      ).toEqual('04');
+
+      // Click on date
+      wrapper.selectCell(5);
+      expect(isSame(onSelect.mock.calls[0][0], '1990-09-05 01:03:07')).toBeTruthy();
+
+      // Click on time
+      onSelect.mockReset();
       wrapper
-        .find('.rc-picker-time-panel-column')
+        .find('ul')
         .first()
         .find('li')
+        .at(11)
+        .simulate('click');
+      expect(isSame(onSelect.mock.calls[0][0], '2001-01-02 11:00:00')).toBeTruthy();
+    });
+
+    it('object have no defaultValue', () => {
+      const onSelect = jest.fn();
+      const wrapper = mount(
+        <MomentPickerPanel
+          showTime={{}}
+          defaultValue={getMoment('2001-01-02 01:03:07')}
+          value={null}
+          onSelect={onSelect}
+        />,
+      );
+
+      // Click on date
+      wrapper.selectCell(8);
+      expect(
+        isSame(onSelect.mock.calls[0][0], `1990-09-08 ${moment().format('hh:mm:ss')}`),
+      ).toBeTruthy();
+
+      // Click on time
+      onSelect.mockReset();
+      wrapper
+        .find('ul')
         .first()
-        .text(),
-    ).toEqual('04');
+        .find('li')
+        .at(10)
+        .simulate('click');
+      expect(
+        isSame(onSelect.mock.calls[0][0], `2001-01-02 10:${moment().format('mm:ss')}`),
+      ).toBeTruthy();
+    });
 
-    // Click on date
-    wrapper.selectCell(5);
-    expect(isSame(onSelect.mock.calls[0][0], '1990-09-05 01:03:07')).toBeTruthy();
+    it('true', () => {
+      const onSelect = jest.fn();
+      const wrapper = mount(<MomentPickerPanel showTime onSelect={onSelect} />);
 
-    // Click on time
-    onSelect.mockReset();
-    wrapper
-      .find('ul')
-      .first()
-      .find('li')
-      .at(11)
-      .simulate('click');
-    expect(isSame(onSelect.mock.calls[0][0], '2001-01-02 11:00:00')).toBeTruthy();
-  });
+      // Click on date
+      wrapper.selectCell(10);
+      expect(
+        isSame(onSelect.mock.calls[0][0], `1990-09-10 ${moment().format('hh:mm:ss')}`),
+      ).toBeTruthy();
 
-  // This test is safe to remove
-  it('showtime is true', () => {
-    const onSelect = jest.fn();
-    const wrapper = mount(<MomentPickerPanel showTime value={null} onSelect={onSelect} />);
-
-    // Click on date
-    wrapper.selectCell(5);
-    expect(
-      isSame(onSelect.mock.calls[0][0], `1990-09-05 ${moment().format('hh:mm:ss')}`),
-    ).toBeTruthy();
-
-    // Click on time
-    onSelect.mockReset();
-    wrapper.selectCell(8);
-    wrapper
-      .find('ul')
-      .first()
-      .find('li')
-      .at(11)
-      .simulate('click');
-    expect(
-      isSame(onSelect.mock.calls[0][0], `1990-09-08 11:${moment().format('mm:ss')}`),
-    ).toBeTruthy();
+      // Click on time
+      onSelect.mockReset();
+      wrapper.selectCell(8);
+      wrapper
+        .find('ul')
+        .first()
+        .find('li')
+        .at(10)
+        .simulate('click');
+      expect(
+        isSame(onSelect.mock.calls[0][0], `1990-09-08 10:${moment().format('mm:ss')}`),
+      ).toBeTruthy();
+    });
   });
 
   describe('not trigger onSelect when cell disabled', () => {


### PR DESCRIPTION
解决bug：https://github.com/ant-design/ant-design/issues/25081
1.在DatetimePanel处理点选日期更新最新时分秒，在DatetimePanel只影响showtime的，是最小化修改。
2.在根源panelBody修改虽然能保证选择日期也能带出精确时分秒，但是showtime=false默认为time不敏感。
稳妥考虑选择1方案