### PR TITLE
chore(range): panel defaultValue should be relative to startDate/endDate

### DIFF
--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -819,7 +819,9 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
           onOk={null}
           onSelect={undefined}
           onChange={undefined}
-          defaultValue={undefined}
+          defaultValue={
+            mergedActivePickerIndex === 0 ? getValue(selectedValue, 1) : getValue(selectedValue, 0)
+          }
           defaultPickerValue={undefined}
         />
       </RangeContext.Provider>

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -1863,4 +1863,41 @@ describe('Picker.Range', () => {
     expect(wrapper.findCell('Jan').hasClass('rc-picker-cell-disabled')).toBeTruthy();
     expect(wrapper.findCell('Dec').hasClass('rc-picker-cell-disabled')).toBeFalsy();
   });
+
+  // https://github.com/ant-design/ant-design/issues/23167
+  it('default endDate should be relative startDate', () => {
+    const wrapper = mount(<MomentRangePicker showTime />);
+    wrapper.openPicker();
+
+    wrapper.selectCell(24);
+    wrapper.find('.rc-picker-ok button').simulate('click');
+
+    wrapper
+      .find('ul')
+      .first()
+      .find('li')
+      .at(0)
+      .simulate('click');
+    wrapper.find('.rc-picker-ok button').simulate('click');
+
+    matchValues(wrapper, '1990-09-24 00:00:00', '1990-09-24 00:00:00');
+  });
+
+  it('default startDate should be relative endDate', () => {
+    const wrapper = mount(<MomentRangePicker showTime />);
+    wrapper.openPicker(1);
+
+    wrapper.selectCell(24);
+    wrapper.find('.rc-picker-ok button').simulate('click');
+
+    wrapper
+      .find('ul')
+      .first()
+      .find('li')
+      .at(0)
+      .simulate('click');
+    wrapper.find('.rc-picker-ok button').simulate('click');
+
+    matchValues(wrapper, '1990-09-24 00:00:00', '1990-09-24 00:00:00');
+  });
 });


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/23167

用户在面板中选择的时候，如果没有选择日期直接选择时间，之前默认取的日期是当前日期，会存在当前日期被禁用，小于开始日期等情况。

现在改为了选择结束日期的时候，默认值为开始日期，反之亦然。