### PR TITLE
fix: check on wrong value in `RangePicker` `onSubmit`

### DIFF
--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -632,7 +632,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
     onSubmit: () => {
       if (
         // When user typing disabledDate with keyboard and enter, this value will be empty
-        !selectedValue ||
+        !selectedValue[index] ||
         // Normal disabled check
         (disabledDate && disabledDate(selectedValue[index]))
       ) {


### PR DESCRIPTION
In `RangePicker` `selectedValue` will be an array.
So this `!selectedValue` equals to `![]` will always be false then pass `undefined` to disabledDate.