### PR TITLE
fix: week range disabled rule

### DIFF
--- a/src/generate/dateFns.ts
+++ b/src/generate/dateFns.ts
@@ -72,8 +72,8 @@ const generateConfig: GenerateConfig<Date> = {
       const clone = Locale[dealLocal(locale)];
       return clone.options.weekStartsOn;
     },
-    getWeekFirstDayValue: (locale, date) => {
-      return startOfWeek(date, { locale: Locale[dealLocal(locale)] }).valueOf();
+    getWeekFirstDate: (locale, date) => {
+      return startOfWeek(date, { locale: Locale[dealLocal(locale)] });
     },
     getWeek: (locale, date) => {
       return getWeek(date, { locale: Locale[dealLocal(locale)] });

--- a/src/generate/dateFns.ts
+++ b/src/generate/dateFns.ts
@@ -19,6 +19,7 @@ import {
   isAfter,
   isValid,
   getWeek,
+  startOfWeek,
   format as formatDate,
   parse as parseDate,
 } from 'date-fns';
@@ -70,6 +71,9 @@ const generateConfig: GenerateConfig<Date> = {
     getWeekFirstDay: locale => {
       const clone = Locale[dealLocal(locale)];
       return clone.options.weekStartsOn;
+    },
+    getWeekFirstDayValue: (locale, date) => {
+      return startOfWeek(date, { locale: Locale[dealLocal(locale)] }).valueOf();
     },
     getWeek: (locale, date) => {
       return getWeek(date, { locale: Locale[dealLocal(locale)] });

--- a/src/generate/dayjs.ts
+++ b/src/generate/dayjs.ts
@@ -80,6 +80,11 @@ const generateConfig: GenerateConfig<Dayjs> = {
         .locale(parseLocale(locale))
         .localeData()
         .firstDayOfWeek(),
+    getWeekFirstDayValue: (locale, date) =>
+      date
+        .locale(parseLocale(locale))
+        .weekday(0)
+        .valueOf(),
     getWeek: (locale, date) => date.locale(parseLocale(locale)).week(),
     getShortWeekDays: locale =>
       dayjs()

--- a/src/generate/dayjs.ts
+++ b/src/generate/dayjs.ts
@@ -80,11 +80,7 @@ const generateConfig: GenerateConfig<Dayjs> = {
         .locale(parseLocale(locale))
         .localeData()
         .firstDayOfWeek(),
-    getWeekFirstDayValue: (locale, date) =>
-      date
-        .locale(parseLocale(locale))
-        .weekday(0)
-        .valueOf(),
+    getWeekFirstDate: (locale, date) => date.locale(parseLocale(locale)).weekday(0),
     getWeek: (locale, date) => date.locale(parseLocale(locale)).week(),
     getShortWeekDays: locale =>
       dayjs()

--- a/src/generate/index.ts
+++ b/src/generate/index.ts
@@ -28,6 +28,7 @@ export interface GenerateConfig<DateType> {
 
   locale: {
     getWeekFirstDay: (locale: string) => number;
+    getWeekFirstDayValue: (locale: string, value: DateType) => number;
     getWeek: (locale: string, value: DateType) => number;
 
     format: (locale: string, date: DateType, format: string) => string;

--- a/src/generate/index.ts
+++ b/src/generate/index.ts
@@ -28,7 +28,7 @@ export interface GenerateConfig<DateType> {
 
   locale: {
     getWeekFirstDay: (locale: string) => number;
-    getWeekFirstDayValue: (locale: string, value: DateType) => number;
+    getWeekFirstDate: (locale: string, value: DateType) => DateType;
     getWeek: (locale: string, value: DateType) => number;
 
     format: (locale: string, date: DateType, format: string) => string;

--- a/src/generate/moment.ts
+++ b/src/generate/moment.ts
@@ -68,10 +68,10 @@ const generateConfig: GenerateConfig<Moment> = {
       const date = moment().locale(locale);
       return date.localeData().firstDayOfWeek();
     },
-    getWeekFirstDayValue: (locale, date) => {
+    getWeekFirstDate: (locale, date) => {
       const clone = date.clone();
       const result = clone.locale(locale);
-      return result.weekday(0).valueOf();
+      return result.weekday(0);
     },
     getWeek: (locale, date) => {
       const clone = date.clone();

--- a/src/generate/moment.ts
+++ b/src/generate/moment.ts
@@ -68,6 +68,11 @@ const generateConfig: GenerateConfig<Moment> = {
       const date = moment().locale(locale);
       return date.localeData().firstDayOfWeek();
     },
+    getWeekFirstDayValue: (locale, date) => {
+      const clone = date.clone();
+      const result = clone.locale(locale);
+      return result.weekday(0).valueOf();
+    },
     getWeek: (locale, date) => {
       const clone = date.clone();
       const result = clone.locale(locale);

--- a/src/hooks/useRangeDisabled.ts
+++ b/src/hooks/useRangeDisabled.ts
@@ -26,10 +26,8 @@ export default function useRangeDisabled<DateType>(
   const startDate = getValue(selectedValue, 0);
   const endDate = getValue(selectedValue, 1);
 
-  function weekNumber(date: DateType) {
-    const year = generateConfig.getYear(date);
-    const week = generateConfig.locale.getWeek(locale.locale, date);
-    return year * 100 + week;
+  function weekFirstDayValue(date: DateType) {
+    return generateConfig.locale.getWeekFirstDayValue(locale.locale, date);
   }
 
   function monthNumber(date: DateType) {
@@ -63,7 +61,7 @@ export default function useRangeDisabled<DateType>(
           case 'month':
             return monthNumber(date) > monthNumber(endDate);
           case 'week':
-            return weekNumber(date) > weekNumber(endDate);
+            return weekFirstDayValue(date) > weekFirstDayValue(endDate);
           default:
             return (
               !isSameDate(generateConfig, date, endDate) && generateConfig.isAfter(date, endDate)
@@ -97,7 +95,7 @@ export default function useRangeDisabled<DateType>(
           case 'month':
             return monthNumber(date) < monthNumber(startDate);
           case 'week':
-            return weekNumber(date) < weekNumber(startDate);
+            return weekFirstDayValue(date) < weekFirstDayValue(startDate);
           default:
             return (
               !isSameDate(generateConfig, date, startDate) &&

--- a/src/hooks/useRangeDisabled.ts
+++ b/src/hooks/useRangeDisabled.ts
@@ -26,8 +26,8 @@ export default function useRangeDisabled<DateType>(
   const startDate = getValue(selectedValue, 0);
   const endDate = getValue(selectedValue, 1);
 
-  function weekFirstDayValue(date: DateType) {
-    return generateConfig.locale.getWeekFirstDayValue(locale.locale, date);
+  function weekFirstDate(date: DateType) {
+    return generateConfig.locale.getWeekFirstDate(locale.locale, date);
   }
 
   function monthNumber(date: DateType) {
@@ -61,7 +61,7 @@ export default function useRangeDisabled<DateType>(
           case 'month':
             return monthNumber(date) > monthNumber(endDate);
           case 'week':
-            return weekFirstDayValue(date) > weekFirstDayValue(endDate);
+            return weekFirstDate(date) > weekFirstDate(endDate);
           default:
             return (
               !isSameDate(generateConfig, date, endDate) && generateConfig.isAfter(date, endDate)
@@ -95,7 +95,7 @@ export default function useRangeDisabled<DateType>(
           case 'month':
             return monthNumber(date) < monthNumber(startDate);
           case 'week':
-            return weekFirstDayValue(date) < weekFirstDayValue(startDate);
+            return weekFirstDate(date) < weekFirstDate(startDate);
           default:
             return (
               !isSameDate(generateConfig, date, startDate) &&

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -134,18 +134,16 @@ describe('Picker.Generate', () => {
 
       it('getWeekFirstDayValue', () => {
         const formatStr = name === 'date-fns' ? 'yyyy-MM-dd' : 'YYYY-MM-DD';
-        expect(
-          generateConfig.locale.getWeekFirstDayValue(
-            'en_US',
-            generateConfig.locale.parse('en_US', '2020-12-30', [formatStr]),
-          ),
-        ).toEqual(1609027200000);
-        expect(
-          generateConfig.locale.getWeekFirstDayValue(
-            'zh_CN',
-            generateConfig.locale.parse('zh_CN', '2020-12-30', [formatStr]),
-          ),
-        ).toEqual(1609113600000);
+        const usDate = generateConfig.locale.getWeekFirstDate(
+          'en_US',
+          generateConfig.locale.parse('en_US', '2020-12-30', [formatStr]),
+        );
+        const cnDate = generateConfig.locale.getWeekFirstDate(
+          'zh_CN',
+          generateConfig.locale.parse('zh_CN', '2020-12-30', [formatStr]),
+        );
+        expect(generateConfig.locale.format('en_US', usDate, formatStr)).toEqual('2020-12-27');
+        expect(generateConfig.locale.format('zh_CN', cnDate, formatStr)).toEqual('2020-12-28');
       });
 
       it('Parse format Wo', () => {

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -139,7 +139,7 @@ describe('Picker.Generate', () => {
             'en_US',
             generateConfig.locale.parse('en_US', '2020-12-30', [formatStr]),
           ),
-        ).toEqual(1608998400000);
+        ).toEqual(1609027200000);
         expect(
           generateConfig.locale.getWeekFirstDayValue(
             'zh_CN',

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -132,6 +132,22 @@ describe('Picker.Generate', () => {
         });
       });
 
+      it('getWeekFirstDayValue', () => {
+        const formatStr = name === 'date-fns' ? 'yyyy-MM-dd' : 'YYYY-MM-DD';
+        expect(
+          generateConfig.locale.getWeekFirstDayValue(
+            'en_US',
+            generateConfig.locale.parse('en_US', '2020-12-30', [formatStr]),
+          ),
+        ).toEqual(1608998400000);
+        expect(
+          generateConfig.locale.getWeekFirstDayValue(
+            'zh_CN',
+            generateConfig.locale.parse('zh_CN', '2020-12-30', [formatStr]),
+          ),
+        ).toEqual(1609084800000);
+      });
+
       it('Parse format Wo', () => {
         if (name !== 'date-fns') {
           expect(

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -145,7 +145,7 @@ describe('Picker.Generate', () => {
             'zh_CN',
             generateConfig.locale.parse('zh_CN', '2020-12-30', [formatStr]),
           ),
-        ).toEqual(1609084800000);
+        ).toEqual(1609113600000);
       });
 
       it('Parse format Wo', () => {


### PR DESCRIPTION
### 🔗 Related issue link
Resolve [#27879](https://github.com/ant-design/ant-design/issues/27879)

### 💡 Background and solution
When you click `2020-12-27 ~ 2020-12-31` these days to select `2021 - 1st` as end week, all the weeks before are disabled.

Previously, we use `weekNumber` for comparison, it works well in most cases. But when you click these days e.g. `2020-12-30`, it will return `202001`, which is smaller than the weeks before in 2020, and result in these weeks are disabled.

```js
// en-us

function weekNumber(date: DateType) { // 2020-12-30
  const year = generateConfig.getYear(date); // 2020
  const week = generateConfig.locale.getWeek(locale.locale, date); // 1
  return year * 100 + week; // 202001
}

const disabled = weekNumber(date) > weekNumber(endDate);
```

### 🎈 Results
Before:
![image](https://user-images.githubusercontent.com/50612752/99869328-ff523100-2c04-11eb-80aa-0381ca276163.png)
After:
![image](https://user-images.githubusercontent.com/50612752/99869329-0416e500-2c05-11eb-9c92-cad2672fc362.png)
