### PR TITLE
fix: Picker shouldn't autoselect values on picking dates in different picker panel mode that the original picker mode

### DIFF
--- a/src/PickerInput/SinglePicker.tsx
+++ b/src/PickerInput/SinglePicker.tsx
@@ -444,7 +444,9 @@ function Picker<DateType extends object = any>(
     const nextValues = multiple ? toggleDates(getCalendarValue(), date) : [date];
 
     // Only trigger calendar event but not update internal `calendarValue` state
-    triggerCalendarChange(nextValues);
+    if(internalPicker === internalMode) {
+      triggerCalendarChange(nextValues);
+    }
 
     // >>> Trigger next active if !needConfirm
     // Fully logic check `useRangeValue` hook

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -478,6 +478,20 @@ describe('Picker.Basic', () => {
       expect(document.querySelector('.rc-picker-date-panel')).toBeTruthy();
     });
 
+    it('date -> year -> month -> date: Selecting date when panel is different than the picker typ shouldn\'t auto-select dates: date -> year -> month -> date', () => {
+      const { container } = render(<DayPicker />);
+      openPicker(container);
+      fireEvent.click(document.querySelector('.rc-picker-year-btn'));
+      
+      expect(document.querySelector('input').value).toEqual('');
+      selectCell(1990);
+      expect(document.querySelector('input').value).toEqual('');
+      selectCell('Jan');
+      expect(document.querySelector('input').value).toEqual('');
+      selectCell(3);
+      expect(document.querySelector('input').value).toEqual('1990-01-03');
+    });
+
     it('time', () => {
       const onChange = jest.fn();
       const onOk = jest.fn();


### PR DESCRIPTION
  Currently when we have date picker with type = `date` and switch the panel mode selection through the popup to `month` and then `year` and then select an `year` from that picker to narrow down the date selection, `triggerCalendarChange` function is called, even though the picker mode is `date`, which causes the date associated with the year(01-01-year) to be auto-selected and shown in the input. There is also a comment on `triggerCalendarChange`, which says  `// Only trigger calendar event but not update internal `calendarValue` state`, but triggerCalendarChange does update the `calendarValue` internally in useInnerValue hook line 147 - `setCalendarValue(clone);`. 
  A fix to the issue would be to not trigger the calendar change until the panel and picker modes are the same.
 
 Using the `multiple` storybook where we have date picker and navigating to decade panel and selecting 2000-2009, causes value 2000-04-08 to be auto-selected as first multiples value
![image](https://github.com/react-component/picker/assets/85161301/3a94ce80-5fba-455e-a732-aa6a13a1b6fb)
![image](https://github.com/react-component/picker/assets/85161301/4d6f3894-e892-4680-ac93-894c3cced1e9)
