### PR TITLE
added lithuanian language

### DIFF
--- a/src/locale/lt_LT.ts
+++ b/src/locale/lt_LT.ts
@@ -1,0 +1,32 @@
+import { Locale } from '../interface';
+
+const locale: Locale = {
+  locale: 'lt_LT',
+  today: 'Šiandien',
+  now: 'Dabar',
+  backToToday: 'Rodyti šiandien',
+  ok: 'Gerai',
+  clear: 'Išvalyti',
+  month: 'Mėnesis',
+  year: 'Metai',
+  timeSelect: 'Pasirinkti laiką',
+  dateSelect: 'Pasirinkti datą',
+  monthSelect: 'Pasirinkti mėnesį',
+  yearSelect: 'Pasirinkti metus',
+  decadeSelect: 'Pasirinkti dešimtmetį',
+  yearFormat: 'YYYY',
+  dateFormat: 'YYYY-MM-DD',
+  dayFormat: 'DD',
+  dateTimeFormat: 'YYYY-MM-DD HH:MM:SS',
+  monthBeforeYear: true,
+  previousMonth: 'Buvęs mėnesis (PageUp)',
+  nextMonth: 'Sekantis mėnesis (PageDown)',
+  previousYear: 'Buvę metai (Control + left)',
+  nextYear: 'Sekantis metai (Control + right)',
+  previousDecade: 'Buvęs dešimtmetis',
+  nextDecade: 'Sekantis dešimtmetis',
+  previousCentury: 'Buvęs amžius',
+  nextCentury: 'Sekantis amžius',
+};
+
+export default locale;


### PR DESCRIPTION
Im using antdesign and they have dependencies to picker version ~1.15.1 but there was no lithuanian language.