### PR TITLE
feat: [#399] added quarterCellRender and yearCellRender to PickerPanel

### DIFF
--- a/src/PickerPanel.tsx
+++ b/src/PickerPanel.tsx
@@ -34,6 +34,8 @@ import PanelContext from './PanelContext';
 import type { DateRender } from './panels/DatePanel/DateBody';
 import { PickerModeMap } from './utils/uiUtil';
 import type { MonthCellRender } from './panels/MonthPanel/MonthBody';
+import type { QuarterCellRender } from './panels/QuarterPanel/QuarterBody';
+import type { YearCellRender } from './panels/YearPanel/YearBody';
 import RangeContext from './RangeContext';
 import getExtraFooter from './utils/getExtraFooter';
 import getRanges from './utils/getRanges';
@@ -65,6 +67,8 @@ export type PickerPanelSharedProps<DateType> = {
   // Render
   dateRender?: DateRender<DateType>;
   monthCellRender?: MonthCellRender<DateType>;
+  quarterCellRender?: QuarterCellRender<DateType>;
+  yearCellRender?: YearCellRender<DateType>;
   renderExtraFooter?: (mode: PanelMode) => React.ReactNode;
 
   // Event

--- a/src/panels/QuarterPanel/QuarterBody.tsx
+++ b/src/panels/QuarterPanel/QuarterBody.tsx
@@ -9,6 +9,11 @@ import PanelBody from '../PanelBody';
 export const QUARTER_COL_COUNT = 4;
 const QUARTER_ROW_COUNT = 1;
 
+export type QuarterCellRender<DateType> = (
+  currentDate: DateType,
+  locale: Locale,
+) => React.ReactNode;
+
 export type QuarterBodyProps<DateType> = {
   prefixCls: string;
   locale: Locale;
@@ -16,11 +21,12 @@ export type QuarterBodyProps<DateType> = {
   value?: DateType | null;
   viewDate: DateType;
   disabledDate?: (date: DateType) => boolean;
+  quarterCellRender?: QuarterCellRender<DateType>;
   onSelect: (value: DateType) => void;
 };
 
 function QuarterBody<DateType>(props: QuarterBodyProps<DateType>) {
-  const { prefixCls, locale, value, viewDate, generateConfig } = props;
+  const { prefixCls, locale, value, viewDate, generateConfig, quarterCellRender } = props;
 
   const { rangedValue, hoverRangedValue } = React.useContext(RangeContext);
 
@@ -39,13 +45,18 @@ function QuarterBody<DateType>(props: QuarterBodyProps<DateType>) {
 
   const baseQuarter = generateConfig.setDate(generateConfig.setMonth(viewDate, 0), 1);
 
+  const getCellNode = quarterCellRender
+    ? (date: DateType) => quarterCellRender(date, locale)
+    : undefined;
+
   return (
     <PanelBody
       {...props}
       rowNum={QUARTER_ROW_COUNT}
       colNum={QUARTER_COL_COUNT}
       baseDate={baseQuarter}
-      getCellText={date =>
+      getCellNode={getCellNode}
+      getCellText={(date) =>
         formatValue(date, {
           locale,
           format: locale.quarterFormat || '[Q]Q',
@@ -54,7 +65,7 @@ function QuarterBody<DateType>(props: QuarterBodyProps<DateType>) {
       }
       getCellClassName={getCellClassName}
       getCellDate={(date, offset) => generateConfig.addMonth(date, offset * 3)}
-      titleCell={date =>
+      titleCell={(date) =>
         formatValue(date, {
           locale,
           format: 'YYYY-[Q]Q',

--- a/src/panels/YearPanel/YearBody.tsx
+++ b/src/panels/YearPanel/YearBody.tsx
@@ -10,6 +10,8 @@ import PanelBody from '../PanelBody';
 export const YEAR_COL_COUNT = 3;
 const YEAR_ROW_COUNT = 4;
 
+export type YearCellRender<DateType> = (currentDate: DateType, locale: Locale) => React.ReactNode;
+
 export type YearBodyProps<DateType> = {
   prefixCls: string;
   locale: Locale;
@@ -17,11 +19,12 @@ export type YearBodyProps<DateType> = {
   value?: NullableDateType<DateType>;
   viewDate: DateType;
   disabledDate?: (date: DateType) => boolean;
+  yearCellRender?: YearCellRender<DateType>;
   onSelect: (value: DateType) => void;
 };
 
 function YearBody<DateType>(props: YearBodyProps<DateType>) {
-  const { prefixCls, value, viewDate, locale, generateConfig } = props;
+  const { prefixCls, value, viewDate, locale, generateConfig, yearCellRender } = props;
   const { rangedValue, hoverRangedValue } = React.useContext(RangeContext);
 
   const yearPrefixCls = `${prefixCls}-cell`;
@@ -51,16 +54,19 @@ function YearBody<DateType>(props: YearBodyProps<DateType>) {
     offsetCell: (date, offset) => generateConfig.addYear(date, offset),
   });
 
+  const getCellNode = yearCellRender ? (date: DateType) => yearCellRender(date, locale) : undefined;
+
   return (
     <PanelBody
       {...props}
       rowNum={YEAR_ROW_COUNT}
       colNum={YEAR_COL_COUNT}
       baseDate={baseYear}
+      getCellNode={getCellNode}
       getCellText={generateConfig.getYear}
       getCellClassName={getCellClassName}
       getCellDate={generateConfig.addYear}
-      titleCell={date =>
+      titleCell={(date) =>
         formatValue(date, {
           locale,
           format: 'YYYY',

--- a/tests/__snapshots__/panel.spec.tsx.snap
+++ b/tests/__snapshots__/panel.spec.tsx.snap
@@ -85,6 +85,37 @@ exports[`Picker.Panel monthCellRender 1`] = `
 </tbody>
 `;
 
+exports[`Picker.Panel quarterCellRender 1`] = `
+<tbody>
+  <tr>
+    <td
+      class="rc-picker-cell rc-picker-cell-in-view"
+      title="1990-Q1"
+    >
+      1990-11
+    </td>
+    <td
+      class="rc-picker-cell rc-picker-cell-in-view"
+      title="1990-Q2"
+    >
+      1990-22
+    </td>
+    <td
+      class="rc-picker-cell rc-picker-cell-in-view"
+      title="1990-Q3"
+    >
+      1990-33
+    </td>
+    <td
+      class="rc-picker-cell rc-picker-cell-in-view"
+      title="1990-Q4"
+    >
+      1990-44
+    </td>
+  </tr>
+</tbody>
+`;
+
 exports[`Picker.Panel should render correctly in rtl 1`] = `
 <div
   class="rc-picker-panel rc-picker-panel-rtl"
@@ -1948,4 +1979,89 @@ exports[`Picker.Panel time disabled columns basic 1`] = `
     </div>
   </div>
 </div>
+`;
+
+exports[`Picker.Panel yearCellRender 1`] = `
+<tbody>
+  <tr>
+    <td
+      class="rc-picker-cell rc-picker-cell-end"
+      title="1989"
+    >
+      1989
+    </td>
+    <td
+      class="rc-picker-cell rc-picker-cell-start rc-picker-cell-in-view"
+      title="1990"
+    >
+      1990
+    </td>
+    <td
+      class="rc-picker-cell rc-picker-cell-in-view"
+      title="1991"
+    >
+      1991
+    </td>
+  </tr>
+  <tr>
+    <td
+      class="rc-picker-cell rc-picker-cell-in-view"
+      title="1992"
+    >
+      1992
+    </td>
+    <td
+      class="rc-picker-cell rc-picker-cell-in-view"
+      title="1993"
+    >
+      1993
+    </td>
+    <td
+      class="rc-picker-cell rc-picker-cell-in-view"
+      title="1994"
+    >
+      1994
+    </td>
+  </tr>
+  <tr>
+    <td
+      class="rc-picker-cell rc-picker-cell-in-view"
+      title="1995"
+    >
+      1995
+    </td>
+    <td
+      class="rc-picker-cell rc-picker-cell-in-view"
+      title="1996"
+    >
+      1996
+    </td>
+    <td
+      class="rc-picker-cell rc-picker-cell-in-view"
+      title="1997"
+    >
+      1997
+    </td>
+  </tr>
+  <tr>
+    <td
+      class="rc-picker-cell rc-picker-cell-in-view"
+      title="1998"
+    >
+      1998
+    </td>
+    <td
+      class="rc-picker-cell rc-picker-cell-end rc-picker-cell-in-view"
+      title="1999"
+    >
+      1999
+    </td>
+    <td
+      class="rc-picker-cell rc-picker-cell-start"
+      title="2000"
+    >
+      2000
+    </td>
+  </tr>
+</tbody>
 `;

--- a/tests/panel.spec.tsx
+++ b/tests/panel.spec.tsx
@@ -520,6 +520,22 @@ describe('Picker.Panel', () => {
     expect(wrapper.find('tbody').render()).toMatchSnapshot();
   });
 
+  it('quarterCellRender', () => {
+    const wrapper = mount(
+      <MomentPickerPanel picker="quarter" quarterCellRender={(date) => date.format('YYYY-QQ')} />,
+    );
+
+    expect(wrapper.find('tbody').render()).toMatchSnapshot();
+  });
+
+  it('yearCellRender', () => {
+    const wrapper = mount(
+      <MomentPickerPanel picker="year" yearCellRender={(date) => date.format('YYYY')} />,
+    );
+
+    expect(wrapper.find('tbody').render()).toMatchSnapshot();
+  });
+
   describe('start weekday should be correct', () => {
     [
       { locale: zhCN, startDate: '30' },


### PR DESCRIPTION
Added `quarterCellRender` and `yearCellRender` props to `PickerPanel` to support custom cell rendering for those calendar types. `monthCellRender` already exists, so it seems like a logical extension. Updated tests to provide coverage to these props.

Implements #399 