### PR TITLE
Fix the first argument of the `onChange` of the `RangePicker` when values are cleared

### DIFF
--- a/src/PickerInput/hooks/useRangeValue.ts
+++ b/src/PickerInput/hooks/useRangeValue.ts
@@ -289,11 +289,7 @@ export default function useRangeValue<ValueType extends DateType[], DateType ext
 
       // Trigger `onChange` if needed
       if (onChange && !isSameMergedDates) {
-        onChange(
-          // Return null directly if all date are empty
-          isNullValue && clone.every((val) => !val) ? null : clone,
-          getDateTexts(clone),
-        );
+        onChange(clone, getDateTexts(clone));
       }
     }
 

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -192,7 +192,7 @@ describe('Picker.Range', () => {
     expect(onChange).toHaveBeenCalledWith([expect.anything(), null], ['1990-09-11', '']);
 
     clearValue();
-    expect(onChange).toHaveBeenCalledWith(null, ['', '']);
+    expect(onChange).toHaveBeenCalledWith([null, null], ['', '']);
     onChange.mockReset();
 
     // Not allow empty with startDate


### PR DESCRIPTION
close #757

I fix the first argument of the `onChange` of the `RangePicker` when values are cleared.
Currently, when I clear the values of the `RangePicker`, the first argument of the `onChange` is `null`.
The type of the `onChange` is `((dates: NoUndefinedRangeValueType<Date>, dateStrings: [string, string]) => void) | undefined`, so the first argument can't be `null`.

On the other hand, that of the `onCalendarChange` function is `[null, null]` and it makes sence if the `onChange` is so.
