### PR TITLE
fix: inputRender for rangePicker usage

### DIFF
--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -257,6 +257,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
     direction,
     activePickerIndex,
     autoComplete = 'off',
+    inputRender,
     changeOnBlur,
   } = props as MergedRangePickerProps<DateType>;
 
@@ -1108,6 +1109,49 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
     size: getInputSize(picker, formatList[0], generateConfig),
   };
 
+  const mergedStartInputProps = {
+    id: id,
+    disabled: mergedDisabled[0],
+    readOnly: inputReadOnly || typeof formatList[0] === 'function' || !startTyping,
+    value: startHoverValue || startText,
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+      triggerStartTextChange(e.target.value);
+    },
+    autoFocus: autoFocus,
+    placeholder: getValue(placeholder, 0) || '',
+    ref: startInputRef,
+    ...startInputProps,
+    ...inputSharedProps,
+    autoComplete: autoComplete,
+  }
+
+  const startInputNode = inputRender ? (
+    inputRender(mergedStartInputProps)
+  ) : (
+    <input {...mergedStartInputProps} />
+  )
+
+  const mergedEndInputProps = {
+    disabled: mergedDisabled[1],
+    readOnly: inputReadOnly || typeof formatList[0] === 'function' || !endTyping,
+    value: endHoverValue || endText,
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+      triggerEndTextChange(e.target.value);
+    },
+    autoFocus: autoFocus,
+    placeholder: getValue(placeholder, 1) || '',
+    ref: endInputRef,
+    ...endInputProps,
+    ...inputSharedProps,
+    autoComplete: autoComplete,
+  }
+
+  const endInputNode = inputRender ? (
+    inputRender(mergedEndInputProps)
+  ) : (
+    <input {...mergedEndInputProps} />
+  )
+
   let activeBarLeft: number = 0;
   let activeBarWidth: number = 0;
   if (startInputDivRef.current && endInputDivRef.current && separatorRef.current) {
@@ -1192,21 +1236,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
             })}
             ref={startInputDivRef}
           >
-            <input
-              id={id}
-              disabled={mergedDisabled[0]}
-              readOnly={inputReadOnly || typeof formatList[0] === 'function' || !startTyping}
-              value={startHoverValue || startText}
-              onChange={(e) => {
-                triggerStartTextChange(e.target.value);
-              }}
-              autoFocus={autoFocus}
-              placeholder={getValue(placeholder, 0) || ''}
-              ref={startInputRef}
-              {...startInputProps}
-              {...inputSharedProps}
-              autoComplete={autoComplete}
-            />
+            {startInputNode}
           </div>
           <div className={`${prefixCls}-range-separator`} ref={separatorRef}>
             {separator}
@@ -1218,19 +1248,7 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
             })}
             ref={endInputDivRef}
           >
-            <input
-              disabled={mergedDisabled[1]}
-              readOnly={inputReadOnly || typeof formatList[0] === 'function' || !endTyping}
-              value={endHoverValue || endText}
-              onChange={(e) => {
-                triggerEndTextChange(e.target.value);
-              }}
-              placeholder={getValue(placeholder, 1) || ''}
-              ref={endInputRef}
-              {...endInputProps}
-              {...inputSharedProps}
-              autoComplete={autoComplete}
-            />
+            {endInputNode}
           </div>
           <div
             className={`${prefixCls}-active-bar`}

--- a/src/RangePicker.tsx
+++ b/src/RangePicker.tsx
@@ -1123,13 +1123,13 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
     ...startInputProps,
     ...inputSharedProps,
     autoComplete: autoComplete,
-  }
+  };
 
   const startInputNode = inputRender ? (
     inputRender(mergedStartInputProps)
   ) : (
     <input {...mergedStartInputProps} />
-  )
+  );
 
   const mergedEndInputProps = {
     disabled: mergedDisabled[1],
@@ -1144,13 +1144,13 @@ function InnerRangePicker<DateType>(props: RangePickerProps<DateType>) {
     ...endInputProps,
     ...inputSharedProps,
     autoComplete: autoComplete,
-  }
+  };
 
   const endInputNode = inputRender ? (
     inputRender(mergedEndInputProps)
   ) : (
     <input {...mergedEndInputProps} />
-  )
+  );
 
   let activeBarLeft: number = 0;
   let activeBarWidth: number = 0;

--- a/tests/__snapshots__/range.spec.tsx.snap
+++ b/tests/__snapshots__/range.spec.tsx.snap
@@ -55,6 +55,20 @@ exports[`Picker.Range icon 1`] = `
 </div>
 `;
 
+exports[`Picker.Range inputRender 1`] = `
+<div
+  class="rc-picker-input rc-picker-input-active"
+>
+  <input
+    autocomplete="off"
+    placeholder=""
+    readonly=""
+    size="12"
+    value=""
+  />
+</div>
+`;
+
 exports[`Picker.Range onPanelChange is array args should render correctly in rtl 1`] = `
 <div>
   <div

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -755,6 +755,12 @@ describe('Picker.Range', () => {
     );
   });
 
+  it('inputRender', () => {
+    render(<MomentRangePicker inputRender={(props) => <input {...props} />} />);
+
+    expect(document.querySelector('.rc-picker-input')).toMatchSnapshot();
+  });
+
   it('block native mouseDown in panel to prevent focus changed', () => {
     const { container } = render(<MomentRangePicker />);
     openPicker(container);


### PR DESCRIPTION
When we pass inputRender to range picker its not been used. See: https://github.com/react-component/picker/issues/684