### PR TITLE
fix: add comments and warnings for the deprecated property defaultPic…

### DIFF
--- a/src/PickerPanel.tsx
+++ b/src/PickerPanel.tsx
@@ -58,7 +58,10 @@ export type PickerPanelSharedProps<DateType> = {
   defaultValue?: DateType;
   /** [Legacy] Set default display picker view date */
   pickerValue?: DateType;
-  /** [Legacy] Set default display picker view date */
+  /**
+   * @deprecated please use `defaultValue` instead.
+   * Set default display picker view date
+   */
   defaultPickerValue?: DateType;
 
   // Date
@@ -170,6 +173,7 @@ function PickerPanel<DateType>(props: PickerPanelProps<DateType>) {
   const isMinuteStepValid = 60 % minuteStep === 0;
   const isSecondStepValid = 60 % secondStep === 0;
 
+  // ============================ Warning ============================
   if (process.env.NODE_ENV !== 'production') {
     warning(!value || generateConfig.isValidate(value), 'Invalidate date pass to `value`.');
     warning(!value || generateConfig.isValidate(value), 'Invalidate date pass to `defaultValue`.');
@@ -182,6 +186,7 @@ function PickerPanel<DateType>(props: PickerPanelProps<DateType>) {
       isSecondStepValid,
       `\`secondStep\` ${secondStep} is invalid. It should be a factor of 60.`,
     );
+    warning(!defaultPickerValue, `'defaultPickerValue' is deprecated. Please use 'defaultValue' instead.`);
     warning(!dateRender, `'dateRender' is deprecated. Please use 'cellRender' instead.`);
     warning(!monthCellRender, `'monthCellRender' is deprecated. Please use 'cellRender' instead.`);
   }

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -97,6 +97,10 @@ export type RangePickerSharedProps<DateType> = {
   id?: string;
   value?: RangeValue<DateType>;
   defaultValue?: RangeValue<DateType>;
+  /**
+   * @deprecated please use `defaultValue` instead.
+   * Set default display picker view date
+   */
   defaultPickerValue?: [DateType, DateType];
   placeholder?: [string, string];
   disabled?: boolean | [boolean, boolean];

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -73,7 +73,10 @@ export type PanelSharedProps<DateType> = {
   generateConfig: GenerateConfig<DateType>;
   value?: NullableDateType<DateType>;
   viewDate: DateType;
-  /** [Legacy] Set default display picker view date */
+  /**
+   * @deprecated please use `defaultValue` instead.
+   * Set default display picker view date
+   */
   defaultPickerValue?: DateType;
   locale: Locale;
   disabledDate?: (date: DateType) => boolean;

--- a/tests/panel.spec.tsx
+++ b/tests/panel.spec.tsx
@@ -632,6 +632,24 @@ describe('Picker.Panel', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('warning with defaultPickerValue', () => {
+      resetWarned();
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      render(
+        <MomentPickerPanel
+          picker={picker as any}
+          defaultPickerValue={getMoment('2023-07-25')}
+        />,
+      );
+
+      expect(errSpy).toHaveBeenCalledWith(
+        "Warning: 'defaultPickerValue' is deprecated. Please use 'defaultValue' instead.",
+      );
+
+      errSpy.mockRestore();
+    });
+
     it('warning with dateRender and monthCellRender', () => {
       resetWarned();
       const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
Add comments and warnings for the deprecated property defaultPickerValue

about:
[issues](https://github.com/ant-design/ant-design/issues/41974)
[ant-design-pr](https://github.com/ant-design/ant-design/pull/43781)