### PR TITLE
fix: Range Picker dropdown misalign (#292)

### DIFF
--- a/src/hooks/usePickerInput.ts
+++ b/src/hooks/usePickerInput.ts
@@ -105,6 +105,8 @@ export default function usePickerInput({
     },
 
     onBlur: (e) => {
+      setFocused(false);
+
       if (preventBlurRef.current || !isClickOutside(document.activeElement)) {
         preventBlurRef.current = false;
         return;
@@ -128,7 +130,6 @@ export default function usePickerInput({
           onSubmit();
         }
       }
-      setFocused(false);
 
       if (onBlur) {
         onBlur(e);


### PR DESCRIPTION
When clicking outside the component, the focused attribute of the input component is not reorganized.

fix: Range  dropdown misalign (#292).
Validation report:

https://user-images.githubusercontent.com/35871603/132129566-8d44c626-41f6-4f94-a30f-e43e300628be.mp4

