### PR TITLE
fix: 修改disableDate属性在YearPanel的错误视图

### DIFF
--- a/src/PickerPanel/YearPanel/index.tsx
+++ b/src/PickerPanel/YearPanel/index.tsx
@@ -66,13 +66,9 @@ export default function YearPanel<DateType extends object = any>(
         const startDate = generateConfig.setDate(startMonth, 1);
 
         // End
-        const endMonth = generateConfig.setMonth(
-          currentDate,
-          generateConfig.getMonth(currentDate) + 1,
-        );
-        const enDate = generateConfig.addDate(endMonth, -1);
-
-        return disabledDate(startDate, disabledInfo) && disabledDate(enDate, disabledInfo);
+        const endMonth = generateConfig.setMonth(currentDate, 11);
+        const endDate = generateConfig.addDate(endMonth, 31);
+        return disabledDate(startDate, disabledInfo) && disabledDate(endDate, disabledInfo);
       }
     : null;
 

--- a/src/PickerPanel/YearPanel/index.tsx
+++ b/src/PickerPanel/YearPanel/index.tsx
@@ -67,7 +67,7 @@ export default function YearPanel<DateType extends object = any>(
 
         // End
         const endMonth = generateConfig.setMonth(currentDate, 11);
-        const endDate = generateConfig.addDate(endMonth, 31);
+        const endDate = generateConfig.setDate(endMonth, 31);
         return disabledDate(startDate, disabledInfo) && disabledDate(endDate, disabledInfo);
       }
     : null;

--- a/src/PickerPanel/YearPanel/index.tsx
+++ b/src/PickerPanel/YearPanel/index.tsx
@@ -66,8 +66,8 @@ export default function YearPanel<DateType extends object = any>(
         const startDate = generateConfig.setDate(startMonth, 1);
 
         // End
-        const endMonth = generateConfig.setMonth(currentDate, 11);
-        const endDate = generateConfig.setDate(endMonth, 31);
+        const endMonth = generateConfig.addYear(startDate, 1);
+        const endDate = generateConfig.addDate(endMonth, -1);
         return disabledDate(startDate, disabledInfo) && disabledDate(endDate, disabledInfo);
       }
     : null;

--- a/tests/panel.spec.tsx
+++ b/tests/panel.spec.tsx
@@ -715,4 +715,15 @@ describe('Picker.Panel', () => {
     expect(container.querySelector('.rc-picker-header-view').textContent).toEqual('01:02:03 AM');
   });
 
+  it('year panel disabled check', () => {
+    const { container } = render(
+      <DayPickerPanel
+        picker="year"
+        disabledDate={(date) => date.isBefore(getDay('1990-12-25'))}
+        defaultValue={getDay('1990-01-01')}
+      />,
+    );
+
+    expect(container.querySelector('.rc-picker-cell-selected').textContent).toEqual('1990');
+  });
 });


### PR DESCRIPTION
修改YearPanel的endDate为一年的最后一天，以及单词的错误拼写