### PR TITLE
fix: range picker saves only last changed date

### DIFF
--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -634,6 +634,8 @@ function RangePicker<DateType extends object = any>(
 
   const onSelectorBlur: SelectorProps['onBlur'] = (event, index) => {
     triggerOpen(false);
+    const nextIndex = nextActiveIndex(calendarValue);
+    flushSubmit(activeIndex, nextIndex === null);
 
     onSharedBlur(event, index);
   };

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -634,8 +634,10 @@ function RangePicker<DateType extends object = any>(
 
   const onSelectorBlur: SelectorProps['onBlur'] = (event, index) => {
     triggerOpen(false);
-    const nextIndex = nextActiveIndex(calendarValue);
-    flushSubmit(activeIndex, nextIndex === null);
+    if (!needConfirm) {
+      const nextIndex = nextActiveIndex(calendarValue);
+      flushSubmit(activeIndex, nextIndex === null);
+    }
 
     onSharedBlur(event, index);
   };

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -1914,4 +1914,34 @@ describe('Picker.Range', () => {
 
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
+
+  it('should save both dates, but not only the last that was changed without submit, enter, tab, etc.', async () => {
+    const { container } = render(<DayRangePicker />);
+
+    act(() => {
+      fireEvent.focus(container.querySelectorAll('input')[0]);
+      fireEvent.change(container.querySelectorAll('input')[0], {
+        target: {
+          value: '2024-06-13',
+        },
+      });
+      fireEvent.blur(container.querySelectorAll('input')[0]);
+
+      fireEvent.focus(container.querySelectorAll('input')[1]);
+      fireEvent.change(container.querySelectorAll('input')[1], {
+        target: {
+          value: '2024-06-15',
+        },
+      });
+      
+      fireEvent.keyDown(container.querySelectorAll('input')[1], {
+        key: 'Enter',
+        code: 'Enter',
+      });
+
+    });
+    
+    expect(container.querySelectorAll('input')[1].value).toBe('2024-06-15');
+    expect(container.querySelectorAll('input')[0].value).toBe('2024-06-13');
+  });
 });


### PR DESCRIPTION
Added `flushSubmit` call to `onSelectorBlur`

Fixes the issue: https://github.com/ant-design/ant-design/issues/49057
