### PR TITLE
fix: Use the passed in default when disabled

### DIFF
--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -307,7 +307,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
 
       // Fill disabled unit
       for (let i = 0; i < 2; i += 1) {
-        if (mergedDisabled[i] && !getValue(postValues, i) && !getValue(allowEmpty, i)) {
+        if (mergedDisabled[i] && !postValues && !getValue(postValues, i) && !getValue(allowEmpty, i)) {
           postValues = updateValues(postValues, generateConfig.getNow(), i);
         }
       }

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -1776,4 +1776,10 @@ describe('Picker.Range', () => {
     // No selected cell
     expect(document.querySelector('.rc-picker-cell-selected')).toBeFalsy();
   });
+
+  it('range picker should use the passed in default when part is disabled', () => {
+    render(<MomentRangePicker defaultValue={[null, null]} disabled={[false, true]} />);
+
+    expect(document.querySelectorAll('input')[1].value).toBeFalsy();
+  });
 });


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/40906

在都被禁用的情况下会使用默认值，但是在单个被禁用的情况下由于传入空数组导致被重新赋值，因此判断如果存在传入值那么就不再进行重新赋值。