### PR TITLE
feat: add placeholder option for multiple picker

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -109,7 +109,9 @@
       border: none;
       outline: none;
       cursor: pointer;
-      transition: background 0.3s, border 0.3s;
+      transition:
+        background 0.3s,
+        border 0.3s;
 
       &:hover {
         background: fade(blue, 30%);
@@ -561,5 +563,9 @@
   &-multiple-input {
     width: 10px;
     opacity: 0.1;
+  }
+  // ==============  placeholder ===============
+  &-selection-placeholder {
+    color: @input-placeholder-color;
   }
 }

--- a/docs/examples/multiple.tsx
+++ b/docs/examples/multiple.tsx
@@ -28,7 +28,13 @@ export default () => {
 
   return (
     <div>
-      <SinglePicker {...sharedLocale} multiple ref={singleRef} onOpenChange={console.error} />
+      <SinglePicker
+        {...sharedLocale}
+        multiple
+        placeholder="sssss"
+        ref={singleRef}
+        onOpenChange={console.error}
+      />
       <SinglePicker {...sharedLocale} multiple ref={singleRef} needConfirm />
     </div>
   );

--- a/src/PickerInput/Selector/SingleSelector/MultipleDates.tsx
+++ b/src/PickerInput/Selector/SingleSelector/MultipleDates.tsx
@@ -11,12 +11,22 @@ export interface MultipleDatesProps<DateType extends object = any>
   removeIcon?: React.ReactNode;
   formatDate: (date: DateType) => string;
   disabled?: boolean;
+  placeholder?: string;
 }
 
 export default function MultipleDates<DateType extends object = any>(
   props: MultipleDatesProps<DateType>,
 ) {
-  const { prefixCls, value, onRemove, removeIcon = '×', formatDate, disabled, maxTagCount } = props;
+  const {
+    prefixCls,
+    value,
+    onRemove,
+    removeIcon = '×',
+    formatDate,
+    disabled,
+    maxTagCount,
+    placeholder,
+  } = props;
 
   const selectorCls = `${prefixCls}-selector`;
   const selectionCls = `${prefixCls}-selection`;
@@ -76,6 +86,7 @@ export default function MultipleDates<DateType extends object = any>(
         itemKey={(date) => formatDate(date)}
         maxCount={maxTagCount}
       />
+      {!value.length && <span className={`${selectionCls}-placeholder`}>{placeholder}</span>}
     </div>
   );
 }

--- a/src/PickerInput/Selector/SingleSelector/index.tsx
+++ b/src/PickerInput/Selector/SingleSelector/index.tsx
@@ -170,6 +170,7 @@ function SingleSelector<DateType extends object = any>(
         maxTagCount={maxTagCount}
         disabled={disabled}
         removeIcon={removeIcon}
+        placeholder={placeholder}
       />
       <input
         className={`${prefixCls}-multiple-input`}


### PR DESCRIPTION
Related to https://github.com/ant-design/ant-design/issues/47665. I add `placeholder` support for multiple `date-picker`, just like the `rc-select` component.