### PR TITLE
invalid locale code fixed ku_IQ changed to kmr_KU

### DIFF
--- a/src/locale/kmr_KU.ts
+++ b/src/locale/kmr_KU.ts
@@ -1,7 +1,7 @@
 import { Locale } from '../interface';
 
 const locale: Locale = {
-  locale: 'ku_IQ',
+  locale: 'kmr_KU',
   today: 'Îro',
   now: 'Niha',
   backToToday: 'Vegere îro',


### PR DESCRIPTION
please [refer to this issue](https://github.com/ant-design/ant-design/issues/25778) on antd repostory kurdish(Kurmanji) dialect should have **kmr_KU** the KU part represents [Kurdistan](https://en.wikipedia.org/wiki/Kurdistan) 