### PR TITLE
docs: update code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,20 @@ https://react-component.github.io/picker/
 
 ## Usage
 
-```js
+The following example uses `Moment.js`, but `rc-picker` also supports `date-fns` and `Day.js`.
+
+```jsx
 import Picker from 'rc-picker';
 import 'rc-picker/assets/index.css';
 import { render } from 'react-dom';
+import enUS from 'rc-picker/lib/locale/en_US';
+import generateConfig from 'rc-picker/lib/generate/moment';
+// For date-fns, use:
+// import generateConfig from 'rc-picker/lib/generate/dateFns';
+// For Day.js, use:
+// import generateConfig from 'rc-picker/lib/generate/dayjs';
 
-render(<Picker />, mountNode);
+render(<Picker generateConfig={generateConfig} locale={locale} />, mountNode);
 ```
 
 ## API


### PR DESCRIPTION
I found that errors are thrown if we render the component without the `generateConfig` and `locale` props, so I added them to the example code to make it clearer.