### PR TITLE
fix: multiple select none current panel should not trigger change

### DIFF
--- a/src/PickerInput/SinglePicker.tsx
+++ b/src/PickerInput/SinglePicker.tsx
@@ -441,6 +441,11 @@ function Picker<DateType extends object = any>(
   const onPanelSelect = (date: DateType) => {
     lastOperation('panel');
 
+    // Not change values if multiple and current panel is to match with picker
+    if (multiple && internalMode !== picker) {
+      return;
+    }
+
     const nextValues = multiple ? toggleDates(getCalendarValue(), date) : [date];
 
     // Only trigger calendar event but not update internal `calendarValue` state

--- a/tests/multiple.spec.tsx
+++ b/tests/multiple.spec.tsx
@@ -155,4 +155,40 @@ describe('Picker.Multiple', () => {
       ).toBeFalsy();
     });
   });
+
+  it('click year panel should not select', () => {
+    const onChange = jest.fn();
+    const onCalendarChange = jest.fn();
+    const { container } = render(
+      <DayPicker multiple onChange={onChange} onCalendarChange={onCalendarChange} needConfirm />,
+    );
+
+    expect(container.querySelector('.rc-picker-multiple')).toBeTruthy();
+
+    openPicker(container);
+
+    // Select year
+    fireEvent.click(document.querySelector('.rc-picker-year-btn'));
+    selectCell(1998);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onCalendarChange).not.toHaveBeenCalled();
+
+    // Select Month
+    selectCell('Oct');
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onCalendarChange).not.toHaveBeenCalled();
+
+    // Select Date
+    selectCell(23);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onCalendarChange).toHaveBeenCalledWith(
+      expect.anything(),
+      ['1998-10-23'],
+      expect.anything(),
+    );
+
+    // Confirm
+    fireEvent.click(document.querySelector('.rc-picker-ok button'));
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), ['1998-10-23']);
+  });
 });


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/51721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了单选器组件，以在多选模式下防止不必要的值更改。
	- 改进了回调函数传递的数据结构，确保更清晰的信息。

- **测试**
	- 为多选器测试套件添加了新测试，验证在选择年份面板时不会触发回调，直到选择特定日期。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->