### PR TITLE
chore: rm useless code

### DIFF
--- a/src/generate/dayjs.ts
+++ b/src/generate/dayjs.ts
@@ -100,9 +100,13 @@ const parseLocale = (locale: string) => {
   return mapLocale || locale.split('_')[0];
 };
 
+/* istanbul ignore next */
 const parseNoMatchNotice = () => {
-  /* istanbul ignore next */
-  noteOnce(false, 'Not match any format. Please help to fire a issue about this.');
+  // zombieJ:
+  // When user typing, its always miss match format.
+  // This check is meaningless.
+  // https://github.com/ant-design/ant-design/issues/51839
+  // noteOnce(false, 'Not match any format. Please help to fire a issue about this.');
 };
 
 const generateConfig: GenerateConfig<Dayjs> = {

--- a/src/generate/dayjs.ts
+++ b/src/generate/dayjs.ts
@@ -1,6 +1,5 @@
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
-import { noteOnce } from 'rc-util/lib/warning';
 import weekday from 'dayjs/plugin/weekday';
 import localeData from 'dayjs/plugin/localeData';
 import weekOfYear from 'dayjs/plugin/weekOfYear';


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/51839

看了一下代码，parse 逻辑在用户输入中是持续校验的。但是问题是，输入中不一定会匹配格式，导致无效的 warning 出来。而 mask 模式下，由于会预先填充内容，导致它一定是匹配不正确的。

这个 parse 代码存在 5 年了，一直没遇到有效的反馈。应该是安全删除的。

cc @iamkun 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进功能**
	- 修改了日期解析中的格式不匹配处理方式，移除了无意义的日志记录。
	- 增加了注释以提供更清晰的上下文，帮助理解格式验证的变化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->