### PR TITLE
fix: RangePicker arrow keys do not start from current date

### DIFF
--- a/examples/range.tsx
+++ b/examples/range.tsx
@@ -153,6 +153,15 @@ export default () => {
             renderExtraFooter={() => <div>extra footer</div>}
           />
         </div>
+        <div style={{ margin: '0 8px' }}>
+          <h3>Uncontrolled2</h3>
+          <RangePicker<Moment>
+            {...sharedProps}
+            value={undefined}
+            locale={zhCN}
+            placeholder={['start...', 'end...']}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/PickerPanel.tsx
+++ b/src/PickerPanel.tsx
@@ -313,7 +313,7 @@ function PickerPanel<DateType>(props: PickerPanelProps<DateType>) {
     }
   };
 
-  if (operationRef) {
+  if (operationRef && panelPosition !== 'right') {
     operationRef.current = {
       onKeyDown: onInternalKeyDown,
       onClose: () => {

--- a/tests/keyboard.spec.tsx
+++ b/tests/keyboard.spec.tsx
@@ -443,6 +443,27 @@ describe('Picker.Keyboard', () => {
           .props().value,
       ).toEqual('');
     });
+
+    it('move based on current date on first keyboard event', () => {
+      jest.useFakeTimers();
+      const onCalendarChange = jest.fn();
+      const onChange = jest.fn();
+      const wrapper = mount(
+        <MomentRangePicker onCalendarChange={onCalendarChange} onChange={onChange} />,
+      );
+
+      // Start Date
+      wrapper.openPicker();
+      wrapper
+        .find('input')
+        .first()
+        .simulate('change', { target: { value: '' } });
+      wrapper.keyDown(KeyCode.TAB);
+      wrapper.keyDown(KeyCode.RIGHT);
+      wrapper.keyDown(KeyCode.ENTER);
+      expect(onCalendarChange.mock.calls[0][1]).toEqual(['1990-09-04', '']);
+      expect(onChange).not.toHaveBeenCalled();
+    });
   });
 
   it('enter should prevent default to avoid form submit', () => {


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/25403