### PR TITLE
fix: add date judgment

### DIFF
--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -357,6 +357,11 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
     };
   }
 
+  const [hoverValue, onEnter, onLeave] = useHoverValue(text, {
+    formatList,
+    generateConfig,
+    locale,
+  });
 
   // ============================= Panel =============================
   const panelProps = {
@@ -384,6 +389,11 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
         setSelectedValue(date);
       }}
       direction={direction}
+      onPanelChange={(viewDate, mode) => {
+        const { onPanelChange } = panelProps;
+        onLeave(true);
+        onPanelChange?.(viewDate, mode);
+      }}
     />
   );
 
@@ -435,12 +445,6 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
       '`defaultOpenValue` may confuse user for the current value status. Please use `defaultValue` instead.',
     );
   }
-
-  const [hoverValue, onEnter, onLeave] = useHoverValue(text, {
-    formatList,
-    generateConfig,
-    locale,
-  });
 
 
   // ============================ Return =============================

--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -357,11 +357,6 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
     };
   }
 
-  const [hoverValue, onEnter, onLeave] = useHoverValue(text, {
-    formatList,
-    generateConfig,
-    locale,
-  });
 
   // ============================= Panel =============================
   const panelProps = {
@@ -389,11 +384,6 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
         setSelectedValue(date);
       }}
       direction={direction}
-      onPanelChange={(viewDate, mode) => {
-        const { onPanelChange } = panelProps;
-        onLeave(true);
-        onPanelChange?.(viewDate, mode);
-      }}
     />
   );
 
@@ -445,6 +435,13 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
       '`defaultOpenValue` may confuse user for the current value status. Please use `defaultValue` instead.',
     );
   }
+
+  const [hoverValue, onEnter, onLeave] = useHoverValue(text, {
+    formatList,
+    generateConfig,
+    locale,
+  });
+
 
   // ============================ Return =============================
   const onContextSelect = (date: DateType, type: 'key' | 'mouse' | 'submit') => {

--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -446,7 +446,6 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
     );
   }
 
-
   // ============================ Return =============================
   const onContextSelect = (date: DateType, type: 'key' | 'mouse' | 'submit') => {
     if (type === 'submit' || (type !== 'key' && !needConfirmButton)) {

--- a/src/PickerPanel.tsx
+++ b/src/PickerPanel.tsx
@@ -254,6 +254,23 @@ function PickerPanel<DateType>(props: PickerPanelProps<DateType>) {
     }
   };
 
+  const getDisableNextMode = (mode: PanelMode): PanelMode => {
+    switch (mode){
+      case 'year': return 'month';
+      case 'quarter': return 'month';
+      case 'decade': return 'year';
+      case 'month': return 'date';
+    }
+    return mode
+  }
+
+  const disablePanelChange = (newMode: PanelMode | null, viewValue: DateType) => {
+    const nextMode = getDisableNextMode(newMode || mergedMode);
+    setInnerMode(nextMode);
+    
+    setInnerViewDate(viewValue)
+  }
+
   const triggerSelect = (
     date: DateType,
     type: 'key' | 'mouse' | 'submit',
@@ -347,6 +364,7 @@ function PickerPanel<DateType>(props: PickerPanelProps<DateType>) {
     onViewDateChange: setViewDate,
     sourceMode,
     onPanelChange: onInternalPanelChange,
+    disablePanelChange,
     disabledDate,
   };
   delete pickerProps.onChange;

--- a/src/PickerPanel.tsx
+++ b/src/PickerPanel.tsx
@@ -30,7 +30,7 @@ import {
   OnPanelChange,
   Components,
 } from './interface';
-import { isEqual } from './utils/dateUtil';
+import { isEqual, getDisableNextMode } from './utils/dateUtil';
 import PanelContext from './PanelContext';
 import { DateRender } from './panels/DatePanel/DateBody';
 import { PickerModeMap } from './utils/uiUtil';
@@ -253,16 +253,6 @@ function PickerPanel<DateType>(props: PickerPanelProps<DateType>) {
       onPanelChange(viewValue, nextMode);
     }
   };
-
-  const getDisableNextMode = (mode: PanelMode): PanelMode => {
-    switch (mode){
-      case 'year': return 'month';
-      case 'quarter': return 'month';
-      case 'decade': return 'year';
-      case 'month': return 'date';
-    }
-    return mode
-  }
 
   const disablePanelChange = (newMode: PanelMode | null, viewValue: DateType) => {
     const nextMode = getDisableNextMode(newMode || mergedMode);

--- a/src/panels/PanelBody.tsx
+++ b/src/panels/PanelBody.tsx
@@ -93,7 +93,7 @@ export default function PanelBody<DateType>({
             ...getCellClassName(currentDate),
           })}
           onClick={() => {
-            if (!disabled && !disabledDate(currentDate)) {
+            if (!disabled && !disabledDate?.(currentDate)) {
               onSelect(currentDate);
             } else {
               disablePanelChange(mode, currentDate);

--- a/src/panels/PanelBody.tsx
+++ b/src/panels/PanelBody.tsx
@@ -23,7 +23,7 @@ export interface PanelBodyProps<DateType> {
   getCellNode?: (date: DateType) => React.ReactNode;
   titleCell?: (date: DateType) => string;
   generateConfig: GenerateConfig<DateType>;
-
+  disablePanelChange: (newMode: PanelMode | null, viewValue: DateType) => void;
   // Used for week panel
   prefixColumn?: (date: DateType) => React.ReactNode;
   rowClassName?: (date: DateType) => string;
@@ -46,6 +46,7 @@ export default function PanelBody<DateType>({
   generateConfig,
   titleCell,
   headerCells,
+  disablePanelChange,
 }: PanelBodyProps<DateType>) {
   const { onDateMouseEnter, onDateMouseLeave, mode } = React.useContext(PanelContext);
 
@@ -92,8 +93,10 @@ export default function PanelBody<DateType>({
             ...getCellClassName(currentDate),
           })}
           onClick={() => {
-            if (!disabled) {
+            if (!disabled && !disabledDate(currentDate)) {
               onSelect(currentDate);
+            } else {
+              disablePanelChange(mode, currentDate);
             }
           }}
           onMouseEnter={() => {

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -325,12 +325,16 @@ export function getCellDateDisabled<DateType>({
   return false;
 }
 
-export function getDisableNextMode( mode: PanelMode ) {
+export function getDisableNextMode(mode: PanelMode) {
   switch (mode) {
-    case 'month': return 'date';
-    case 'year': return 'month';
-    case 'quarter': return 'month';
-    case 'decade': return 'year';
+    case 'month':
+      return 'date';
+    case 'year':
+      return 'month';
+    case 'quarter':
+      return 'month';
+    case 'decade':
+      return 'year';
   }
-  return mode
+  return mode;
 }

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -324,3 +324,13 @@ export function getCellDateDisabled<DateType>({
   }
   return false;
 }
+
+export function getDisableNextMode( mode: PanelMode ) {
+  switch (mode) {
+    case 'month': return 'date';
+    case 'year': return 'month';
+    case 'quarter': return 'month';
+    case 'decade': return 'year';
+  }
+  return mode
+}


### PR DESCRIPTION
针对 [afc163之前提出的问题](https://github.com/react-component/picker/pull/191#issuecomment-748874674)进行了一层判断，比如禁用了今天(2020年12.24)之前的时间，然后选择了2021年5.1，但是此时想点击回2020年，选择2020年，原先的日期面板为
![image](https://user-images.githubusercontent.com/44696899/103092410-1cc65080-4632-11eb-80f6-d766cce5d5ae.png)仍停留在2020年5月，

我在选取日期之前增加了一个逻辑判断，现在为
![image](https://user-images.githubusercontent.com/44696899/103092464-47b0a480-4632-11eb-9175-8d199dada1db.png)

@kerm1it 
