### PR TITLE
Fix: matching endTime and startTime

### DIFF
--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -744,6 +744,13 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
     };
   });
 
+  const getMergedPickerDate = (mergedIndex: typeof mergedActivePickerIndex) => {
+    if (mergedIndex === 1 && getViewDate(1) <= getViewDate(0)) {
+      return getViewDate(0);
+    }
+    return getViewDate(mergedIndex);
+  };
+
   // ============================= Panel =============================
   function renderPanel(
     panelPosition: 'left' | 'right' | false = false,
@@ -883,7 +890,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
     });
 
     if (picker !== 'time' && !showTime) {
-      const viewDate = getViewDate(mergedActivePickerIndex);
+      const viewDate = getMergedPickerDate(mergedActivePickerIndex);
       const nextViewDate = getClosingViewDate(viewDate, picker, generateConfig);
       const currentMode = mergedModes[mergedActivePickerIndex];
 


### PR DESCRIPTION
ant-design/ant-design#27898

选择结束时间时如果时间小于初始时间就转跳到初始时间之后