### PR TITLE
fix: fix type of Picker

### DIFF
--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -105,7 +105,7 @@ export type PickerDateProps<DateType> = {} & PickerSharedProps<DateType> &
   OmitPanelProps<PickerPanelDateProps<DateType>>;
 
 export type PickerTimeProps<DateType> = {
-  picker: 'time';
+  picker?: 'date' | 'week' | 'month' | 'quarter' | 'year';
   /**
    * @deprecated Please use `defaultValue` directly instead
    * since `defaultOpenValue` will confuse user of current value status


### PR DESCRIPTION
fix: https://github.com/ant-design/ant-design/issues/22955

picker的取值范围应该是 'date' | 'week' | 'month' | 'quarter' | 'year';
且由于下面给的默认值 'date'，这里应该是Optional的