### PR TITLE
Add `shortWeekDays` and `shortMonths` to pt_PT.ts

### DIFF
--- a/src/locale/pt_PT.ts
+++ b/src/locale/pt_PT.ts
@@ -27,6 +27,21 @@ const locale: Locale = {
   nextDecade: 'Década seguinte',
   previousCentury: 'Século anterior',
   nextCentury: 'Século seguinte',
+  shortWeekDays: ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"],
+  shortMonths: [
+    "Jan",
+    "Fev",
+    "Mar",
+    "Abr",
+    "Mai",
+    "Jun",
+    "Jul",
+    "Ago",
+    "Set",
+    "Out",
+    "Nov",
+    "Dez",
+  ],
 };
 
 export default locale;


### PR DESCRIPTION
Adds missing translation for shortWeekDays and shortMonths, in portuguese (ptPT).