### PR TITLE
fix: ref execute the onBlur method

### DIFF
--- a/src/PickerInput/Selector/RangeSelector.tsx
+++ b/src/PickerInput/Selector/RangeSelector.tsx
@@ -146,9 +146,10 @@ function RangeSelector<DateType extends object = any>(
         getInput(options ?? 0)?.focus();
       }
     },
-    blur: () => {
+    blur: (event) => {
       getInput(0)?.blur();
       getInput(1)?.blur();
+      onBlur?.(event);
     },
   }));
 

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -440,8 +440,9 @@ export interface PickerRef {
 }
 
 // rangePicker
-export interface RangePickerRef extends Omit<PickerRef, 'focus'> {
+export interface RangePickerRef extends Omit<PickerRef, 'focus' | 'blur'> {
   focus: (index?: number | (FocusOptions & { index?: number })) => void;
+  blur: (event: React.FocusEvent<HTMLInputElement>) => void
 }
 
 // ======================== Selector ========================

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -442,7 +442,7 @@ export interface PickerRef {
 // rangePicker
 export interface RangePickerRef extends Omit<PickerRef, 'focus' | 'blur'> {
   focus: (index?: number | (FocusOptions & { index?: number })) => void;
-  blur: (event: React.FocusEvent<HTMLInputElement>) => void
+  blur: (event?: React.FocusEvent<HTMLInputElement>) => void
 }
 
 // ======================== Selector ========================


### PR DESCRIPTION
在开发过程中我希望通过ref上的blur方法使rangePicker关闭,发现并没有作用,阅读源码发现是onBlur方法没有调用导致的