### PR TITLE
feat: Add luxon configuration with locale weeks set to `true`

### DIFF
--- a/src/generate/luxon.ts
+++ b/src/generate/luxon.ts
@@ -54,7 +54,7 @@ const normalizeFormat = (format: string): string =>
  */
 const normalizeLocale = (locale: string): string => locale.replace(/_/g, '-');
 
-const generateConfig: GenerateConfig<DateTime> = {
+const getGenerateConfig = (useLocaleWeeks?: boolean): GenerateConfig<DateTime> => ({
   // get
   getNow: () => DateTime.local(),
   getFixedDate: (string) => DateTime.fromFormat(string, 'yyyy-MM-dd'),
@@ -85,9 +85,11 @@ const generateConfig: GenerateConfig<DateTime> = {
   isValidate: (date) => date.isValid,
 
   locale: {
-    getWeekFirstDate: (locale, date) => date.setLocale(normalizeLocale(locale)).startOf('week'),
+    getWeekFirstDate: (locale, date) =>
+      date.setLocale(normalizeLocale(locale)).startOf('week', { useLocaleWeeks }),
     getWeekFirstDay: (locale) =>
-      DateTime.local().setLocale(normalizeLocale(locale)).startOf('week').weekday,
+      DateTime.local().setLocale(normalizeLocale(locale)).startOf('week', { useLocaleWeeks })
+        .weekday,
     getWeek: (locale, date) => date.setLocale(normalizeLocale(locale)).weekNumber,
     getShortWeekDays: (locale) => {
       const weekdays = Info.weekdays(weekDayFormatMap[locale] || 'short', {
@@ -126,6 +128,8 @@ const generateConfig: GenerateConfig<DateTime> = {
       return null;
     },
   },
-};
+});
 
+const generateConfig = getGenerateConfig();
+export const generateConfigWithLocale = getGenerateConfig(true);
 export default generateConfig;


### PR DESCRIPTION
Add configuration option for luxon with `useLocaleWeeks` for better flexebility.
The new configuration is exported seperetly in order to make an additional option and not cause breaking changes.