### PR TITLE
chore: compatible with antd test

### DIFF
--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -369,7 +369,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
       disabledDate,
       generateConfig,
     },
-    firstTimeOpen,
+    !mergedOpen || firstTimeOpen,
   );
 
   // ============================= Popup =============================


### PR DESCRIPTION
In some test env. Developer hack `@rc-component/trigger` to force open for testing snapshot. Here is to ensure keep snapshot same as before.

Note: this will never reach for real world.