### PR TITLE
Add flag to always show selected/active date on open

### DIFF
--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -52,6 +52,7 @@ export type PickerSharedProps<DateType> = {
   autoFocus?: boolean;
   disabled?: boolean;
   tabIndex?: number;
+  showSelected?: boolean;
   open?: boolean;
   defaultOpen?: boolean;
   /** Make input readOnly to avoid popup keyboard in mobile */
@@ -156,6 +157,7 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
     allowClear,
     autoFocus,
     showTime,
+    showSelected,
     picker = 'date',
     format,
     use12Hours,

--- a/src/PickerPanel.tsx
+++ b/src/PickerPanel.tsx
@@ -48,6 +48,7 @@ export type PickerPanelSharedProps<DateType> = {
   /** @deprecated Will be removed in next big version. Please use `picker` instead */
   mode?: PanelMode;
   tabIndex?: number;
+  showSelected?: boolean;
 
   // Locale
   locale: Locale;
@@ -146,6 +147,7 @@ function PickerPanel<DateType>(props: PickerPanelProps<DateType>) {
     showNow,
     showTime,
     showToday,
+    showSelected,
     renderExtraFooter,
     hideHeader,
     onSelect,
@@ -189,7 +191,7 @@ function PickerPanel<DateType>(props: PickerPanelProps<DateType>) {
   // ============================ State =============================
 
   const panelContext = React.useContext(PanelContext);
-  const { operationRef, onSelect: onContextSelect, hideRanges, defaultOpenValue } = panelContext;
+  const { operationRef, onSelect: onContextSelect, hideRanges, defaultOpenValue, open } = panelContext;
 
   const { inRange, panelPosition, rangedValue, hoverRangedValue } = React.useContext(RangeContext);
   const panelRef = React.useRef<PanelRefProps>({});
@@ -401,6 +403,10 @@ function PickerPanel<DateType>(props: PickerPanelProps<DateType>) {
       setInnerViewDate(value);
     }
   }, [value]);
+
+  React.useEffect(() => {
+    if (value && showSelected) setInnerViewDate(value);
+  }, [open]);
 
   React.useEffect(() => {
     initRef.current = false;


### PR DESCRIPTION
# What does this feature do?

Adds a new prop `showSelected`. When flag is set to `true`, the active/selected date will always be set as the `viewDate` when the date range picker modal is opened.

# Why is this needed?

There are use cases where we want the the current selected date to be shown when the modal is open. This is useful when using presets, so we don't get lost where the selected dates are.

# What's next?

Expose the same flag/prop on Ant Design.