### PR TITLE
නව භාෂාවක් එකතු කිරීම

### DIFF
--- a/src/locale/si_LK.ts
+++ b/src/locale/si_LK.ts
@@ -1,0 +1,33 @@
+import type { Locale } from '../interface';
+
+const locale: Locale = {
+  locale: 'si_LK',
+  today: 'අද',
+  now: 'දැන්',
+  backToToday: 'අදට ආපසු',
+  ok: 'හරි',
+  clear: 'හිස් කරන්න',
+  month: 'මාසය',
+  year: 'අවුරුද්ද',
+  timeSelect: 'වේලාවක් තෝරන්න',
+  dateSelect: 'දිනයක් තෝරන්න',
+  weekSelect: 'සතියක් තෝරන්න',
+  monthSelect: 'මාසයක් තෝරන්න',
+  yearSelect: 'අවුරුද්දක් තෝරන්න',
+  decadeSelect: 'දශකයක් තෝරන්න',
+  yearFormat: 'YYYY',
+  dateFormat: 'YYYY/M/D',
+  dayFormat: 'D',
+  dateTimeFormat: 'YYYY/M/D HH:mm:ss',
+  monthBeforeYear: false,
+  previousMonth: 'කලින් මාසය (පිටුව ඉහළට)',
+  nextMonth: 'ඊළඟ මාසය (පිටුව පහළට)',
+  previousYear: 'පසුගිය අවුරුද්ද (Control + වම)',
+  nextYear: 'ඊළඟ අවුරුද්ද (Control + දකුණ)',
+  previousDecade: 'පසුගිය දශකය',
+  nextDecade: 'ඊළඟ දශකය',
+  previousCentury: 'පසුගිය සියවස',
+  nextCentury: 'ඊළඟ සියවස',
+};
+
+export default locale;


### PR DESCRIPTION
භාෂාවේ නම: Sinhalese / Sinhala
දේශීය නම: සිංහල
කේතය: සිං / si

`si_LK` is unnecessary but it seems we cannot use `si`