### PR TITLE
Fix: Update pt_BR.ts

### DIFF
--- a/src/locale/pt_BR.ts
+++ b/src/locale/pt_BR.ts
@@ -27,6 +27,21 @@ const locale: Locale = {
   nextDecade: 'Próxima década',
   previousCentury: 'Século anterior',
   nextCentury: 'Próximo século',
+  shortWeekDays: ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb'],
+    shortMonths: [
+      'Jan',
+      'Fev',
+      'Mar',
+      'Abr',
+      'Mai',
+      'Jun',
+      'Jul',
+      'Ago',
+      'Set',
+      'Out',
+      'Nov',
+      'Dez',
+    ],
 };
 
 export default locale;


### PR DESCRIPTION
Update the name of the days of the week and months for Brazilian Portuguese, as names in English are currently being displayed