### PR TITLE
fix: fix 12 hours format incorrect hour pass

### DIFF
--- a/src/hooks/useTimeSelection.ts
+++ b/src/hooks/useTimeSelection.ts
@@ -28,7 +28,8 @@ export default function useTimeSelection<DateType>({
     const now = generateConfig.getNow();
     let newDate = value || now;
 
-    const mergedHour = newHour < 0 ? generateConfig.getHour(now) : newHour;
+    const newFormattedHour = !use12Hours || !isNewPM ? newHour : newHour + 12;
+    const mergedHour = newHour < 0 ? generateConfig.getHour(now) : newFormattedHour;
     let mergedMinute = newMinute < 0 ? generateConfig.getMinute(now) : newMinute;
     let mergedSecond = newSecond < 0 ? generateConfig.getSecond(now) : newSecond;
 
@@ -53,13 +54,7 @@ export default function useTimeSelection<DateType>({
       }
     }
 
-    newDate = utilSetTime(
-      generateConfig,
-      newDate,
-      !use12Hours || !isNewPM ? mergedHour : mergedHour + 12,
-      mergedMinute,
-      mergedSecond,
-    );
+    newDate = utilSetTime(generateConfig, newDate, mergedHour, mergedMinute, mergedSecond);
 
     return newDate;
   };

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -634,6 +634,32 @@ describe('Picker.Basic', () => {
       );
     });
 
+    it('should change 12 hours format correctly', () => {
+      const onTimeChange = jest.fn();
+      const { getByText } = render(
+        <MomentPicker
+          disabledTime={() => ({
+            disabledHours: () => [0],
+            disabledMinutes: (hour) => {
+              onTimeChange(hour);
+              return [0];
+            },
+            disabledSeconds: () => [0],
+          })}
+          value={getMoment('2000-01-01 21:40:40')}
+          format="YYYY-MM-DD hh:mm:ss A"
+          use12Hours
+          showTime
+          open
+        />,
+      );
+
+      fireEvent.click(getByText('PM'));
+
+      expect(onTimeChange).not.toBeCalledWith(9);
+      expect(onTimeChange).toBeCalledWith(21);
+    });
+
     it('should show warning when minute step is invalid', () => {
       expect(errorSpy).not.toBeCalled();
       const { container } = render(<MomentPicker picker="time" minuteStep={9} />);


### PR DESCRIPTION
Fix `disabledTime.disabledMinutes`, `disabledTime.disabledSeconds` hour argument for 12 hours picker format

Before: 

https://github.com/react-component/picker/assets/70964765/2001c123-90a2-41dc-a10f-57ddb4f4db83

After:

https://github.com/react-component/picker/assets/70964765/bcd1ce7e-e1a1-4604-bb25-baa122d428ea

