### PR TITLE
feat: update settime

### DIFF
--- a/src/panels/TimePanel/TimeBody.tsx
+++ b/src/panels/TimePanel/TimeBody.tsx
@@ -105,30 +105,6 @@ function TimeBody<DateType>(props: TimeBodyProps<DateType>) {
     return [disabledHours, disabledMinutes, disabledSeconds];
   }, [disabledHours, disabledMinutes, disabledSeconds, disabledTime, now]);
 
-  // Set Time
-  const setTime = (
-    isNewPM: boolean | undefined,
-    newHour: number,
-    newMinute: number,
-    newSecond: number,
-  ) => {
-    let newDate = value || generateConfig.getNow();
-
-    const mergedHour = Math.max(0, newHour);
-    const mergedMinute = Math.max(0, newMinute);
-    const mergedSecond = Math.max(0, newSecond);
-
-    newDate = utilSetTime(
-      generateConfig,
-      newDate,
-      !use12Hours || !isNewPM ? mergedHour : mergedHour + 12,
-      mergedMinute,
-      mergedSecond,
-    );
-
-    return newDate;
-  };
-
   // ========================= Unit =========================
   const rawHours = generateUnits(0, 23, hourStep, mergedDisabledHours && mergedDisabledHours());
 
@@ -184,6 +160,39 @@ function TimeBody<DateType>(props: TimeBodyProps<DateType>) {
     secondStep,
     mergedDisabledSeconds && mergedDisabledSeconds(originHour, minute),
   );
+
+  // Set Time
+  const setTime = (
+    isNewPM: boolean | undefined,
+    newHour: number,
+    newMinute: number,
+    newSecond: number,
+  ) => {
+    let newDate = value || generateConfig.getNow();
+
+    const mergedHour = Math.max(0, newHour);
+    let mergedMinute = Math.max(0, newMinute);
+    let mergedSecond = Math.max(0, newSecond);
+
+    const disabledMinutesSet = new Set(mergedDisabledMinutes?.(mergedHour));
+    if (disabledMinutesSet.has(mergedMinute)) {
+      mergedMinute = minutes.find((m) => !disabledMinutesSet.has(m.value))?.value ?? 0;
+    }
+    const disabledSecondsSet = new Set(mergedDisabledSeconds?.(mergedHour, mergedMinute));
+    if (disabledSecondsSet.has(mergedSecond)) {
+      mergedSecond = seconds.find((s) => !disabledSecondsSet.has(s.value))?.value ?? 0;
+    }
+
+    newDate = utilSetTime(
+      generateConfig,
+      newDate,
+      !use12Hours || !isNewPM ? mergedHour : mergedHour + 12,
+      mergedMinute,
+      mergedSecond,
+    );
+
+    return newDate;
+  };
 
   // ====================== Operations ======================
   operationRef.current = {

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -977,6 +977,79 @@ describe('Picker.Basic', () => {
       unmount();
     });
   });
+  
+  describe('time picker auto select correct value', () => {
+    it('correct minute', () => {
+      const { container } = render(
+        <MomentPicker
+          picker="time"
+          disabledTime={() => {
+            return {
+              disabledMinutes: (h) => {
+                if (h === 8) return new Array(20).fill(0).map((_, i) => i);
+                return [];
+              },
+            };
+          }}
+        />,
+      );
+      openPicker(container);
+      const list = document.querySelectorAll('.rc-picker-content .rc-picker-time-panel-column');
+      (list[0].querySelectorAll('.rc-picker-time-panel-cell')[8] as HTMLLIElement).click();
+      const disabledMinutes = list[1].querySelectorAll('.rc-picker-time-panel-cell-disabled');
+      expect(disabledMinutes.length).toBe(20);
+      const selectedMinute = list[1].querySelector(
+        '.rc-picker-time-panel-cell-selected .rc-picker-time-panel-cell-inner',
+      );
+      expect(selectedMinute.innerHTML).toBe(`20`);
+    });
+    it('correct second', () => {
+      const { container } = render(
+        <MomentPicker
+          picker="time"
+          disabledTime={() => {
+            return {
+              disabledMinutes: (h) => {
+                if (h === 8) return new Array(20).fill(0).map((_, i) => i);
+                return [];
+              },
+              disabledSeconds: (h, m) => {
+                if (h === 9) return new Array(20).fill(0).map((_, i) => i);
+                if (m === 30) return new Array(10).fill(0).map((_, i) => i);
+                return [];
+              },
+            };
+          }}
+        />,
+      );
+      openPicker(container);
+      const list = document.querySelectorAll('.rc-picker-content .rc-picker-time-panel-column');
+      let disabledMinutes!: NodeListOf<Element>;
+      let selectedSecond!: Element;
+
+      (list[0].querySelectorAll('.rc-picker-time-panel-cell')[9] as HTMLLIElement).click();
+      disabledMinutes = list[2].querySelectorAll('.rc-picker-time-panel-cell-disabled');
+      expect(disabledMinutes.length).toBe(20);
+
+      (list[0].querySelectorAll('.rc-picker-time-panel-cell')[0] as HTMLLIElement).click();
+      (list[1].querySelectorAll('.rc-picker-time-panel-cell')[0] as HTMLLIElement).click();
+      (list[2].querySelectorAll('.rc-picker-time-panel-cell')[1] as HTMLLIElement).click();
+      disabledMinutes = list[2].querySelectorAll('.rc-picker-time-panel-cell-disabled');
+      expect(disabledMinutes.length).toBe(0);
+      selectedSecond = list[2].querySelector(
+        '.rc-picker-time-panel-cell-selected .rc-picker-time-panel-cell-inner',
+      );
+      expect(selectedSecond.innerHTML).toBe('01');
+
+      (list[1].querySelectorAll('.rc-picker-time-panel-cell')[30] as HTMLLIElement).click();
+      disabledMinutes = list[2].querySelectorAll('.rc-picker-time-panel-cell-disabled');
+      expect(disabledMinutes.length).toBe(10);
+      selectedSecond = list[2].querySelector(
+        '.rc-picker-time-panel-cell-selected .rc-picker-time-panel-cell-inner',
+      );
+      expect(selectedSecond.innerHTML).toBe(`10`);
+    });
+  });
 
   describe('prevent default on keydown', () => {
     it('should open picker panel if no prevent default', () => {


### PR DESCRIPTION
在业务中遇到一个问题，我尝试着写了个demo，在第8小时的时候，我期望禁用前20个分钟：
<img width="789" alt="image" src="https://github.com/react-component/picker/assets/51100990/490006b0-4dc3-4ce8-a21e-6691cf8f0fbd">
但是，当我选择了第8小时的时候，他会默认的展示第0分钟：
<img width="190" alt="image" src="https://github.com/react-component/picker/assets/51100990/f8db41b7-4d92-40d1-a21e-b29cd42d30ba">
从dom结构能看到，第0分钟的class上既有disabled又有selected，这不符合预期，因为这意味着用户可以在8:00的时候点击确定：
<img width="457" alt="image" src="https://github.com/react-component/picker/assets/51100990/703c7a97-811e-4b4b-8c48-a8ca10a1fa86">
我尝试着修复了他，在setTime的时候去判断分秒是否会被禁用，如果禁用了他将切换到从上往下第一个没被禁用的时间，展示效果是当我选第8小时的时候，他会跳转到第20分钟：
<img width="184" alt="image" src="https://github.com/react-component/picker/assets/51100990/5b9f165a-1e9d-4203-a1cc-46a184e27299">

