### PR TITLE
fix: Corrected the order of shortWeekDays in Turkish locale file

### DIFF
--- a/src/locale/tr_TR.ts
+++ b/src/locale/tr_TR.ts
@@ -29,7 +29,7 @@ const locale: Locale = {
   nextDecade: 'Sonraki On Yıl',
   previousCentury: 'Önceki Yüzyıl',
   nextCentury: 'Sonraki Yüzyıl',
-  shortWeekDays: ['Pzt', 'Sal', 'Çar', 'Per', 'Cum', 'Cmt', 'Paz'],
+  shortWeekDays: ['Paz', 'Pzt', 'Sal', 'Çar', 'Per', 'Cum', 'Cmt'],
   shortMonths: ['Oca', 'Şub', 'Mar', 'Nis', 'May', 'Haz', 'Tem', 'Ağu', 'Eyl', 'Eki', 'Kas', 'Ara'],
 };
 


### PR DESCRIPTION
Problem:
There was an issue in the Turkish localization file where the order of days in the shortWeekDays array was incorrect. The array started with 'Pzt' instead of 'Paz', which caused dates like 2024-07-24 to be displayed as 'Per' instead of 'Çar'. This resulted in incorrect day displays in the application.

Fix:
The shortWeekDays array in the Turkish localization file has been corrected to start with 'Paz', ensuring that the days of the week are displayed correctly. For example, 2024-07-24 is now correctly displayed as 'Çar'.

Changes:

Corrected the order of days in the shortWeekDays array in the Turkish localization file.

Impact:
This fix ensures that all dates are displayed with the correct day names in Turkish, preventing any potential confusion for users.

