### PR TITLE
Feature: Set start date to end date if end date is before start date close on change of end date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,8 @@ node_modules
 .cache
 assets/**/*.css
 build
-lib
-es
+# lib
+# es
 yarn.lock
 package-lock.json
 coverage/

--- a/src/generate/dateFns.ts
+++ b/src/generate/dateFns.ts
@@ -1,27 +1,28 @@
 import {
-  getDay,
-  getYear,
-  getMonth,
-  getDate,
+  addDays,
+  addMonths,
+  addYears,
   endOfMonth,
+  format as formatDate,
+  getDate,
+  getDay,
   getHours,
   getMinutes,
+  getMonth,
   getSeconds,
-  addYears,
-  addMonths,
-  addDays,
-  setYear,
-  setMonth,
+  getWeek,
+  getYear,
+  isAfter,
+  isBefore,
+  isValid,
+  parse as parseDate,
   setDate,
   setHours,
   setMinutes,
+  setMonth,
   setSeconds,
-  isAfter,
-  isValid,
-  getWeek,
+  setYear,
   startOfWeek,
-  format as formatDate,
-  parse as parseDate,
 } from 'date-fns';
 import * as Locale from 'date-fns/locale';
 import type { GenerateConfig } from '.';
@@ -42,15 +43,15 @@ const localeParse = (format: string) => {
 const generateConfig: GenerateConfig<Date> = {
   // get
   getNow: () => new Date(),
-  getFixedDate: string => new Date(string),
-  getEndDate: date => endOfMonth(date),
-  getWeekDay: date => getDay(date),
-  getYear: date => getYear(date),
-  getMonth: date => getMonth(date),
-  getDate: date => getDate(date),
-  getHour: date => getHours(date),
-  getMinute: date => getMinutes(date),
-  getSecond: date => getSeconds(date),
+  getFixedDate: (string) => new Date(string),
+  getEndDate: (date) => endOfMonth(date),
+  getWeekDay: (date) => getDay(date),
+  getYear: (date) => getYear(date),
+  getMonth: (date) => getMonth(date),
+  getDate: (date) => getDate(date),
+  getHour: (date) => getHours(date),
+  getMinute: (date) => getMinutes(date),
+  getSecond: (date) => getSeconds(date),
 
   // set
   addYear: (date, diff) => addYears(date, diff),
@@ -65,10 +66,11 @@ const generateConfig: GenerateConfig<Date> = {
 
   // Compare
   isAfter: (date1, date2) => isAfter(date1, date2),
-  isValidate: date => isValid(date),
+  isBefore: (date1, date2) => isBefore(date1, date2),
+  isValidate: (date) => isValid(date),
 
   locale: {
-    getWeekFirstDay: locale => {
+    getWeekFirstDay: (locale) => {
       const clone = Locale[dealLocal(locale)];
       return clone.options.weekStartsOn;
     },
@@ -78,11 +80,11 @@ const generateConfig: GenerateConfig<Date> = {
     getWeek: (locale, date) => {
       return getWeek(date, { locale: Locale[dealLocal(locale)] });
     },
-    getShortWeekDays: locale => {
+    getShortWeekDays: (locale) => {
       const clone = Locale[dealLocal(locale)];
       return Array.from({ length: 7 }).map((_, i) => clone.localize.day(i, { width: 'short' }));
     },
-    getShortMonths: locale => {
+    getShortMonths: (locale) => {
       const clone = Locale[dealLocal(locale)];
       return Array.from({ length: 12 }).map((_, i) =>
         clone.localize.month(i, { width: 'abbreviated' }),

--- a/src/generate/dayjs.ts
+++ b/src/generate/dayjs.ts
@@ -1,12 +1,12 @@
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
-import { noteOnce } from 'rc-util/lib/warning';
-import weekday from 'dayjs/plugin/weekday';
-import localeData from 'dayjs/plugin/localeData';
-import weekOfYear from 'dayjs/plugin/weekOfYear';
-import weekYear from 'dayjs/plugin/weekYear';
 import advancedFormat from 'dayjs/plugin/advancedFormat';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
+import localeData from 'dayjs/plugin/localeData';
+import weekday from 'dayjs/plugin/weekday';
+import weekOfYear from 'dayjs/plugin/weekOfYear';
+import weekYear from 'dayjs/plugin/weekYear';
+import { noteOnce } from 'rc-util/lib/warning';
 import type { GenerateConfig } from '.';
 
 dayjs.extend(customParseFormat);
@@ -134,6 +134,7 @@ const generateConfig: GenerateConfig<Dayjs> = {
 
   // Compare
   isAfter: (date1, date2) => date1.isAfter(date2),
+  isBefore: (date1, date2) => date1.isBefore(date2),
   isValidate: (date) => date.isValid(),
 
   locale: {

--- a/src/generate/index.ts
+++ b/src/generate/index.ts
@@ -24,6 +24,7 @@ export type GenerateConfig<DateType> = {
 
   // Compare
   isAfter: (date1: DateType, date2: DateType) => boolean;
+  isBefore: (date1: DateType, date2: DateType) => boolean;
   isValidate: (date: DateType) => boolean;
 
   locale: {

--- a/src/generate/moment.ts
+++ b/src/generate/moment.ts
@@ -6,21 +6,21 @@ import type { GenerateConfig } from '.';
 const generateConfig: GenerateConfig<Moment> = {
   // get
   getNow: () => moment(),
-  getFixedDate: string => moment(string, 'YYYY-MM-DD'),
-  getEndDate: date => {
+  getFixedDate: (string) => moment(string, 'YYYY-MM-DD'),
+  getEndDate: (date) => {
     const clone = date.clone();
     return clone.endOf('month');
   },
-  getWeekDay: date => {
+  getWeekDay: (date) => {
     const clone = date.clone().locale('en_US');
     return clone.weekday() + clone.localeData().firstDayOfWeek();
   },
-  getYear: date => date.year(),
-  getMonth: date => date.month(),
-  getDate: date => date.date(),
-  getHour: date => date.hour(),
-  getMinute: date => date.minute(),
-  getSecond: date => date.second(),
+  getYear: (date) => date.year(),
+  getMonth: (date) => date.month(),
+  getDate: (date) => date.date(),
+  getHour: (date) => date.hour(),
+  getMinute: (date) => date.minute(),
+  getSecond: (date) => date.second(),
 
   // set
   addYear: (date, diff) => {
@@ -62,10 +62,11 @@ const generateConfig: GenerateConfig<Moment> = {
 
   // Compare
   isAfter: (date1, date2) => date1.isAfter(date2),
-  isValidate: date => date.isValid(),
+  isBefore: (date1, date2) => date1.isBefore(date2),
+  isValidate: (date) => date.isValid(),
 
   locale: {
-    getWeekFirstDay: locale => {
+    getWeekFirstDay: (locale) => {
       const date = moment().locale(locale);
       return date.localeData().firstDayOfWeek();
     },
@@ -79,11 +80,11 @@ const generateConfig: GenerateConfig<Moment> = {
       const result = clone.locale(locale);
       return result.week();
     },
-    getShortWeekDays: locale => {
+    getShortWeekDays: (locale) => {
       const date = moment().locale(locale);
       return date.localeData().weekdaysMin();
     },
-    getShortMonths: locale => {
+    getShortMonths: (locale) => {
       const date = moment().locale(locale);
       return date.localeData().monthsShort();
     },


### PR DESCRIPTION
See: https://github.com/react-component/picker/issues/444

If the end date is before the start date, set the start date to that value and leave the focus in the end date.

If a user changes the end date and there is a start date and the end date is after the start date, close the picker