### PR TITLE
fix: missing week days and months when using dateFns generate config

### DIFF
--- a/src/generate/dateFns.ts
+++ b/src/generate/dateFns.ts
@@ -71,6 +71,16 @@ const generateConfig: GenerateConfig<Date> = {
     getWeek: (locale, date) => {
       return getWeek(date, { locale: Locale[dealLocal(locale)] });
     },
+    getShortWeekDays: locale => {
+      const clone = Locale[dealLocal(locale)];
+      return Array.from({ length: 7 }).map((_, i) => clone.localize.day(i, { width: 'short' }));
+    },
+    getShortMonths: locale => {
+      const clone = Locale[dealLocal(locale)];
+      return Array.from({ length: 12 }).map((_, i) =>
+        clone.localize.month(i, { width: 'abbreviated' }),
+      );
+    },
     format: (locale, date, format) => {
       if (!isValid(date)) {
         return null;

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -144,59 +144,57 @@ describe('Picker.Generate', () => {
         ).toEqual(null);
       });
 
-      if (name !== 'date-fns') {
-        it('getShortWeekDays', () => {
-          expect(generateConfig.locale.getShortWeekDays!('zh_CN')).toEqual([
-            '日',
-            '一',
-            '二',
-            '三',
-            '四',
-            '五',
-            '六',
-          ]);
-          expect(generateConfig.locale.getShortWeekDays!('en_US')).toEqual([
-            'Su',
-            'Mo',
-            'Tu',
-            'We',
-            'Th',
-            'Fr',
-            'Sa',
-          ]);
-        });
+      it('getShortWeekDays', () => {
+        expect(generateConfig.locale.getShortWeekDays!('zh_CN')).toEqual([
+          '日',
+          '一',
+          '二',
+          '三',
+          '四',
+          '五',
+          '六',
+        ]);
+        expect(generateConfig.locale.getShortWeekDays!('en_US')).toEqual([
+          'Su',
+          'Mo',
+          'Tu',
+          'We',
+          'Th',
+          'Fr',
+          'Sa',
+        ]);
+      });
 
-        it('getShortMonths', () => {
-          expect(generateConfig.locale.getShortMonths!('zh_CN')).toEqual([
-            '1月',
-            '2月',
-            '3月',
-            '4月',
-            '5月',
-            '6月',
-            '7月',
-            '8月',
-            '9月',
-            '10月',
-            '11月',
-            '12月',
-          ]);
-          expect(generateConfig.locale.getShortMonths!('en_US')).toEqual([
-            'Jan',
-            'Feb',
-            'Mar',
-            'Apr',
-            'May',
-            'Jun',
-            'Jul',
-            'Aug',
-            'Sep',
-            'Oct',
-            'Nov',
-            'Dec',
-          ]);
-        });
-      }
+      it('getShortMonths', () => {
+        expect(generateConfig.locale.getShortMonths!('zh_CN')).toEqual([
+          '1月',
+          '2月',
+          '3月',
+          '4月',
+          '5月',
+          '6月',
+          '7月',
+          '8月',
+          '9月',
+          '10月',
+          '11月',
+          '12月',
+        ]);
+        expect(generateConfig.locale.getShortMonths!('en_US')).toEqual([
+          'Jan',
+          'Feb',
+          'Mar',
+          'Apr',
+          'May',
+          'Jun',
+          'Jul',
+          'Aug',
+          'Sep',
+          'Oct',
+          'Nov',
+          'Dec',
+        ]);
+      });
 
       it('getWeek', () => {
         const formatStr = name === 'date-fns' ? 'yyyy-MM-dd' : 'YYYY-MM-DD';


### PR DESCRIPTION
Currently the weekdays and months is disappear on picker when using the `dateFns` generate config.
This PR implement `getShortWeekDays` and `getShortMonths` in dateFns generate config to fixed it, otherwise we need define `shortMonths` and `shortWeekDays` in locale files.