### PR TITLE
fix: Luxon AM/PM formatting

### DIFF
--- a/src/generate/luxon.ts
+++ b/src/generate/luxon.ts
@@ -25,7 +25,8 @@ const normalizeFormatPart = (part: string): string =>
     .replace(/D/g, 'd')
     .replace(/gg/g, 'kk')
     .replace(/Q/g, 'q')
-    .replace(/([Ww])o/g, 'WW');
+    .replace(/([Ww])o/g, 'WW')
+    .replace(/A/g, 'a');
 
 /**
  * Normalizes a moment compatible format string to a luxon compatible format string


### PR DESCRIPTION
Luxon uses lowercase `a` for the meridiam token. Currently, AM/PM labels show up as `A` as Luxon passes it through