### PR TITLE
fix: RangePicker.defaultPickerValue has no effect if showTime is set

### DIFF
--- a/src/PickerPanel.tsx
+++ b/src/PickerPanel.tsx
@@ -101,7 +101,8 @@ export type PickerPanelDateProps<DateType> = {
 
 export type PickerPanelTimeProps<DateType> = {
   picker: 'time';
-} & PickerPanelSharedProps<DateType> & SharedTimeProps<DateType>;
+} & PickerPanelSharedProps<DateType> &
+  SharedTimeProps<DateType>;
 
 export type PickerPanelProps<DateType> =
   | PickerPanelBaseProps<DateType>
@@ -208,12 +209,16 @@ function PickerPanel<DateType>(props: PickerPanelProps<DateType>) {
       // When value is null and set showTime
       if (!mergedValue && showTime) {
         if (typeof showTime === 'object') {
-          return setDateTime(generateConfig, date, showTime.defaultValue || now);
+          return setDateTime(
+            generateConfig,
+            Array.isArray(date) ? date[0] : date,
+            showTime.defaultValue || now,
+          );
         }
         if (defaultValue) {
-          return setDateTime(generateConfig, date, defaultValue);
+          return setDateTime(generateConfig, Array.isArray(date) ? date[0] : date, defaultValue);
         }
-        return setDateTime(generateConfig, date, now);
+        return setDateTime(generateConfig, Array.isArray(date) ? date[0] : date, now);
       }
       return date;
     },

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -848,7 +848,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
           defaultValue={
             mergedActivePickerIndex === 0 ? getValue(selectedValue, 1) : getValue(selectedValue, 0)
           }
-          defaultPickerValue={undefined}
+          // defaultPickerValue={undefined}
         />
       </RangeContext.Provider>
     );

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -31,7 +31,16 @@ describe('Picker.Range', () => {
 
       matchValues(wrapper, '1989-11-28', '1990-09-03');
     });
+    it('defaultPickerValue with showTime', () => {
+      const startDate = getMoment('1982-02-12');
+      const endDate = getMoment('1982-02-12');
 
+      const wrapper = mount(
+        <MomentRangePicker defaultPickerValue={[startDate, endDate]} showTime />,
+      );
+      wrapper.openPicker();
+      expect(wrapper.find('.rc-picker-year-btn').first().text()).toEqual(startDate.format('YYYY'));
+    });
     it('controlled', () => {
       const wrapper = mount(
         <MomentRangePicker value={[getMoment('1989-11-28'), getMoment('1990-09-03')]} />,


### PR DESCRIPTION
I am trying to fix [this Bug ](https://github.com/ant-design/ant-design/issues/30005) I also ran into on the Ant Design range picker.

