### PR TITLE
feat(getNow): improve the current time acquisition method

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "luxon": "3.x",
     "mockdate": "^3.0.2",
     "moment": "^2.24.0",
+    "moment-timezone": "^0.5.45",
     "np": "^10.0.2",
     "prettier": "^3.1.0",
     "rc-test": "^7.0.9",

--- a/src/generate/dayjs.ts
+++ b/src/generate/dayjs.ts
@@ -108,10 +108,10 @@ const parseNoMatchNotice = () => {
 const generateConfig: GenerateConfig<Dayjs> = {
   // get
   getNow: () => {
-    if (typeof dayjs.tz === 'function') {
-      // https://github.com/ant-design/ant-design/discussions/50934
-      return dayjs.tz();
-    }
+    // if (typeof dayjs.tz === 'function') {
+    //   // https://github.com/ant-design/ant-design/discussions/50934
+    //   return dayjs.tz();
+    // }
     return dayjs();
   },
   getFixedDate: (string) => dayjs(string, ['YYYY-M-DD', 'YYYY-MM-DD']),

--- a/src/generate/dayjs.ts
+++ b/src/generate/dayjs.ts
@@ -108,11 +108,12 @@ const parseNoMatchNotice = () => {
 const generateConfig: GenerateConfig<Dayjs> = {
   // get
   getNow: () => {
-    // if (typeof dayjs.tz === 'function') {
-    //   // https://github.com/ant-design/ant-design/discussions/50934
-    //   return dayjs.tz();
-    // }
-    return dayjs();
+    const now = dayjs();
+    // https://github.com/ant-design/ant-design/discussions/50934
+    if (typeof now.tz === 'function') {
+      return now.tz(); // use default timezone
+    }
+    return now;
   },
   getFixedDate: (string) => dayjs(string, ['YYYY-M-DD', 'YYYY-MM-DD']),
   getEndDate: (date) => date.endOf('month'),

--- a/src/generate/dayjs.ts
+++ b/src/generate/dayjs.ts
@@ -107,7 +107,13 @@ const parseNoMatchNotice = () => {
 
 const generateConfig: GenerateConfig<Dayjs> = {
   // get
-  getNow: () => dayjs(),
+  getNow: () => {
+    if (typeof dayjs.tz === 'function') {
+      // https://github.com/ant-design/ant-design/discussions/50934
+      return dayjs.tz();
+    }
+    return dayjs();
+  },
   getFixedDate: (string) => dayjs(string, ['YYYY-M-DD', 'YYYY-MM-DD']),
   getEndDate: (date) => date.endOf('month'),
   getWeekDay: (date) => {

--- a/tests/generateWithTZ.spec.tsx
+++ b/tests/generateWithTZ.spec.tsx
@@ -1,0 +1,37 @@
+import MockDate from 'mockdate';
+import dayjsGenerateConfig from '../src/generate/dayjs';
+
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const CN = 'Asia/Shanghai';
+const JP = 'Asia/Tokyo';
+
+beforeEach(() => {
+  MockDate.set(dayjs.tz('2024-09-23 05:02:03.172', CN).toDate());
+});
+
+afterEach(() => {
+  dayjs.tz.setDefault();
+  MockDate.reset();
+});
+
+describe('dayjs: getNow', () => {
+  it('normal', () => {
+    const now = new Date();
+    expect(now.toDateString()).toEqual('Mon Sep 23 2024');
+    expect(now.toTimeString()).toContain('05:02:03 GMT+0800');
+  });
+
+  it('should be work', async () => {
+    dayjs.tz.setDefault(JP);
+    const now = dayjsGenerateConfig.getNow();
+    const L_now = dayjs();
+    expect(L_now.format()).toEqual('2024-09-23T05:02:03+08:00');
+    expect(now.format()).toEqual('2024-09-23T06:02:03+09:00');
+  });
+});

--- a/tests/generateWithTZ.spec.tsx
+++ b/tests/generateWithTZ.spec.tsx
@@ -14,10 +14,13 @@ const JP = 'Asia/Tokyo';
 
 beforeEach(() => {
   MockDate.set(new Date());
+  dayjs.tz.setDefault(CN);
+  moment.tz.setDefault(CN);
 });
 
 afterEach(() => {
   dayjs.tz.setDefault();
+  moment.tz.setDefault();
   MockDate.reset();
 });
 

--- a/tests/generateWithTZ.spec.tsx
+++ b/tests/generateWithTZ.spec.tsx
@@ -4,6 +4,7 @@ import dayjsGenerateConfig from '../src/generate/dayjs';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
+import moment from 'moment-timezone';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -12,7 +13,7 @@ const CN = 'Asia/Shanghai';
 const JP = 'Asia/Tokyo';
 
 beforeEach(() => {
-  MockDate.set(dayjs.tz('2024-09-23 05:02:03.172', CN).toDate());
+  MockDate.set(new Date());
 });
 
 afterEach(() => {
@@ -22,16 +23,18 @@ afterEach(() => {
 
 describe('dayjs: getNow', () => {
   it('normal', () => {
-    const now = new Date();
-    expect(now.toDateString()).toEqual('Mon Sep 23 2024');
-    expect(now.toTimeString()).toContain('05:02:03 GMT+0800');
+    const D_now = dayjsGenerateConfig.getNow();
+    const M_now = moment();
+
+    expect(D_now.format()).toEqual(M_now.format());
   });
 
-  it('should be work', async () => {
+  it('should work normally in timezone', async () => {
     dayjs.tz.setDefault(JP);
-    const now = dayjsGenerateConfig.getNow();
-    const L_now = dayjs();
-    expect(L_now.format()).toEqual('2024-09-23T05:02:03+08:00');
-    expect(now.format()).toEqual('2024-09-23T06:02:03+09:00');
+    const D_now = dayjsGenerateConfig.getNow();
+    const M_now = moment().tz(JP);
+
+    expect(D_now.format()).toEqual(M_now.format());
+    expect(D_now.get('hour') - D_now.utc().get('hour')).toEqual(9);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "src/**/*.tsx",
     "docs/examples/*.tsx",
     "tests/**/*.ts",
-    "tests/**/*.tsx"
+    "tests/**/*.tsx",
+    "typings.d.ts"
   ]
 }

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,0 +1,3 @@
+import 'dayjs/plugin/timezone';
+
+export {};


### PR DESCRIPTION
### 背景

see: https://github.com/ant-design/ant-design/discussions/50934

### 解决方案

优先判断 dayjs 是否存在 `dayjs.tz` ，如果有且是一个函数，表明用户添加了 dayjs 的 timezone 插件。

当前 PR 改进获取当前时间时，优先使用 `dayjs.tz()` 获取，其次用默认的 `dayjs()`。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 增强了 `getNow` 方法，支持时区功能。
  - 引入了新的 TypeScript 声明文件 `typings.d.ts`，以支持 `dayjs` 的时区插件。
  - 新增了对 `moment-timezone` 的依赖，以扩展时区操作的功能。

- **测试**
  - 新增了针对 `dayjsGenerateConfig` 模块的单元测试，重点测试时区功能。

- **配置**
  - 更新了 `tsconfig.json` 文件，包含新的类型声明文件路径。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->