### PR TITLE
disableDate后导致部分日期无法禁用或无法点击

### DIFF
--- a/src/PickerPanel.tsx
+++ b/src/PickerPanel.tsx
@@ -347,7 +347,7 @@ function PickerPanel<DateType>(props: PickerPanelProps<DateType>) {
     onViewDateChange: setViewDate,
     sourceMode,
     onPanelChange: onInternalPanelChange,
-    disabledDate: mergedMode !== 'decade' ? disabledDate : undefined,
+    disabledDate: disabledDate,
   };
   delete pickerProps.onChange;
   delete pickerProps.onSelect;

--- a/src/PickerPanel.tsx
+++ b/src/PickerPanel.tsx
@@ -347,7 +347,7 @@ function PickerPanel<DateType>(props: PickerPanelProps<DateType>) {
     onViewDateChange: setViewDate,
     sourceMode,
     onPanelChange: onInternalPanelChange,
-    disabledDate: disabledDate,
+    disabledDate,
   };
   delete pickerProps.onChange;
   delete pickerProps.onSelect;

--- a/src/generate/dateFns.ts
+++ b/src/generate/dateFns.ts
@@ -4,6 +4,7 @@ import {
   getMonth,
   getDate,
   endOfMonth,
+  endOfYear,
   getHours,
   getMinutes,
   getSeconds,
@@ -62,6 +63,8 @@ const generateConfig: GenerateConfig<Date> = {
   setHour: (date, hour) => setHours(date, hour),
   setMinute: (date, minute) => setMinutes(date, minute),
   setSecond: (date, second) => setSeconds(date, second),
+  addEndMonth: (date, diff) => addMonths(endOfMonth(date), diff),
+  addEndYear: (date, diff) => addYears(endOfYear(date), diff),
 
   // Compare
   isAfter: (date1, date2) => isAfter(date1, date2),

--- a/src/generate/dayjs.ts
+++ b/src/generate/dayjs.ts
@@ -69,6 +69,8 @@ const generateConfig: GenerateConfig<Dayjs> = {
   setHour: (date, hour) => date.hour(hour),
   setMinute: (date, minute) => date.minute(minute),
   setSecond: (date, second) => date.second(second),
+  addEndMonth: (date, diff) => date.add(diff, 'month').endOf('month'),
+  addEndYear: (date, diff) => date.add(diff, 'year').endOf('year'),
 
   // Compare
   isAfter: (date1, date2) => date1.isAfter(date2),

--- a/src/generate/index.ts
+++ b/src/generate/index.ts
@@ -21,6 +21,8 @@ export interface GenerateConfig<DateType> {
   setHour: (value: DateType, hour: number) => DateType;
   setMinute: (value: DateType, minute: number) => DateType;
   setSecond: (value: DateType, second: number) => DateType;
+  addEndMonth: (value: DateType, second: number) => DateType;
+  addEndYear: (value: DateType, second: number) => DateType;
 
   // Compare
   isAfter: (date1: DateType, date2: DateType) => boolean;

--- a/src/generate/moment.ts
+++ b/src/generate/moment.ts
@@ -58,6 +58,14 @@ const generateConfig: GenerateConfig<Moment> = {
     const clone = date.clone();
     return clone.second(second);
   },
+  addEndMonth: (date, diff) => {
+    const clone = date.clone();
+    return clone.endOf('month').add(diff, 'month');
+  },
+  addEndYear: (date, diff) => {
+    const clone = date.clone();
+    return clone.endOf('year').add(diff, 'year');
+  },
 
   // Compare
   isAfter: (date1, date2) => date1.isAfter(date2),

--- a/src/panels/DatePanel/DateBody.tsx
+++ b/src/panels/DatePanel/DateBody.tsx
@@ -92,6 +92,7 @@ function DateBody<DateType>(props: DateBodyProps<DateType>) {
       getCellText={generateConfig.getDate}
       getCellClassName={getCellClassName}
       getCellDate={generateConfig.addDate}
+      getCompareDate={generateConfig.addDate}
       titleCell={date =>
         formatValue(date, {
           locale,

--- a/src/panels/DecadePanel/DecadeBody.tsx
+++ b/src/panels/DecadePanel/DecadeBody.tsx
@@ -10,13 +10,12 @@ export interface YearBodyProps<DateType> {
   prefixCls: string;
   generateConfig: GenerateConfig<DateType>;
   viewDate: DateType;
-  disabledDate?: (date: DateType) => boolean;
   onSelect: (value: DateType) => void;
 }
 
 function DecadeBody<DateType>(props: YearBodyProps<DateType>) {
   const DECADE_UNIT_DIFF_DES = DECADE_UNIT_DIFF - 1;
-  const { prefixCls, viewDate, generateConfig, disabledDate } = props;
+  const { prefixCls, viewDate, generateConfig } = props;
 
   const cellPrefixCls = `${prefixCls}-cell`;
 
@@ -35,13 +34,11 @@ function DecadeBody<DateType>(props: YearBodyProps<DateType>) {
   );
 
   const getCellClassName = (date: DateType) => {
-    const disabled = disabledDate && disabledDate(date);
 
     const startDecadeNumber = generateConfig.getYear(date);
     const endDecadeNumber = startDecadeNumber + DECADE_UNIT_DIFF_DES;
 
     return {
-      [`${cellPrefixCls}-disabled`]: disabled,
       [`${cellPrefixCls}-in-view`]:
         startDecadeYear <= startDecadeNumber && endDecadeNumber <= endDecadeYear,
       [`${cellPrefixCls}-selected`]: startDecadeNumber === decadeYearNumber,
@@ -60,6 +57,7 @@ function DecadeBody<DateType>(props: YearBodyProps<DateType>) {
       }}
       getCellClassName={getCellClassName}
       getCellDate={(date, offset) => generateConfig.addYear(date, offset * DECADE_UNIT_DIFF)}
+      getCompareDate={(date, offset) => generateConfig.addEndYear(date, offset * DECADE_UNIT_DIFF + DECADE_UNIT_DIFF_DES)}
     />
   );
 }

--- a/src/panels/MonthPanel/MonthBody.tsx
+++ b/src/panels/MonthPanel/MonthBody.tsx
@@ -70,6 +70,7 @@ function MonthBody<DateType>(props: MonthBodyProps<DateType>) {
       }
       getCellClassName={getCellClassName}
       getCellDate={generateConfig.addMonth}
+      getCompareDate={generateConfig.addEndMonth}
       titleCell={date =>
         formatValue(date, {
           locale,

--- a/src/panels/PanelBody.tsx
+++ b/src/panels/PanelBody.tsx
@@ -18,6 +18,7 @@ export interface PanelBodyProps<DateType> {
   baseDate: DateType;
   getCellClassName: (date: DateType) => Record<string, boolean | undefined>;
   getCellDate: (date: DateType, offset: number) => DateType;
+  getCompareDate: (date: DateType, offset: number) => DateType;
   getCellText: (date: DateType) => React.ReactNode;
   getCellNode?: (date: DateType) => React.ReactNode;
   titleCell?: (date: DateType) => string;
@@ -42,6 +43,7 @@ export default function PanelBody<DateType>({
   getCellText,
   getCellNode,
   getCellDate,
+  getCompareDate,
   generateConfig,
   titleCell,
   headerCells,
@@ -60,7 +62,8 @@ export default function PanelBody<DateType>({
     for (let j = 0; j < colNum; j += 1) {
       const offset = i * colNum + j;
       const currentDate = getCellDate(baseDate, offset);
-      const disabled = disabledDate && disabledDate(currentDate);
+      const compareDate = getCompareDate(baseDate, offset)
+      const disabled = disabledDate && disabledDate(compareDate);
 
       if (j === 0) {
         rowStartDate = currentDate;

--- a/src/panels/PanelBody.tsx
+++ b/src/panels/PanelBody.tsx
@@ -62,7 +62,7 @@ export default function PanelBody<DateType>({
     for (let j = 0; j < colNum; j += 1) {
       const offset = i * colNum + j;
       const currentDate = getCellDate(baseDate, offset);
-      const compareDate = getCompareDate(baseDate, offset)
+      const compareDate = getCompareDate(baseDate, offset);
       const disabled = disabledDate && disabledDate(compareDate);
 
       if (j === 0) {
@@ -81,8 +81,11 @@ export default function PanelBody<DateType>({
           title={title}
           className={classNames(cellPrefixCls, {
             [`${cellPrefixCls}-disabled`]: disabled,
-            [`${cellPrefixCls}-start`]: getCellText(currentDate) === 1 || picker === 'year' && Number(title) % 10 === 0,
-            [`${cellPrefixCls}-end`]: title === getLastDay(generateConfig, currentDate) || picker === 'year' && Number(title) % 10 === 9,
+            [`${cellPrefixCls}-start`]:
+              getCellText(currentDate) === 1 || (picker === 'year' && Number(title) % 10 === 0),
+            [`${cellPrefixCls}-end`]:
+              title === getLastDay(generateConfig, currentDate) ||
+              (picker === 'year' && Number(title) % 10 === 9),
             ...getCellClassName(currentDate),
           })}
           onClick={() => {

--- a/src/panels/QuarterPanel/QuarterBody.tsx
+++ b/src/panels/QuarterPanel/QuarterBody.tsx
@@ -54,6 +54,7 @@ function QuarterBody<DateType>(props: QuarterBodyProps<DateType>) {
       }
       getCellClassName={getCellClassName}
       getCellDate={(date, offset) => generateConfig.addMonth(date, offset * 3)}
+      getCompareDate={(date, offset) => generateConfig.addEndMonth(date, offset * 3)}
       titleCell={date =>
         formatValue(date, {
           locale,

--- a/src/panels/YearPanel/YearBody.tsx
+++ b/src/panels/YearPanel/YearBody.tsx
@@ -60,6 +60,7 @@ function YearBody<DateType>(props: YearBodyProps<DateType>) {
       getCellText={generateConfig.getYear}
       getCellClassName={getCellClassName}
       getCellDate={generateConfig.addYear}
+      getCompareDate={generateConfig.addEndYear}
       titleCell={date =>
         formatValue(date, {
           locale,

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -65,6 +65,13 @@ describe('Picker.Generate', () => {
         expect(generateConfig.locale.format('en_US', date, 'YYYY-MM-DD')).toEqual('1992-11-05');
       });
 
+      it('end', () => {
+        let date = generateConfig.getNow();
+        date = generateConfig.addEndMonth(date, 2);
+        date = generateConfig.addEndYear(date, 2);
+        expect(generateConfig.locale.format('en_US', date, 'YYYY-MM-DD')).toEqual('1992-12-31');
+      });
+
       it('isAfter', () => {
         const now = generateConfig.getNow();
         const prev = generateConfig.addDate(now, -1);


### PR DESCRIPTION
### 1、禁用日期后decade无法禁用
具体例子见
[ant-design #28155](https://github.com/ant-design/ant-design/issues/28155#issue-755223608)

### 2、在disableDate今日日期后选择’年份‘或’月份‘无法返回
在[ant-design #28155](https://github.com/ant-design/ant-design/issues/28155#issue-755223608)中我发现了新问题，在禁用当年的时间后点击年或月无法返回
![](https://pic.amikara.com/2020-12-10-F5B28E91-0840-4B86-A576-6542DAD8FF39.png)
![](https://pic.amikara.com/2020-12-10-080532.png)

### 更新日志
+ 更改DisableDate参数数值
+ 修改DecadePanel的Disable方式
