### PR TITLE
fix: resolves an issue that occurs when showTime and changeOnBlur exist at the same time

### DIFF
--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -325,6 +325,7 @@ function InnerPicker<DateType>(props: PickerProps<DateType>) {
 
   const [inputProps, { focused, typing }] = usePickerInput({
     blurToCancel: needConfirmButton,
+    changeOnBlur,
     open: mergedOpen,
     value: text,
     triggerOpen,

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -573,13 +573,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
 
   const onInternalBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
     if (delayOpen) {
-      if (changeOnBlur) {
-        const selectedIndexValue = getValue(selectedValue, mergedActivePickerIndex);
-
-        if (selectedIndexValue) {
-          triggerChange(selectedValue, mergedActivePickerIndex);
-        }
-      } else if (needConfirmButton) {
+      if (needConfirmButton) {
         // when in dateTime mode, switching between two date input fields will trigger onCalendarChange.
         // when onBlur is triggered, the input field has already switched, 
         // so it's necessary to obtain the value of the previous input field here.
@@ -589,6 +583,12 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
         if (selectedIndexValue) {
           triggerChange(selectedValue, needTriggerIndex, true);
         }
+      } else if (changeOnBlur) {
+        const selectedIndexValue = getValue(selectedValue, mergedActivePickerIndex);
+
+        if (selectedIndexValue) {
+          triggerChange(selectedValue, mergedActivePickerIndex);
+        }
       }
     }
 
@@ -597,6 +597,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
 
   const getSharedInputHookProps = (index: 0 | 1, resetText: () => void) => ({
     blurToCancel: !changeOnBlur && needConfirmButton,
+    changeOnBlur,
     forwardKeyDown,
     onBlur: onInternalBlur,
     isClickOutside: (target: EventTarget | null) => {

--- a/src/hooks/usePickerInput.ts
+++ b/src/hooks/usePickerInput.ts
@@ -12,6 +12,7 @@ export default function usePickerInput({
   forwardKeyDown,
   onKeyDown,
   blurToCancel,
+  changeOnBlur,
   onSubmit,
   onCancel,
   onFocus,
@@ -24,6 +25,7 @@ export default function usePickerInput({
   forwardKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => boolean;
   onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>, preventDefault: () => void) => void;
   blurToCancel?: boolean;
+  changeOnBlur?: boolean
   onSubmit: () => void | boolean;
   onCancel: () => void;
   onFocus?: React.FocusEventHandler<HTMLInputElement>;
@@ -158,7 +160,7 @@ export default function usePickerInput({
           raf(() => {
             preventBlurRef.current = false;
           });
-        } else if (!blurToCancel && (!focused || clickedOutside)) {
+        } else if (!changeOnBlur && !blurToCancel && (!focused || clickedOutside)) {
           triggerOpen(false);
         }
       }

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -1924,24 +1924,48 @@ describe('Picker.Range', () => {
     expect(document.querySelectorAll('.rc-picker-input')[1]).toHaveClass('rc-picker-input-active');
   });
 
-  it('dateTime mode switch should trigger onCalendarChange', () => {
-    const onCalendarChange = jest.fn();
-    const { container } = render(
-      <MomentRangePicker
-        showTime
-        onCalendarChange={onCalendarChange}
-      />,
-    );
+  describe('trigger onCalendarChange', () => {
+    const switchInput = (container: HTMLElement) => {
+      openPicker(container, 0);
 
-    openPicker(container, 0);
+      selectCell(8, 0);
 
-    selectCell(8, 0);
+      openPicker(container, 1);
 
-    openPicker(container, 1);
+      // onBlur is triggered when the switch is complete
+      closePicker(container, 0);
+    };
 
-    // onBlur is triggered when the switch is complete
-    closePicker(container, 0);
+    it('dateTime mode switch should trigger onCalendarChange', () => {
+      const onCalendarChange = jest.fn();
+      const { container } = render(
+        <MomentRangePicker showTime onCalendarChange={onCalendarChange} />,
+      );
 
-    expect(onCalendarChange).toHaveBeenCalled();
+      switchInput(container);
+
+      expect(onCalendarChange).toHaveBeenCalled();
+    });
+
+    it('should only trigger onCalendarChange when showTime and changeOnBlur exist', () => {
+      const onCalendarChange = jest.fn();
+      const onChange = jest.fn();
+      const { container, baseElement } = render(
+        <MomentRangePicker
+          showTime
+          changeOnBlur
+          onChange={onChange}
+          onCalendarChange={onCalendarChange}
+        />,
+      );
+
+      switchInput(container);
+
+      // one of the panel should be open
+      expect(baseElement.querySelector('.rc-picker-dropdown')).toBeTruthy();
+
+      expect(onCalendarChange).toHaveBeenCalled();
+      expect(onChange).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
发现两个问题：
1、之前当 showTime 和 changeOnBlur 同时存在时，会先执行 changeOnBlur 对应的事件，但是因为取值逻辑的关系无法获取到正确的 value，导致不会触发后续的 onCalendarChange；
2、showTime 和 changeOnBlur 同时存在时，当切换输入框就会关闭时间选择面板。

ref: https://github.com/ant-design/ant-design/issues/44280