### PR TITLE
fix: activeBar offset not right when start from the opposite direction

### DIFF
--- a/src/PickerInput/Selector/RangeSelector.tsx
+++ b/src/PickerInput/Selector/RangeSelector.tsx
@@ -187,10 +187,10 @@ function RangeSelector<DateType extends object = any>(
       const { offsetWidth, offsetLeft, offsetParent } = input.nativeElement;
       const parentWidth = (offsetParent as HTMLElement)?.offsetWidth || 0;
       const activeOffset = placementRight ? (parentWidth - offsetWidth - offsetLeft) : offsetLeft;
-      setActiveBarStyle((ori) => ({
-        ...ori,
+      setActiveBarStyle(({ insetInlineStart, insetInlineEnd, ...rest }) => ({
+        ...rest,
         width: offsetWidth,
-        [offsetUnit]: activeOffset,
+        [offsetUnit]: activeOffset
       }));
       onActiveOffset(activeOffset);
     }


### PR DESCRIPTION
修改弹窗位置为相反的方向时，activeBar的位置出现错误
![动画](https://github.com/user-attachments/assets/285bc3a5-2f96-4d13-b320-679b1265b369)
因为添加insetInlineStart/或insetInlineEnd的时候并未清除原有的样式
![image](https://github.com/user-attachments/assets/77634316-d79b-427a-8224-027555ef2557)

相关问题：
close https://github.com/ant-design/ant-design/issues/51480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能更新**
	- 修改了 `RangeSelector` 组件的样式更新逻辑，以优化活动条的外观。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->