### PR TITLE
fix: onHover is not a function

### DIFF
--- a/src/PickerPanel/TimePanel/TimePanelBody/index.tsx
+++ b/src/PickerPanel/TimePanel/TimePanelBody/index.tsx
@@ -26,8 +26,15 @@ export default function TimePanelBody<DateType extends object = any>(
     changeOnScroll,
   } = props;
 
-  const { prefixCls, values, generateConfig, locale, onSelect, onHover, pickerValue } =
-    usePanelContext<DateType>();
+  const {
+    prefixCls,
+    values,
+    generateConfig,
+    locale,
+    onSelect,
+    onHover = () => {},
+    pickerValue,
+  } = usePanelContext<DateType>();
 
   const value = values?.[0] || null;
 


### PR DESCRIPTION
close https://github.com/react-component/picker/issues/869

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 为 `TimePanelBody` 组件添加了 `onHover` 函数的默认值，增强了组件的健壮性，避免了因未定义的 `onHover` 函数而导致的运行时错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->