### PR TITLE
fix: document.activeElement cannot get correct dom when the component…

### DIFF
--- a/src/hooks/usePickerInput.ts
+++ b/src/hooks/usePickerInput.ts
@@ -112,7 +112,12 @@ export default function usePickerInput({
 
       if (blurToCancel) {
         setTimeout(() => {
-          if (isClickOutside(document.activeElement)) {
+          let { activeElement } = document;
+          while (activeElement && activeElement.shadowRoot) {
+            activeElement = activeElement.shadowRoot.activeElement;
+          }
+
+          if (isClickOutside(activeElement)) {
             onCancel();
           }
         }, 0);


### PR DESCRIPTION
document.activeElement cannot get correct dom when the component is placed in shadow dom