### PR TITLE
feat(RangeSelector): add -input-start and -input-end className to differ inputs

### DIFF
--- a/src/PickerInput/Selector/Input.tsx
+++ b/src/PickerInput/Selector/Input.tsx
@@ -52,6 +52,7 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 
 const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
   const {
+    className,
     active,
     showActiveCls = true,
     suffixIcon,
@@ -377,10 +378,14 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
   return (
     <div
       ref={holderRef}
-      className={classNames(inputPrefixCls, {
-        [`${inputPrefixCls}-active`]: active && showActiveCls,
-        [`${inputPrefixCls}-placeholder`]: helped,
-      })}
+      className={classNames(
+        inputPrefixCls,
+        {
+          [`${inputPrefixCls}-active`]: active && showActiveCls,
+          [`${inputPrefixCls}-placeholder`]: helped,
+        },
+        className,
+      )}
     >
       <Component
         ref={inputRef}

--- a/src/PickerInput/Selector/RangeSelector.tsx
+++ b/src/PickerInput/Selector/RangeSelector.tsx
@@ -242,6 +242,7 @@ function RangeSelector<DateType extends object = any>(
         <Input
           ref={inputStartRef}
           {...getInputProps(0)}
+          className={`${prefixCls}-input-start`}
           autoFocus={startAutoFocus}
           tabIndex={tabIndex}
           date-range="start"
@@ -250,6 +251,7 @@ function RangeSelector<DateType extends object = any>(
         <Input
           ref={inputEndRef}
           {...getInputProps(1)}
+          className={`${prefixCls}-input-end`}
           autoFocus={endAutoFocus}
           tabIndex={tabIndex}
           date-range="end"

--- a/tests/__snapshots__/range.spec.tsx.snap
+++ b/tests/__snapshots__/range.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`Picker.Range icon 1`] = `
     class="rc-picker rc-picker-range"
   >
     <div
-      class="rc-picker-input"
+      class="rc-picker-input rc-picker-input-start"
     >
       <input
         aria-invalid="false"
@@ -22,7 +22,7 @@ exports[`Picker.Range icon 1`] = `
       ~
     </div>
     <div
-      class="rc-picker-input"
+      class="rc-picker-input rc-picker-input-end"
     >
       <input
         aria-invalid="false"
@@ -61,7 +61,7 @@ exports[`Picker.Range onPanelChange is array args should render correctly in pla
     class="rc-picker rc-picker-range rc-picker-focused"
   >
     <div
-      class="rc-picker-input rc-picker-input-active"
+      class="rc-picker-input rc-picker-input-active rc-picker-input-start"
     >
       <input
         aria-invalid="false"
@@ -77,7 +77,7 @@ exports[`Picker.Range onPanelChange is array args should render correctly in pla
       ~
     </div>
     <div
-      class="rc-picker-input"
+      class="rc-picker-input rc-picker-input-end"
     >
       <input
         aria-invalid="false"
@@ -101,7 +101,7 @@ exports[`Picker.Range onPanelChange is array args should render correctly in rtl
     class="rc-picker rc-picker-range rc-picker-rtl"
   >
     <div
-      class="rc-picker-input"
+      class="rc-picker-input rc-picker-input-start"
     >
       <input
         aria-invalid="false"
@@ -117,7 +117,7 @@ exports[`Picker.Range onPanelChange is array args should render correctly in rtl
       ~
     </div>
     <div
-      class="rc-picker-input"
+      class="rc-picker-input rc-picker-input-end"
     >
       <input
         aria-invalid="false"
@@ -142,7 +142,7 @@ exports[`Picker.Range panelRender 1`] = `
       class="rc-picker rc-picker-range"
     >
       <div
-        class="rc-picker-input rc-picker-input-active"
+        class="rc-picker-input rc-picker-input-active rc-picker-input-start"
       >
         <input
           aria-invalid="false"
@@ -158,7 +158,7 @@ exports[`Picker.Range panelRender 1`] = `
         ~
       </div>
       <div
-        class="rc-picker-input"
+        class="rc-picker-input rc-picker-input-end"
       >
         <input
           aria-invalid="false"
@@ -208,7 +208,7 @@ exports[`Picker.Range use dateRender and monthCellRender in date range picker 1`
       class="rc-picker rc-picker-range rc-picker-focused"
     >
       <div
-        class="rc-picker-input rc-picker-input-active"
+        class="rc-picker-input rc-picker-input-active rc-picker-input-start"
       >
         <input
           aria-invalid="false"
@@ -224,7 +224,7 @@ exports[`Picker.Range use dateRender and monthCellRender in date range picker 1`
         ~
       </div>
       <div
-        class="rc-picker-input"
+        class="rc-picker-input rc-picker-input-end"
       >
         <input
           aria-invalid="false"
@@ -1265,7 +1265,7 @@ exports[`Picker.Range use dateRender and monthCellRender in month range picker 1
       class="rc-picker rc-picker-range rc-picker-focused"
     >
       <div
-        class="rc-picker-input rc-picker-input-active"
+        class="rc-picker-input rc-picker-input-active rc-picker-input-start"
       >
         <input
           aria-invalid="false"
@@ -1281,7 +1281,7 @@ exports[`Picker.Range use dateRender and monthCellRender in month range picker 1
         ~
       </div>
       <div
-        class="rc-picker-input"
+        class="rc-picker-input rc-picker-input-end"
       >
         <input
           aria-invalid="false"


### PR DESCRIPTION
在单元测试和端到端测试中，我们经常需要定位 input 元素。而目前 picker 的两个 input 的 className 是完全相同的，定位起来多有不便。因此，我给两个 input 分别增加了不同的类名 `rc-picker-input-start` 和 `rc-picker-input-end`，这样定位起来就更加方便了。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 为输入组件增加了自定义 CSS 类名的能力，提高了样式灵活性。

- **样式**
	- 为范围选择器的开始和结束输入框添加了更具体的类名，以便更精细的样式控制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->