### PR TITLE
fix: dateTime mode switch should trigger onCalendarChange

### DIFF
--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -277,7 +277,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
 
   const formatDateValue = (values: RangeValue<DateType>, index: 0 | 1) =>
     values && values[index]
-      ? formatValue(values[index], { generateConfig, locale, format: formatList[index] })
+      ? formatValue(values[index], { generateConfig, locale, format: formatList[0] })
       : '';
 
   // Operation ref

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -257,7 +257,6 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
   } = props as MergedRangePickerProps<DateType>;
 
   const needConfirmButton: boolean = (picker === 'date' && !!showTime) || picker === 'time';
-  const needIgnoreConfirm: boolean = changeOnBlur && needConfirmButton;
 
   const containerRef = useRef<HTMLDivElement>(null);
   const panelDivRef = useRef<HTMLDivElement>(null);
@@ -567,10 +566,14 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
   }, [mergedOpen]);
 
   const onInternalBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
-    if (changeOnBlur && delayOpen) {
-      // As the date picker was manually switched, 
-      // it's necessary to trigger the onChange event of the previous date picker.
-      const needTriggerIndex = needIgnoreConfirm ? (mergedActivePickerIndex ? 0 : 1) : mergedActivePickerIndex;
+    if ((changeOnBlur || needConfirmButton) && delayOpen) {
+      // As the date picker was manually switched,
+      // it's necessary to trigger the onCalendarChange event of the previous date picker.
+      const needTriggerIndex = needConfirmButton
+        ? mergedActivePickerIndex
+          ? 0
+          : 1
+        : mergedActivePickerIndex;
       const selectedIndexValue = getValue(selectedValue, needTriggerIndex);
       if (selectedIndexValue) {
         triggerChange(selectedValue, needTriggerIndex);
@@ -588,7 +591,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
       return !elementsContains(
         [
           // Filter the ref of the currently selected input to trigger the onBlur event of another input.
-          ...(needIgnoreConfirm ? [elementsRefs[mergedActivePickerIndex]] : elementsRefs),
+          ...(needConfirmButton ? [elementsRefs[mergedActivePickerIndex]] : elementsRefs),
           panelDivRef.current,
         ],
         target as HTMLElement,
@@ -638,7 +641,6 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
     onKeyDown: (e, preventDefault) => {
       onKeyDown?.(e, preventDefault);
     },
-    changeOnBlur,
   };
 
   const [startInputProps, { focused: startFocused, typing: startTyping }] = usePickerInput({

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -568,20 +568,26 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
   }, [mergedOpen]);
 
   const onInternalBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
-    if ((changeOnBlur || needConfirmButton) && delayOpen) {
-      // As the date picker was manually switched,
-      // it's necessary to trigger the onCalendarChange event of the previous date picker.
-      const needTriggerIndex = needConfirmButton
-        ? mergedActivePickerIndex
-          ? 0
-          : 1
-        : mergedActivePickerIndex;
-      const selectedIndexValue = getValue(selectedValue, needTriggerIndex);
+    if (delayOpen) {
+      if (changeOnBlur) {
+        const selectedIndexValue = getValue(selectedValue, mergedActivePickerIndex);
 
-      if (selectedIndexValue) {
-        triggerChange(selectedValue, needTriggerIndex, needConfirmButton);
+        if (selectedIndexValue) {
+          triggerChange(selectedValue, mergedActivePickerIndex);
+        }
+      } else if (needConfirmButton) {
+        // when in dateTime mode, switching between two date input fields will trigger onCalendarChange.
+        // when onBlur is triggered, the input field has already switched, 
+        // so it's necessary to obtain the value of the previous input field here.
+        const needTriggerIndex = mergedActivePickerIndex ? 0 : 1;
+        const selectedIndexValue = getValue(selectedValue, needTriggerIndex);
+
+        if (selectedIndexValue) {
+          triggerChange(selectedValue, needTriggerIndex, true);
+        }
       }
     }
+
     return onBlur?.(e);
   };
 

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -366,8 +366,6 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
       }
     }
 
-    setSelectedValue(values);
-
     const startStr = formatDateValue(values, 0);
     const endStr = formatDateValue(values, 1);
 
@@ -462,6 +460,8 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
   function triggerChange(newValue: RangeValue<DateType>, sourceIndex: 0 | 1) {
     const { values, startValue, endValue, startStr, endStr } = convertValue(newValue, sourceIndex);
 
+    setSelectedValue(values);
+
     onInternalCalendarChange(values, startStr, endStr, sourceIndex);
 
     // >>>>> Trigger `onChange` event
@@ -486,6 +486,8 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
 
   function triggerCalendarChange(newValue: RangeValue<DateType>, sourceIndex: 0 | 1) {
     const { values, startStr, endStr } = convertValue(newValue, sourceIndex);
+
+    setSelectedValue(values);
 
     onInternalCalendarChange(values, startStr, endStr, sourceIndex);
   }

--- a/src/hooks/usePickerInput.ts
+++ b/src/hooks/usePickerInput.ts
@@ -16,7 +16,6 @@ export default function usePickerInput({
   onCancel,
   onFocus,
   onBlur,
-  changeOnBlur,
 }: {
   open: boolean;
   value: string;
@@ -29,7 +28,6 @@ export default function usePickerInput({
   onCancel: () => void;
   onFocus?: React.FocusEventHandler<HTMLInputElement>;
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
-  changeOnBlur?: boolean;
 }): [React.DOMAttributes<HTMLInputElement>, { focused: boolean; typing: boolean }] {
   const [typing, setTyping] = useState(false);
   const [focused, setFocused] = useState(false);
@@ -160,7 +158,7 @@ export default function usePickerInput({
           raf(() => {
             preventBlurRef.current = false;
           });
-        } else if (!changeOnBlur && (!focused || clickedOutside)) {
+        } else if (!blurToCancel && (!focused || clickedOutside)) {
           triggerOpen(false);
         }
       }

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 import KeyCode from 'rc-util/lib/KeyCode';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
 import { resetWarned } from 'rc-util/lib/warning';
-import React, { useState } from 'react';
+import React from 'react';
 import type { PickerMode } from '../src/interface';
 import zhCN from '../src/locale/zh_CN';
 import type { RangePickerProps } from '../src/RangePicker';
@@ -1924,24 +1924,14 @@ describe('Picker.Range', () => {
     expect(document.querySelectorAll('.rc-picker-input')[1]).toHaveClass('rc-picker-input-active');
   });
 
-  it('disabledDate should work when using both showTime and changeOnBlur', () => {
-    const Demo: React.FC = () => {
-      const [date, setDate] = useState<[Moment, Moment]>();
-
-      const disabledDate = (current: Moment) => date?.[0] && current.diff(date[0], 'days') >= 7;
-
-      return (
-        <MomentRangePicker
-          value={date}
-          disabledDate={disabledDate}
-          onChange={setDate}
-          showTime
-          changeOnBlur
-        />
-      );
-    };
-
-    const { container } = render(<Demo />);
+  it('dateTime mode switch should trigger onCalendarChange', () => {
+    const onCalendarChange = jest.fn();
+    const { container } = render(
+      <MomentRangePicker
+        showTime
+        onCalendarChange={onCalendarChange}
+      />,
+    );
 
     openPicker(container, 0);
 
@@ -1949,6 +1939,9 @@ describe('Picker.Range', () => {
 
     openPicker(container, 1);
 
-    expect(findCell(7)).toHaveClass('rc-picker-cell-disabled');
+    // onBlur is triggered when the switch is complete
+    closePicker(container, 0);
+
+    expect(onCalendarChange).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/44280

问题出现原因：
在设置了 showTime 和 changeOnBlur 后，在没有点击确认按钮时点击输入框切换选择开始或结束日期时不会触发对应的 onChange 事件，因此 disabledDate 就失效了，导致最终可以选择出不符合 disabledDate 的时间范围。

解决思路：
去触发切换前输入框的 `onCalendarChange` 事件。

ref: 
https://github.com/ant-design/ant-design/issues/24704
https://github.com/ant-design/ant-design/issues/30467
https://github.com/ant-design/ant-design/issues/31261