### PR TITLE
Fix TypeScript error in SinglePickerPanelProps interface

### DIFF
--- a/src/PickerPanel/index.tsx
+++ b/src/PickerPanel/index.tsx
@@ -118,8 +118,7 @@ export interface BasePickerPanelProps<DateType extends object = any>
   hideHeader?: boolean;
 }
 
-export interface SinglePickerPanelProps<DateType extends object = any>
-  extends BasePickerPanelProps<DateType> {
+export type SinglePickerPanelProps<DateType extends object = any> = BasePickerPanelProps<DateType> & {
   multiple?: false;
 
   defaultValue?: DateType | null;


### PR DESCRIPTION
**Description:**

This pull request addresses the TypeScript error reported in issue #764.

**Changes Made:**

- Modified the SinglePickerPanelProps interface to resolve the TypeScript error.
- Replaced the interface extension with a type intersection, ensuring compatibility with the BasePickerPanelProps interface.

**Details:**

The TypeScript error occurred due to an incorrect extension of the SinglePickerPanelProps interface, specifically relating to the defaultValue property. 

To resolve this issue, the interface extension was replaced with a type intersection, aligning the SinglePickerPanelProps interface with the expected types in the BasePickerPanelProps interface. 

**Additional Notes:**
Tested locally to ensure that the build process completes successfully without encountering TypeScript errors.