### PR TITLE
Dayjs should parse date in strict mode

### DIFF
--- a/src/generate/dayjs.ts
+++ b/src/generate/dayjs.ts
@@ -115,7 +115,7 @@ const generateConfig: GenerateConfig<Dayjs> = {
           parseNoMatchNotice();
           return null;
         }
-        const date = dayjs(formatText, format).locale(localeStr);
+        const date = dayjs(formatText, format, null, true).locale(localeStr);
         if (date.isValid()) {
           return date;
         }


### PR DESCRIPTION
Fix #346 
To avoid the input text to be parsed to early, parse text in strict mode.