### PR TITLE
fix: updated ru_RU locale

### DIFF
--- a/src/locale/ru_RU.ts
+++ b/src/locale/ru_RU.ts
@@ -5,7 +5,7 @@ const locale: Locale = {
   today: 'Сегодня',
   now: 'Сейчас',
   backToToday: 'Текущая дата',
-  ok: 'Ok',
+  ok: 'ОК',
   clear: 'Очистить',
   month: 'Месяц',
   year: 'Год',


### PR DESCRIPTION
Renamed `locale.ok` key from English 'Ok' to Russian 'ОК' to be the same as in antd's ru_RU locale file ([for example](https://github.com/ant-design/ant-design/blob/master/components/locale/ru_RU.tsx#L37))