### PR TITLE
chore(parseValue): should keep origin state

### DIFF
--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -228,6 +228,7 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
         locale,
         formatList,
         generateConfig,
+        date: mergedValue,
       });
       if (inputDate && (!disabledDate || !disabledDate(inputDate))) {
         setSelectedValue(inputDate);

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -517,6 +517,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
       locale,
       formatList,
       generateConfig,
+      date: mergedValue && mergedValue[index],
     });
 
     const disabledFunc = index === 0 ? disabledStartDate : disabledEndDate;

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -1,6 +1,7 @@
 import { DECADE_UNIT_DIFF } from '../panels/DecadePanel/index';
 import type { PanelMode, NullableDateType, PickerMode, Locale, CustomFormat } from '../interface';
 import type { GenerateConfig } from '../generate';
+import { setDateTime } from './timeUtil';
 
 export const WEEK_DAY_COUNT = 7;
 
@@ -211,23 +212,62 @@ export function formatValue<DateType>(
     : generateConfig.locale.format(locale.locale, value, format);
 }
 
+export function setDate<DateType>(
+  generateConfig: GenerateConfig<DateType>,
+  date: DateType,
+  defaultDate: NullableDateType<DateType>,
+  time: boolean = true
+) {
+  if (!defaultDate) {
+    return date;
+  }
+
+  let newDate = date;
+  newDate = generateConfig.setYear(
+    newDate,
+    generateConfig.getYear(defaultDate),
+  );
+  newDate = generateConfig.setMonth(
+    newDate,
+    generateConfig.getMonth(defaultDate),
+  );
+  newDate = generateConfig.setDate(
+    newDate,
+    generateConfig.getDate(defaultDate),
+  );
+
+  if (time) {
+    newDate = setDateTime(generateConfig, newDate, defaultDate);
+  }
+
+  return newDate;
+}
+
 export function parseValue<DateType>(
   value: string,
   {
     generateConfig,
     locale,
     formatList,
+    date
   }: {
     generateConfig: GenerateConfig<DateType>;
     locale: Locale;
     formatList: (string | CustomFormat<DateType>)[];
+    date: DateType
   },
 ) {
   if (!value || typeof formatList[0] === 'function') {
     return null;
   }
 
-  return generateConfig.locale.parse(locale.locale, value, formatList as string[]);
+  let newDate = generateConfig.locale.parse(locale.locale, value, formatList as string[]);
+  // keep origin state
+  if (newDate && date) {
+    newDate = setDate(generateConfig, date, newDate);
+  }
+
+  return newDate;
 }
 
 // eslint-disable-next-line consistent-return

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -218,10 +218,6 @@ export function setDate<DateType>(
   defaultDate: NullableDateType<DateType>,
   time: boolean = true
 ) {
-  if (!defaultDate) {
-    return date;
-  }
-
   let newDate = date;
   newDate = generateConfig.setYear(
     newDate,

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -969,6 +969,19 @@ describe('Picker.Basic', () => {
       wrapper.confirmOK();
       expect(wrapper.find('input').prop('value')).toBe('1990-08-03 00:00:00');
     });
+    it("shouldn't trigger when value of input is invalid", () => {
+      const onChange = jest.fn();
+      const defaultValue = getMoment('1990-09-03 00:00:00').utc();
+      const wrapper = mount(<MomentPicker defaultValue={defaultValue} onChange={onChange} showTime />);
+      wrapper.openPicker();
+      wrapper.find('input').simulate('change', {
+        target: {
+          value: '1990-0-03 00:00:00',
+        },
+      });
+      wrapper.confirmOK();
+      expect(onChange).not.toHaveBeenCalled();
+    });
     it('should keep origin state', () => {
       const onChange = jest.fn();
       const defaultValue = getMoment('1990-09-03 00:00:00').utc();

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -956,4 +956,31 @@ describe('Picker.Basic', () => {
       }
     });
   });
+
+  describe('parse value', () => {
+    it('should work correctly', () => {
+      const wrapper = mount(<MomentPicker showTime />);
+      wrapper.openPicker();
+      wrapper.find('input').simulate('change', {
+        target: {
+          value: '1990-08-03 00:00:00',
+        },
+      });
+      wrapper.confirmOK();
+      expect(wrapper.find('input').prop('value')).toBe('1990-08-03 00:00:00');
+    });
+    it('should keep origin state', () => {
+      const onChange = jest.fn();
+      const defaultValue = getMoment('1990-09-03 00:00:00').utc();
+      const wrapper = mount(<MomentPicker defaultValue={defaultValue} onChange={onChange} showTime />);
+      wrapper.openPicker();
+      wrapper.find('input').simulate('change', {
+        target: {
+          value: '1990-08-03 00:00:00',
+        },
+      });
+      wrapper.confirmOK();
+      expect(onChange.mock.calls[0][0].isUTC()).toBeTruthy();
+    });
+  });
 });

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -3,10 +3,11 @@ import MockDate from 'mockdate';
 import { act } from 'react-dom/test-utils';
 import KeyCode from 'rc-util/lib/KeyCode';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
-import { Moment } from 'moment';
-import { mount, getMoment, isSame, MomentRangePicker, Wrapper } from './util/commonUtil';
+import type { Moment } from 'moment';
+import type { Wrapper } from './util/commonUtil';
+import { mount, getMoment, isSame, MomentRangePicker } from './util/commonUtil';
 import zhCN from '../src/locale/zh_CN';
-import { PickerMode } from '../src/interface';
+import type { PickerMode } from '../src/interface';
 
 describe('Picker.Range', () => {
   function matchValues(wrapper: Wrapper, value1: string, value2: string) {
@@ -1899,5 +1900,82 @@ describe('Picker.Range', () => {
     wrapper.find('.rc-picker-ok button').simulate('click');
 
     matchValues(wrapper, '1990-09-24 00:00:00', '1990-09-24 00:00:00');
+  });
+
+  describe('parse value', () => {
+    it('should work correctly', () => {
+      const defaultValue: [Moment, Moment] = [
+        getMoment('1989-11-28 00:00:00'),
+        getMoment('1990-09-03 00:00:00'),
+      ];
+      const wrapper = mount(<MomentRangePicker showTime defaultValue={defaultValue} />);
+      wrapper.openPicker(0);
+      wrapper
+        .find('input')
+        .first()
+        .simulate('change', {
+          target: {
+            value: '1989-10-28 00:00:00',
+          },
+        });
+      wrapper.confirmOK();
+
+      wrapper
+        .find('input')
+        .last()
+        .simulate('change', {
+          target: {
+            value: '1990-08-03 00:00:00',
+          },
+        });
+      wrapper.confirmOK();
+
+      expect(
+        wrapper
+          .find('input')
+          .first()
+          .prop('value'),
+      ).toBe('1989-10-28 00:00:00');
+      expect(
+        wrapper
+          .find('input')
+          .last()
+          .prop('value'),
+      ).toBe('1990-08-03 00:00:00');
+    });
+    it('should keep origin state', () => {
+      const onChange = jest.fn();
+      const defaultValue: [Moment, Moment] = [
+        getMoment('1989-11-28 00:00:00').utc(),
+        getMoment('1990-09-03 00:00:00').utc(),
+      ];
+      const wrapper = mount(
+        <MomentRangePicker defaultValue={defaultValue} onChange={onChange} showTime />,
+      );
+      wrapper.openPicker(0);
+      wrapper
+        .find('input')
+        .first()
+        .simulate('change', {
+          target: {
+            value: '1989-10-28 00:00:00',
+          },
+        });
+      wrapper.confirmOK();
+
+      wrapper
+        .find('input')
+        .last()
+        .simulate('change', {
+          target: {
+            value: '1990-08-03 00:00:00',
+          },
+        });
+      wrapper.confirmOK();
+
+      const changedValue = onChange.mock.calls[0][0];
+      expect(changedValue[0].isUTC()).toBeTruthy();
+      expect(changedValue[1].isUTC()).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/29618

优化了输入框解析值，解析完成后，如果之前有值，就把解析后值的年月日、时分秒设置到之前的值上，这样如果之前设置了utc时区等状态，可以保持原来的状态。