### PR TITLE
fix: add missing luxon peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   "peerDependencies": {
     "date-fns": ">= 2.x",
     "dayjs": ">= 1.x",
+    "luxon": ">= 3.x",
     "moment": ">= 2.x",
     "react": ">=16.9.0",
     "react-dom": ">=16.9.0"
@@ -88,6 +89,9 @@
       "optional": true
     },
     "dayjs": {
+      "optional": true
+    },
+    "luxon": {
       "optional": true
     },
     "moment": {


### PR DESCRIPTION
### Context

In [the PR](https://github.com/react-component/picker/pull/230) adding the luxon integration, the peer dependencies were not updated properly.

The PR was open for quite some time and the project structure evolved in the meantime, I forgot to adjust this part on the latest rebase.

### Content

Simply adding the missing dependencies.