### PR TITLE
Fix missing shortweekdays and shortmonths for date-fns

### DIFF
--- a/src/generate/dateFns.ts
+++ b/src/generate/dateFns.ts
@@ -20,6 +20,8 @@ import {
   getWeek,
   format as formatDate,
   parse as parseDate,
+  startOfWeek,
+  startOfYear,
 } from 'date-fns';
 import * as Locale from 'date-fns/locale';
 import { GenerateConfig } from '.';
@@ -36,6 +38,10 @@ const localeParse = (format: string) => {
     .replace(/g/g, 'G')
     .replace(/([Ww])o/g, 'wo');
 };
+
+const now = new Date();
+const firstDOW = startOfWeek(now);
+const firstDOY = startOfYear(now);
 
 const generateConfig: GenerateConfig<Date> = {
   // get
@@ -67,6 +73,16 @@ const generateConfig: GenerateConfig<Date> = {
     getWeekFirstDay: locale => {
       const clone = Locale[dealLocal(locale)];
       return clone.options.weekStartsOn;
+    },
+    getShortWeekDays: locale => {
+      return Array.from(Array(7)).map((e, i) =>
+        formatDate(addDays(firstDOW, i), 'EEEEEE', { locale: Locale[dealLocal(locale)] }),
+      );
+    },
+    getShortMonths: locale => {
+      return Array.from(Array(12)).map((d, i) =>
+        formatDate(addMonths(firstDOY, i), 'MMM', { locale: Locale[dealLocal(locale)] }),
+      );
     },
     getWeek: (locale, date) => {
       return getWeek(date, { locale: Locale[dealLocal(locale)] });

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -144,59 +144,57 @@ describe('Picker.Generate', () => {
         ).toEqual(null);
       });
 
-      if (name !== 'date-fns') {
-        it('getShortWeekDays', () => {
-          expect(generateConfig.locale.getShortWeekDays!('zh_CN')).toEqual([
-            '日',
-            '一',
-            '二',
-            '三',
-            '四',
-            '五',
-            '六',
-          ]);
-          expect(generateConfig.locale.getShortWeekDays!('en_US')).toEqual([
-            'Su',
-            'Mo',
-            'Tu',
-            'We',
-            'Th',
-            'Fr',
-            'Sa',
-          ]);
-        });
+      it('getShortWeekDays', () => {
+        expect(generateConfig.locale.getShortWeekDays!('zh_CN')).toEqual([
+          '日',
+          '一',
+          '二',
+          '三',
+          '四',
+          '五',
+          '六',
+        ]);
+        expect(generateConfig.locale.getShortWeekDays!('en_US')).toEqual([
+          'Su',
+          'Mo',
+          'Tu',
+          'We',
+          'Th',
+          'Fr',
+          'Sa',
+        ]);
+      });
 
-        it('getShortMonths', () => {
-          expect(generateConfig.locale.getShortMonths!('zh_CN')).toEqual([
-            '1月',
-            '2月',
-            '3月',
-            '4月',
-            '5月',
-            '6月',
-            '7月',
-            '8月',
-            '9月',
-            '10月',
-            '11月',
-            '12月',
-          ]);
-          expect(generateConfig.locale.getShortMonths!('en_US')).toEqual([
-            'Jan',
-            'Feb',
-            'Mar',
-            'Apr',
-            'May',
-            'Jun',
-            'Jul',
-            'Aug',
-            'Sep',
-            'Oct',
-            'Nov',
-            'Dec',
-          ]);
-        });
-      }
+      it('getShortMonths', () => {
+        expect(generateConfig.locale.getShortMonths!('zh_CN')).toEqual([
+          '1月',
+          '2月',
+          '3月',
+          '4月',
+          '5月',
+          '6月',
+          '7月',
+          '8月',
+          '9月',
+          '10月',
+          '11月',
+          '12月',
+        ]);
+        expect(generateConfig.locale.getShortMonths!('en_US')).toEqual([
+          'Jan',
+          'Feb',
+          'Mar',
+          'Apr',
+          'May',
+          'Jun',
+          'Jul',
+          'Aug',
+          'Sep',
+          'Oct',
+          'Nov',
+          'Dec',
+        ]);
+      });
 
       it('getWeek', () => {
         const formatStr = name === 'date-fns' ? 'yyyy-MM-dd' : 'YYYY-MM-DD';


### PR DESCRIPTION
This PR fixes empty month pickers and missing weekday names in daypicker when using with date-fns

![image](https://user-images.githubusercontent.com/1418446/89828041-c829a980-db58-11ea-800f-0aa48e93b35a.png)
![image](https://user-images.githubusercontent.com/1418446/89827953-a2040980-db58-11ea-9810-e832e4b7775e.png)
