### PR TITLE
fix: React 19 scroll sync

### DIFF
--- a/src/PickerPanel/TimePanel/TimePanelBody/TimeColumn.tsx
+++ b/src/PickerPanel/TimePanel/TimePanelBody/TimeColumn.tsx
@@ -54,7 +54,7 @@ export default function TimeColumn<DateType extends object>(props: TimeUnitColum
       stopScroll();
       clearDelayCheck();
     };
-  }, [value, optionalValue, units]);
+  }, [value, optionalValue, units.join(',')]);
 
   // ========================= Change =========================
   // Scroll event if sync onScroll

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -292,9 +292,7 @@ describe('Picker.Basic', () => {
 
     // https://github.com/ant-design/ant-design/issues/49400
     it('should not throw errow when input end year first', () => {
-      const { container } = render(
-        <DayRangePicker picker="year" />,
-      );
+      const { container } = render(<DayRangePicker picker="year" />);
       openPicker(container);
       fireEvent.focus(container.querySelectorAll('input')[1]);
       expect(() => {
@@ -369,7 +367,7 @@ describe('Picker.Basic', () => {
     it('pass tabIndex', () => {
       const { container } = render(
         <div>
-          <DayPicker tabIndex={-1}/>
+          <DayPicker tabIndex={-1} />
         </div>,
       );
 
@@ -583,12 +581,7 @@ describe('Picker.Basic', () => {
   });
 
   it('prefix', () => {
-    render(
-      <DayPicker
-        prefix={<span className="prefix" />}
-        allowClear
-      />,
-    );
+    render(<DayPicker prefix={<span className="prefix" />} allowClear />);
     expect(document.querySelector('.prefix')).toBeInTheDocument();
   });
 
@@ -1064,6 +1057,10 @@ describe('Picker.Basic', () => {
       });
     });
 
+    beforeEach(() => {
+      triggered = false;
+    });
+
     afterAll(() => {
       domMock.mockRestore();
     });
@@ -1082,6 +1079,46 @@ describe('Picker.Basic', () => {
 
       jest.useRealTimers();
       unmount();
+    });
+
+    it('not repeat scroll if disabledTime return same value', () => {
+      const getDisabledTimeFn = () => () => ({
+        disabledHours: () => [10],
+        disabledMinutes: () => [10],
+        disabledSeconds: () => [10],
+      });
+
+      const { rerender } = render(
+        <DayPicker
+          picker="time"
+          defaultValue={getDay('2020-07-22 09:03:28')}
+          open
+          disabledTime={getDisabledTimeFn()}
+        />,
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+        jest.clearAllTimers();
+      });
+      expect(triggered).toBeTruthy();
+
+      // New disabledTime
+      triggered = false;
+      rerender(
+        <DayPicker
+          picker="time"
+          defaultValue={getDay('2020-07-22 09:03:28')}
+          open
+          disabledTime={getDisabledTimeFn()}
+        />,
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+        jest.clearAllTimers();
+      });
+      expect(triggered).toBeFalsy();
     });
   });
 


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/52254

从代码看，每次传入新的fn做一次调用是符合预期的。但是这里如果返回的 units 是相同的，那滚动的确没有什么意义。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **性能优化**
	- 优化了时间选择器组件中的依赖数组，减少不必要的重新渲染。

- **测试改进**
	- 改进了日期范围选择器的测试用例，增加了对用户输入的健壮性测试。
	- 修正了测试代码的格式和可读性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->