### PR TITLE
dateFnsGenerateConfig: pass all getters through date-fns

### DIFF
--- a/src/generate/dateFns.ts
+++ b/src/generate/dateFns.ts
@@ -23,6 +23,7 @@ import {
   setSeconds,
   setYear,
   startOfWeek,
+  getMilliseconds,
   type Locale,
 } from 'date-fns';
 import * as locales from 'date-fns/locale';
@@ -55,7 +56,7 @@ const generateConfig: GenerateConfig<Date> = {
   getHour: (date) => getHours(date),
   getMinute: (date) => getMinutes(date),
   getSecond: (date) => getSeconds(date),
-  getMillisecond: (date) => date.getMilliseconds(),
+  getMillisecond: (date) => getMilliseconds(date),
 
   // set
   addYear: (date, diff) => addYears(date, diff),


### PR DESCRIPTION
Date-fns can work win number or Date by default.  It is ok, when config work as expected using date-fns lib