### PR TITLE
feat(luxon-getNow): Improve the response `tz` setting for obtaining the current time method

### DIFF
--- a/src/generate/luxon.ts
+++ b/src/generate/luxon.ts
@@ -59,9 +59,9 @@ const generateConfig: GenerateConfig<DateTime> = {
   // get
   getNow: () => {
     /**
-     * The current time that can respond to tz settings is required.
+     * The current time that can respond to tz settings is required. like `dayjs().tz()`.
      * @see: https://github.com/ant-design/ant-design/issues/51282
-     * like `dayjs().tz()`: https://github.com/ant-design/ant-design/discussions/50934
+     *       https://github.com/react-component/picker/pull/878
      */
     return DateTime.now();
   },

--- a/src/generate/luxon.ts
+++ b/src/generate/luxon.ts
@@ -57,7 +57,14 @@ const normalizeLocale = (locale: string): string => locale.replace(/_/g, '-');
 
 const generateConfig: GenerateConfig<DateTime> = {
   // get
-  getNow: () => DateTime.local(),
+  getNow: () => {
+    /**
+     * The current time that can respond to tz settings is required.
+     * @see: https://github.com/ant-design/ant-design/issues/51282
+     * like `dayjs().tz()`: https://github.com/ant-design/ant-design/discussions/50934
+     */
+    return DateTime.now();
+  },
   getFixedDate: (string) => DateTime.fromFormat(string, 'yyyy-MM-dd'),
   getEndDate: (date) => date.endOf('month'),
   getWeekDay: (date) => date.weekday,


### PR DESCRIPTION
fix: https://github.com/ant-design/ant-design/issues/51282

看起来和之前解决 #878 问题一样

1. `DateTime.local()`方法只会应用 system 的 tz， 需要使用 `toLocal()` 来应用本地设置的 timezone。默认不传递即生效 `Settings.defaultZone` 设置的值。

2. `DateTime.now()` 会直接返回应用了 tz 的本地时间





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了获取当前时间的方法，以支持时区设置。
- **文档**
	- 添加了注释，解释了使用 `DateTime.now()` 的必要性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->