### PR TITLE
refactor(DatePanel): stop displaying an entire line of dates for the …

### DIFF
--- a/src/PickerPanel/DatePanel/index.tsx
+++ b/src/PickerPanel/DatePanel/index.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import type { PanelMode, SharedPanelProps } from '../../interface';
 import {
   formatValue,
+  getNumberOfWeeksInMonth,
   getWeekStartDate,
   isSameDate,
   isSameMonth,
@@ -49,6 +50,13 @@ export default function DatePanel<DateType extends object = any>(props: DatePane
   const monthStartDate = generateConfig.setDate(pickerValue, 1);
   const baseDate = getWeekStartDate(locale.locale, generateConfig, monthStartDate);
   const month = generateConfig.getMonth(pickerValue);
+
+  const numberOfWeeksInMonth = getNumberOfWeeksInMonth(
+    generateConfig,
+    pickerValue,
+    weekFirstDay,
+    locale.locale,
+  );
 
   // =========================== PrefixColumn ===========================
   const showPrefixColumn = showWeek === undefined ? isWeek : showWeek;
@@ -199,7 +207,7 @@ export default function DatePanel<DateType extends object = any>(props: DatePane
           titleFormat={locale.fieldDateFormat}
           {...props}
           colNum={WEEK_DAY_COUNT}
-          rowNum={6}
+          rowNum={numberOfWeeksInMonth}
           baseDate={baseDate}
           // Header
           headerCells={headerCells}

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -1,5 +1,6 @@
 import type { GenerateConfig } from '../generate';
 import type { CustomFormat, InternalMode, Locale, NullableDateType } from '../interface';
+import { differenceInCalendarWeeks, lastDayOfMonth, startOfMonth } from 'date-fns';
 
 export const WEEK_DAY_COUNT = 7;
 
@@ -269,4 +270,28 @@ export function fillTime<DateType>(
   });
 
   return tmpDate;
+}
+
+type WeekStartsOnType = 0 | 3 | 1 | 4 | 2 | 5 | 6;
+
+export function getNumberOfWeeksInMonth<DateType>(
+  generateConfig: GenerateConfig<DateType>,
+  date: DateType,
+  weekFirstDay: number,
+  locale: string,
+) {
+  const _date = new Date(
+    generateConfig.getYear(date),
+    generateConfig.getMonth(date),
+    generateConfig.getDate(date),
+  );
+
+  return (
+    differenceInCalendarWeeks(lastDayOfMonth(_date), startOfMonth(_date), {
+      weekStartsOn: weekFirstDay as WeekStartsOnType,
+      locale: {
+        code: locale,
+      },
+    }) + 1
+  );
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

Hello, this is a suggestion and if you want i can add some other test.

My problem today is that for all month, we have 6 row. But in some month we don't need the last row and it take somme place. 


### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Stop displaying an entire line of dates for the next month in calendar    |
| 🇨🇳 Chinese |       在 Calendar 元件中停止顯示下個月的一整行日期    |
