### PR TITLE
fix the first argument type of `onChange` of the `RangePicker`.

### DIFF
--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -64,7 +64,10 @@ export interface BaseRangePickerProps<DateType extends object>
   // Value
   value?: RangeValueType<DateType> | null;
   defaultValue?: RangeValueType<DateType>;
-  onChange?: (dates: NoUndefinedRangeValueType<DateType>, dateStrings: [string, string]) => void;
+  onChange?: (
+    dates: NoUndefinedRangeValueType<DateType> | null,
+    dateStrings: [string, string],
+  ) => void;
   onCalendarChange?: (
     dates: NoUndefinedRangeValueType<DateType>,
     dateStrings: [string, string],


### PR DESCRIPTION
related to https://github.com/react-component/picker/pull/758

In that PR, I tried to update the behavior when users clear values on `RangePicker` because the value is not fit to its type.
It is actually by design. ([see](https://github.com/react-component/picker/pull/758#issuecomment-1965676604))

However, the problem I mentioned in https://github.com/react-component/picker/issues/757 is not fixed yet.
In this PR, I update the type to solve it.