### PR TITLE
improvement: dateTime mode apply the current time

### DIFF
--- a/src/hooks/useTimeSelection.ts
+++ b/src/hooks/useTimeSelection.ts
@@ -25,10 +25,22 @@ export default function useTimeSelection<DateType>({
     newMinute: number,
     newSecond: number,
   ) => {
-    let newDate = value || generateConfig.getNow();
+    const now = generateConfig.getNow();
+    let newDate = value || now;
 
-    const mergedHour = Math.max(0, newHour);
-    let mergedMinute = Math.max(0, newMinute);
+    let initHour = 0;
+    let initMinute = 0;
+
+    if (!value && newHour < 0) {
+      initHour = generateConfig.getHour(now);
+
+      if (newMinute < 0) {
+        initMinute = generateConfig.getMinute(now);
+      }
+    }
+
+    const mergedHour = Math.max(initHour, newHour);
+    let mergedMinute = Math.max(initMinute, newMinute);
     let mergedSecond = Math.max(0, newSecond);
 
     const newDisabledMinutes = disabledMinutes && disabledMinutes(mergedHour);

--- a/src/hooks/useTimeSelection.ts
+++ b/src/hooks/useTimeSelection.ts
@@ -31,7 +31,7 @@ export default function useTimeSelection<DateType>({
     let initHour = 0;
     let initMinute = 0;
 
-    if (!value && newHour < 0) {
+    if (newHour < 0) {
       initHour = generateConfig.getHour(now);
 
       if (newMinute < 0) {

--- a/src/hooks/useTimeSelection.ts
+++ b/src/hooks/useTimeSelection.ts
@@ -28,20 +28,9 @@ export default function useTimeSelection<DateType>({
     const now = generateConfig.getNow();
     let newDate = value || now;
 
-    let initHour = 0;
-    let initMinute = 0;
-
-    if (newHour < 0) {
-      initHour = generateConfig.getHour(now);
-
-      if (newMinute < 0) {
-        initMinute = generateConfig.getMinute(now);
-      }
-    }
-
-    const mergedHour = Math.max(initHour, newHour);
-    let mergedMinute = Math.max(initMinute, newMinute);
-    let mergedSecond = Math.max(0, newSecond);
+    const mergedHour = newHour < 0 ? generateConfig.getHour(now) : newHour;
+    let mergedMinute = newMinute < 0 ? generateConfig.getMinute(now) : newMinute;
+    let mergedSecond = newSecond < 0 ? generateConfig.getSecond(now) : newSecond;
 
     const newDisabledMinutes = disabledMinutes && disabledMinutes(mergedHour);
     if (newDisabledMinutes?.includes(mergedMinute)) {

--- a/tests/disabledTime.spec.tsx
+++ b/tests/disabledTime.spec.tsx
@@ -92,6 +92,7 @@ describe('Picker.DisabledTime', () => {
   });
 
   it('dynamic disabledTime should be correct', () => {
+    jest.useFakeTimers().setSystemTime(getMoment('2023-09-05 22:02:00').valueOf());
     render(
       <MomentPicker
         open
@@ -106,6 +107,7 @@ describe('Picker.DisabledTime', () => {
             }
           },
           disabledSeconds: (_, selectMinute) => {
+            console.log(selectMinute)
             if (selectMinute === 2) {
               return [0, 1];
             } else {
@@ -134,6 +136,7 @@ describe('Picker.DisabledTime', () => {
     expect(document.querySelector('.rc-picker-input input').getAttribute('value')).toEqual(
       '02:02:02',
     );
+    jest.useRealTimers();
   });
 
   describe('warning for legacy props', () => {

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -1111,23 +1111,12 @@ describe('Picker.Basic', () => {
   it('select minutes and seconds directly in dateTime mode will apply the current time', () => {
     jest.setSystemTime(getMoment('2023-09-04 21:49:10').valueOf());
     const ui = <MomentPicker showTime />;
-    const { container, unmount, rerender } = render(ui);
+    const { container } = render(ui);
 
     openPicker(container);
     // Select minute
     selectColumn(1, 5);
 
-    expect(container.querySelector('input')).toHaveValue('2023-09-04 21:05:00');
-    
-    // reset
-    unmount();
-
-    rerender(ui);
-
-    openPicker(container);
-    // Select second
-    selectColumn(2, 7);
-
-    expect(container.querySelector('input')).toHaveValue('2023-09-04 21:49:07');
+    expect(container.querySelector('input')).toHaveValue('2023-09-04 21:05:10');
   });
 });

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -52,6 +52,10 @@ describe('Picker.Basic', () => {
     });
   }
 
+  function selectColumn(colIndex: number, rowIndex: number) {
+    fireEvent.click(document.querySelectorAll('ul')[colIndex].querySelectorAll('li')[rowIndex]);
+  }
+
   describe('mode', () => {
     const modeList: { mode: PanelMode; className: string }[] = [
       {
@@ -473,10 +477,6 @@ describe('Picker.Basic', () => {
       const onOk = jest.fn();
       const { container } = render(<MomentPicker picker="time" onChange={onChange} onOk={onOk} />);
       openPicker(container);
-
-      function selectColumn(colIndex: number, rowIndex: number) {
-        fireEvent.click(document.querySelectorAll('ul')[colIndex].querySelectorAll('li')[rowIndex]);
-      }
 
       selectColumn(0, 13);
       selectColumn(1, 22);
@@ -1106,5 +1106,28 @@ describe('Picker.Basic', () => {
 
     // Reset locale
     moment.locale('en');
+  });
+
+  it('select minutes and seconds directly in dateTime mode will apply the current time', () => {
+    jest.setSystemTime(getMoment('2023-09-04 21:49:10').valueOf());
+    const ui = <MomentPicker showTime />;
+    const { container, unmount, rerender } = render(ui);
+
+    openPicker(container);
+    // Select minute
+    selectColumn(1, 5);
+
+    expect(container.querySelector('input')).toHaveValue('2023-09-04 21:05:00');
+    
+    // reset
+    unmount();
+
+    rerender(ui);
+
+    openPicker(container);
+    // Select second
+    selectColumn(2, 7);
+
+    expect(container.querySelector('input')).toHaveValue('2023-09-04 21:49:07');
   });
 });


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/44524

使 datetime 模式在不选择日期，直接选择分、秒的情况下自动应用当前时间的时、分。