### PR TITLE
fix type error on picker prop

### DIFF
--- a/src/PickerPanel.tsx
+++ b/src/PickerPanel.tsx
@@ -99,7 +99,7 @@ export type PickerPanelBaseProps<DateType> = {
 } & PickerPanelSharedProps<DateType>;
 
 export type PickerPanelDateProps<DateType> = {
-  picker?: 'date';
+  picker?: 'time' | 'date' | 'week' | 'month' | 'year';
   showToday?: boolean;
   showNow?: boolean;
 


### PR DESCRIPTION
When passing picker prop that is not ``` ' date'  | undefined ``` It throws a TS error even though other props are accepted by the component such as "month" or "year".