### PR TITLE
fix(range): panel keep open when nextValue is empty(#26024)

### DIFF
--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -470,7 +470,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
     if (
       nextOpenIndex !== null &&
       nextOpenIndex !== mergedActivePickerIndex &&
-      !openRecordsRef.current[nextOpenIndex] &&
+      (!openRecordsRef.current[nextOpenIndex] || !getValue(values, nextOpenIndex)) &&
       getValue(values, sourceIndex)
     ) {
       // Delay to focus to avoid input blur trigger expired selectedValues

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -1696,4 +1696,44 @@ describe('Picker.Range', () => {
     ).toEqual('2020-07-24 06:00:00');
     expect(wrapper.find('.rc-picker-ok button').props().disabled).toBeTruthy();
   });
+
+  // https://github.com/ant-design/ant-design/issues/26024
+  it('panel should keep open when nextValue is empty', () => {
+    MockDate.set(getMoment('2020-08-08 00:00:00').toDate());
+
+    const wrapper = mount(<MomentRangePicker />);
+
+    wrapper.openPicker(0);
+
+    wrapper.selectCell(7, 0);
+    expect(
+      wrapper
+        .find('input')
+        .first()
+        .prop('value'),
+    ).toBe('2020-08-07');
+
+    // back to first panel and clear input value
+    wrapper
+      .find('input')
+      .first()
+      .simulate('focus');
+    wrapper.inputValue('', 0);
+
+    // reselect date
+    wrapper.selectCell(9, 0);
+    expect(
+      wrapper
+        .find('input')
+        .first()
+        .prop('value'),
+    ).toBe('2020-08-09');
+
+    // end date
+    wrapper.selectCell(9, 1);
+
+    matchValues(wrapper, '2020-08-09', '2020-09-09');
+
+    MockDate.reset();
+  });
 });

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -1699,8 +1699,6 @@ describe('Picker.Range', () => {
 
   // https://github.com/ant-design/ant-design/issues/26024
   it('panel should keep open when nextValue is empty', () => {
-    MockDate.set(getMoment('2020-08-08 00:00:00').toDate());
-
     const wrapper = mount(<MomentRangePicker />);
 
     wrapper.openPicker(0);
@@ -1711,7 +1709,7 @@ describe('Picker.Range', () => {
         .find('input')
         .first()
         .prop('value'),
-    ).toBe('2020-08-07');
+    ).toBe('1990-09-07');
 
     // back to first panel and clear input value
     wrapper
@@ -1727,13 +1725,11 @@ describe('Picker.Range', () => {
         .find('input')
         .first()
         .prop('value'),
-    ).toBe('2020-08-09');
+    ).toBe('1990-09-09');
 
     // end date
     wrapper.selectCell(9, 1);
 
-    matchValues(wrapper, '2020-08-09', '2020-09-09');
-
-    MockDate.reset();
+    matchValues(wrapper, '1990-09-09', '1990-10-09');
   });
 });


### PR DESCRIPTION
[#26024](https://github.com/ant-design/ant-design/issues/26024)

@afc163 @zombieJ 