### PR TITLE
fix: add null check of arrowRef.current

### DIFF
--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -870,7 +870,8 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
     mergedActivePickerIndex &&
     startInputDivRef.current &&
     separatorRef.current &&
-    panelDivRef.current
+    panelDivRef.current &&
+    arrowRef.current
   ) {
     // Arrow offset
     arrowLeft = startInputDivRef.current.offsetWidth + separatorRef.current.offsetWidth;


### PR DESCRIPTION
When evaluating `arrowRef.current.offsetLeft`, maybe `arrowRef.current` is null. As a result it throws `undefined is not an object` error.

So I add a null check before.

@zombieJ 

close https://github.com/ant-design/ant-design/issues/42849