### PR TITLE
chore(deps): update moment to 2.29.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "classnames": "^2.2.1",
     "date-fns": "2.x",
     "dayjs": "1.x",
-    "moment": "^2.24.0",
+    "moment": "^2.29.2",
     "rc-trigger": "^5.0.4",
     "rc-util": "^5.4.0",
     "shallowequal": "^1.1.0"


### PR DESCRIPTION
Downstream projects are getting security scan warnings for https://security.snyk.io/vuln/SNYK-JS-MOMENT-2440688.

I don't think the path traversal vulnerability applies, since picker runs client-side. But it would be nice to clean up the scans.