### PR TITLE
fix: dayjs and date-fns as deps with wide semver version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "dependencies": {
     "@babel/runtime": "^7.10.1",
     "classnames": "^2.2.1",
-    "date-fns": "^2.15.0",
+    "date-fns": "2.x",
+    "dayjs": "1.x",
     "moment": "^2.24.0",
     "rc-trigger": "^5.0.4",
     "rc-util": "^5.4.0",
@@ -59,7 +60,6 @@
     "@umijs/fabric": "^2.0.8",
     "coveralls": "^3.0.6",
     "cross-env": "^7.0.2",
-    "dayjs": "^1.8.30",
     "enzyme": "^3.0.0",
     "enzyme-adapter-react-16": "^1.0.1",
     "enzyme-to-json": "^3.4.0",
@@ -85,7 +85,6 @@
     "mode": "npm"
   },
   "peerDependencies": {
-    "dayjs": "^1.8.30",
     "react": ">=16.9.0",
     "react-dom": ">=16.9.0"
   }


### PR DESCRIPTION
1. Move dayjs out of peerDependencies
https://github.com/ant-design/ant-design/issues/31096
https://github.com/ant-design/ant-design/issues/23435

2. Use wide semver version range for dayjs and date-fns , avoid https://github.com/ant-design/ant-design/issues/26190#issuecomment-775397824