### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ render(<Picker />, mountNode);
 | className | String | '' | additional css class of root dom node |
 | style | React.CSSProperties |  | additional style of root dom node |
 | dropdownClassName | String | '' | additional className applied to dropdown |
-| dropdownAlign | Object:alignConfig of [dom-align](https://github.com/yiminghe/dom-align) |  | value will be merged into placement's dropdownAlign config |
+| popupAlign | Object:alignConfig of [dom-align](https://github.com/yiminghe/dom-align) |  | value will be merged into placement's popupAlign config |
 | popupStyle | React.CSSProperties |  | customize popup style |
 | transitionName | String | '' | css class for animation |
 | locale | Object | import from 'rc-picker/lib/locale/en_US' | rc-picker locale |


### PR DESCRIPTION
`dropdownAlign` rename to `popupAlign`

Docs also missing `placement` and `builtinPlacements`.

Need to change popup shift behavior, so I need this prop.

rc-picker version: 3.14.6 / antd version: 5.10.3
https://stackblitz.com/edit/antd-reproduce-5x-zcgv9l

rc-picker version: 4.6.14 / antd version: 5.20.6
https://stackblitz.com/edit/antd-reproduce-5x-oeocvg
