### PR TITLE
fix: the RangePicker  sets disabledDate, the date cannot be modified

### DIFF
--- a/src/PickerInput/hooks/useRangeValue.ts
+++ b/src/PickerInput/hooks/useRangeValue.ts
@@ -270,10 +270,9 @@ export default function useRangeValue<ValueType extends DateType[], DateType ext
     // >>> Invalid
     const validateDates =
       // Validate start
-      (!start || !isInvalidateDate(start, { activeIndex: 0 })) &&
+      (disabled[0] || !start || !isInvalidateDate(start, { activeIndex: 0 })) &&
       // Validate end
-      (!end || !isInvalidateDate(end, { from: start, activeIndex: 1 }));
-
+      (disabled[1] || !end || !isInvalidateDate(end, { from: start, activeIndex: 1 }));
     // >>> Result
     const allPassed =
       // Null value is from clear button

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -231,7 +231,7 @@ describe('Picker.Range', () => {
       expect(baseElement.querySelector('.rc-picker-dropdown-hidden')).toBeTruthy();
     });
 
-    it('should not be checked if the value is disabled', () => {
+    it('should not be checked if the startDate is disabled', () => {
       const onChange = jest.fn();
       const { container } = render(
         <DayRangePicker
@@ -247,6 +247,24 @@ describe('Picker.Range', () => {
       expect(onChange).toHaveBeenCalledWith(
         [expect.anything(), expect.anything()],
         ['2024-10-28', '2024-11-21'],
+      );
+    });
+    it('should not be checked if the endDate is disabled', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <DayRangePicker
+          disabled={[false, true]}
+          defaultValue={[getDay('2024-10-28'), getDay('2024-11-20')]}
+          disabledDate={(date: Dayjs) => date >= dayjs('2024-11-10').endOf('day')}
+          onChange={onChange}
+        />,
+      );
+
+      openPicker(container, 0);
+      selectCell('21', 0);
+      expect(onChange).toHaveBeenCalledWith(
+        [expect.anything(), expect.anything()],
+        ['2024-10-21', '2024-11-20'],
       );
     });
 

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -231,6 +231,25 @@ describe('Picker.Range', () => {
       expect(baseElement.querySelector('.rc-picker-dropdown-hidden')).toBeTruthy();
     });
 
+    it('should not be checked if the value is disabled', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <DayRangePicker
+          disabled={[true, false]}
+          defaultValue={[getDay('2024-10-28'), getDay('2024-11-20')]}
+          disabledDate={(date: Dayjs) => date <= dayjs('2024-11-20').endOf('day')}
+          onChange={onChange}
+        />,
+      );
+
+      openPicker(container, 1);
+      selectCell('21', 1);
+      expect(onChange).toHaveBeenCalledWith(
+        [expect.anything(), expect.anything()],
+        ['2024-10-28', '2024-11-21'],
+      );
+    });
+
     it('should close panel when finish first choose with showTime = true and disabled = [false, true]', () => {
       const { baseElement } = render(<DayRangePicker showTime disabled={[false, true]} />);
       expect(baseElement.querySelectorAll('.rc-picker-input')).toHaveLength(2);
@@ -541,7 +560,7 @@ describe('Picker.Range', () => {
     it('pass tabIndex', () => {
       const { container } = render(
         <div>
-          <DayRangePicker tabIndex={-1}/>
+          <DayRangePicker tabIndex={-1} />
         </div>,
       );
 
@@ -705,12 +724,7 @@ describe('Picker.Range', () => {
   });
 
   it('prefix', () => {
-    render(
-      <DayRangePicker
-        prefix={<span className="prefix" />}
-        allowClear
-      />,
-    );
+    render(<DayRangePicker prefix={<span className="prefix" />} allowClear />);
     expect(document.querySelector('.prefix')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix https://github.com/ant-design/ant-design/issues/51402

### 💡 Background and Solution

   - In RangePicker component, when the start date is disabled (disabled[0] = true)
   - And the initial value meets the disabledDate condition
   - The end date cannot be changed normally
  Solution:
    Don't check the value if it is disabled

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix  the RangePicker  sets disabledDate, the date cannot be modified      |
| 🇨🇳 Chinese |     修复当RangePicker设置disabledDate时，日期无法正常修改的问题    |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新功能**
	- 增强了日期范围选择器的日期验证逻辑，确保禁用的日期被正确处理。

- **错误修复**
	- 更新了测试用例，确保在选择禁用日期时不会触发 `onChange` 回调。

- **测试**
	- 增加了对禁用日期的检查，确保组件在选择无效日期时的行为符合预期。
	- 改进了测试结构，使其更易于理解和导航。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->