### PR TITLE
fix(WeekPicker):cross year select not selected at panel

### DIFF
--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -123,9 +123,10 @@ export function isSameWeek<DateType>(
   if (typeof equal === 'boolean') {
     return equal;
   }
-
+  const weekStartDate1 = generateConfig.locale.getWeekFirstDate(locale, date1!);
+  const weekStartDate2 = generateConfig.locale.getWeekFirstDate(locale, date2!);
   return (
-    isSameYear(generateConfig, date1!, date2!) &&
+    isSameYear(generateConfig, weekStartDate1, weekStartDate2) &&
     generateConfig.locale.getWeek(locale, date1!) === generateConfig.locale.getWeek(locale, date2!)
   );
 }

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -1,7 +1,7 @@
 import momentGenerateConfig from '../src/generate/moment';
 import { getLowerBoundTime, setTime, getLastDay } from '../src/utils/timeUtil';
 import { toArray } from '../src/utils/miscUtil';
-import { isSameTime, isSameDecade } from '../src/utils/dateUtil';
+import { isSameTime, isSameDecade, isSameWeek } from '../src/utils/dateUtil';
 import { getMoment } from './util/commonUtil';
 
 describe('Picker.Util', () => {
@@ -66,11 +66,35 @@ describe('Picker.Util', () => {
   });
 
   describe('getLastDay', () => {
+    expect(getLastDay(momentGenerateConfig, getMoment('2020-10-01'))).toEqual('2020-10-31');
+  });
+
+  it('isSameWeek', () => {
+    // 2024 CN first date === 2024-01-01 monday
     expect(
-      getLastDay(
-        momentGenerateConfig,
-        getMoment('2020-10-01'),
-      ),
-    ).toEqual('2020-10-31');
+      isSameWeek(momentGenerateConfig, 'zh_CN', getMoment('2023-12-31'), getMoment('2024-01-01')),
+    ).toBeFalsy();
+    expect(
+      isSameWeek(momentGenerateConfig, 'zh_CN', getMoment('2023-12-31'), getMoment('2024-12-31')),
+    ).toBeFalsy();
+    expect(
+      isSameWeek(momentGenerateConfig, 'zh_CN', getMoment('2024-01-02'), getMoment('2024-01-01')),
+    ).toBeTruthy();
+    expect(
+      isSameWeek(momentGenerateConfig, 'zh_CN', getMoment('2024-01-02'), getMoment('2024-03-01')),
+    ).toBeFalsy();
+    // 2024 US first date === 2023-12-31 sunday
+    expect(
+      isSameWeek(momentGenerateConfig, 'en_US', getMoment('2023-12-31'), getMoment('2024-01-01')),
+    ).toBeTruthy();
+    expect(
+      isSameWeek(momentGenerateConfig, 'en_US', getMoment('2023-12-31'), getMoment('2024-12-31')),
+    ).toBeFalsy();
+    expect(
+      isSameWeek(momentGenerateConfig, 'en_US', getMoment('2024-01-02'), getMoment('2024-01-01')),
+    ).toBeTruthy();
+    expect(
+      isSameWeek(momentGenerateConfig, 'en_US', getMoment('2024-01-02'), getMoment('2024-03-01')),
+    ).toBeFalsy();
   });
 });


### PR DESCRIPTION
fix antd@4.x bug  [周选择时间控件选中跨年周时无高亮问题](https://github.com/ant-design/ant-design/issues/47229)
It's cause `isSameWeek` function. for example: use 2024 first week, first date is `2023-12-31` (sunday) when local is US.
so when I click `2024-01-01`, it's will be run the following code. 
`isSameWeek` receive `generateConfig`, `US`, `2024-01-01` and `2023-12-31`, following logic, it's will be return false, because the two date is not same year. we need to use ` generateConfig.locale.getWeekFirstDate` function to calc date then judge is same year.
```ts
  const rowClassName = (date: DateType) =>
    classNames(rowPrefixCls, {
      [`${rowPrefixCls}-selected`]: isSameWeek(
        generateConfig,
        locale.locale,
        value,
        date,
      ),
    });
```
```ts
export function isSameWeek<DateType>(
  generateConfig: GenerateConfig<DateType>,
  locale: string,
  date1: NullableDateType<DateType>,
  date2: NullableDateType<DateType>,
) {
  const equal = isNullEqual(date1, date2);
  if (typeof equal === 'boolean') {
    return equal;
  }
  // const weekStartDate1 = generateConfig.locale.getWeekFirstDate(locale, date1!);
  // const weekStartDate2 = generateConfig.locale.getWeekFirstDate(locale, date2!);
  return (
    isSameYear(generateConfig, date1, date2) &&
    generateConfig.locale.getWeek(locale, date1!) === generateConfig.locale.getWeek(locale, date2!)
  );
}

```
