### PR TITLE
feat: improve a11y when table header is empty and add localization support

### DIFF
--- a/src/PickerPanel/DatePanel/index.tsx
+++ b/src/PickerPanel/DatePanel/index.tsx
@@ -98,7 +98,13 @@ export default function DatePanel<DateType extends object = any>(props: DatePane
       : []);
 
   if (prefixColumn) {
-    headerCells.push(<th key="empty" aria-label="empty cell" />);
+    headerCells.push(
+      <th key="empty">
+        <span style={{ width: 0, height: 0, position: 'absolute', overflow: 'hidden', opacity: 0 }}>
+          Week
+        </span>
+      </th>,
+    );
   }
   for (let i = 0; i < WEEK_DAY_COUNT; i += 1) {
     headerCells.push(<th key={i}>{weekDaysLocale[(i + weekFirstDay) % WEEK_DAY_COUNT]}</th>);

--- a/src/PickerPanel/DatePanel/index.tsx
+++ b/src/PickerPanel/DatePanel/index.tsx
@@ -101,7 +101,7 @@ export default function DatePanel<DateType extends object = any>(props: DatePane
     headerCells.push(
       <th key="empty">
         <span style={{ width: 0, height: 0, position: 'absolute', overflow: 'hidden', opacity: 0 }}>
-          Week
+          {locale.week}
         </span>
       </th>,
     );
@@ -142,7 +142,7 @@ export default function DatePanel<DateType extends object = any>(props: DatePane
   const yearNode: React.ReactNode = (
     <button
       type="button"
-      aria-label="year panel"
+      aria-label={locale.yearSelect}
       key="year"
       onClick={() => {
         onModeChange('year', pickerValue);
@@ -160,7 +160,7 @@ export default function DatePanel<DateType extends object = any>(props: DatePane
   const monthNode: React.ReactNode = (
     <button
       type="button"
-      aria-label="month panel"
+      aria-label={locale.monthSelect}
       key="month"
       onClick={() => {
         onModeChange('month', pickerValue);

--- a/src/PickerPanel/MonthPanel/index.tsx
+++ b/src/PickerPanel/MonthPanel/index.tsx
@@ -71,7 +71,7 @@ export default function MonthPanel<DateType extends object = any>(
     <button
       type="button"
       key="year"
-      aria-label="year panel"
+      aria-label={locale.yearSelect}
       onClick={() => {
         onModeChange('year');
       }}

--- a/src/PickerPanel/PanelHeader.tsx
+++ b/src/PickerPanel/PanelHeader.tsx
@@ -122,7 +122,7 @@ function PanelHeader<DateType extends object>(props: HeaderProps<DateType>) {
       {superOffset && (
         <button
           type="button"
-          aria-label="super-prev-year"
+          aria-label={locale.previousYear}
           onClick={() => onSuperOffset(-1)}
           tabIndex={-1}
           className={classNames(
@@ -138,7 +138,7 @@ function PanelHeader<DateType extends object>(props: HeaderProps<DateType>) {
       {offset && (
         <button
           type="button"
-          aria-label="prev-year"
+          aria-label={locale.previousMonth}
           onClick={() => onOffset(-1)}
           tabIndex={-1}
           className={classNames(prevBtnCls, disabledOffsetPrev && `${prevBtnCls}-disabled`)}
@@ -152,7 +152,7 @@ function PanelHeader<DateType extends object>(props: HeaderProps<DateType>) {
       {offset && (
         <button
           type="button"
-          aria-label="next-year"
+          aria-label={locale.nextMonth}
           onClick={() => onOffset(1)}
           tabIndex={-1}
           className={classNames(nextBtnCls, disabledOffsetNext && `${nextBtnCls}-disabled`)}
@@ -165,7 +165,7 @@ function PanelHeader<DateType extends object>(props: HeaderProps<DateType>) {
       {superOffset && (
         <button
           type="button"
-          aria-label="super-next-year"
+          aria-label={locale.nextYear}
           onClick={() => onSuperOffset(1)}
           tabIndex={-1}
           className={classNames(

--- a/src/PickerPanel/QuarterPanel/index.tsx
+++ b/src/PickerPanel/QuarterPanel/index.tsx
@@ -39,7 +39,7 @@ export default function QuarterPanel<DateType extends object = any>(
     <button
       type="button"
       key="year"
-      aria-label="year panel"
+      aria-label={locale.yearSelect}
       onClick={() => {
         onModeChange('year');
       }}

--- a/src/PickerPanel/YearPanel/index.tsx
+++ b/src/PickerPanel/YearPanel/index.tsx
@@ -77,7 +77,7 @@ export default function YearPanel<DateType extends object = any>(
     <button
       type="button"
       key="decade"
-      aria-label="decade panel"
+      aria-label={locale.decadeSelect}
       onClick={() => {
         onModeChange('decade');
       }}

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -63,6 +63,7 @@ export type Locale = {
   dateSelect: string;
   weekSelect?: string;
   clear: string;
+  week: string;
   month: string;
   year: string;
   previousMonth: string;

--- a/src/locale/am_ET.ts
+++ b/src/locale/am_ET.ts
@@ -7,6 +7,7 @@ const locale: Locale = {
   backToToday: 'ወደ ዛሬ ተመለስ',
   ok: 'እሺ',
   clear: 'አንፃ',
+  week: 'ሳምንት',
   month: 'ወር',
   year: 'ዓመት',
   timeSelect: 'ሰዓት ምረጥ',

--- a/src/locale/ar_EG.ts
+++ b/src/locale/ar_EG.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'العودة إلى اليوم',
   ok: 'تأكيد',
   clear: 'مسح',
+  week: 'الأسبوع',
   month: 'الشهر',
   year: 'السنة',
   timeSelect: 'اختيار الوقت',

--- a/src/locale/az_AZ.ts
+++ b/src/locale/az_AZ.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Bugünə qayıt',
   ok: 'Təsdiq',
   clear: 'Təmizlə',
+  week: 'Həftə',
   month: 'Ay',
   year: 'İl',
   timeSelect: 'vaxtı seç',

--- a/src/locale/bg_BG.ts
+++ b/src/locale/bg_BG.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Към днес',
   ok: 'Добре',
   clear: 'Изчистване',
+  week: 'Седмица',
   month: 'Месец',
   year: 'Година',
   timeSelect: 'Избор на час',

--- a/src/locale/bn_BD.ts
+++ b/src/locale/bn_BD.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'আজকে ফিরে চলুন',
   ok: 'ওকে',
   clear: 'পরিস্কার',
+  week: 'সপ্তাহ',
   month: 'মাস',
   year: 'বছর',
   timeSelect: 'সময় নির্বাচন',

--- a/src/locale/by_BY.ts
+++ b/src/locale/by_BY.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Дадзеная дата',
   ok: 'OK',
   clear: 'Ачысціць',
+  week: 'Тыдзень',
   month: 'Месяц',
   year: 'Год',
   timeSelect: 'Выбраць час',

--- a/src/locale/ca_ES.ts
+++ b/src/locale/ca_ES.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Tornar a avui',
   ok: 'Acceptar',
   clear: 'Netejar',
+  week: 'Setmana',
   month: 'Mes',
   year: 'Any',
   timeSelect: 'Seleccionar hora',

--- a/src/locale/cs_CZ.ts
+++ b/src/locale/cs_CZ.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Zpět na dnešek',
   ok: 'OK',
   clear: 'Vymazat',
+  week: 'Týden',
   month: 'Měsíc',
   year: 'Rok',
   timeSelect: 'Vybrat čas',

--- a/src/locale/da_DK.ts
+++ b/src/locale/da_DK.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Gå til i dag',
   ok: 'OK',
   clear: 'Ryd',
+  week: 'Uge',
   month: 'Måned',
   year: 'År',
   timeSelect: 'Vælg tidspunkt',

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Zurück zu Heute',
   ok: 'OK',
   clear: 'Zurücksetzen',
+  week: 'Woche',
   month: 'Monat',
   year: 'Jahr',
   timeSelect: 'Zeit wählen',

--- a/src/locale/el_GR.ts
+++ b/src/locale/el_GR.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Πίσω στη σημερινή μέρα',
   ok: 'OK',
   clear: 'Καθαρισμός',
+  week: 'Εβδομάδα',
   month: 'Μήνας',
   year: 'Έτος',
   timeSelect: 'Επιλογή ώρας',

--- a/src/locale/en_GB.ts
+++ b/src/locale/en_GB.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Back to today',
   ok: 'OK',
   clear: 'Clear',
+  week: 'Week',
   month: 'Month',
   year: 'Year',
   timeSelect: 'Select time',

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Back to today',
   ok: 'OK',
   clear: 'Clear',
+  week: 'Week',
   month: 'Month',
   year: 'Year',
   timeSelect: 'select time',

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Volver a hoy',
   ok: 'Aceptar',
   clear: 'Limpiar',
+  week: 'Semana',
   month: 'Mes',
   year: 'Año',
   timeSelect: 'Seleccionar hora',

--- a/src/locale/es_MX.ts
+++ b/src/locale/es_MX.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Volver a hoy',
   ok: 'Aceptar',
   clear: 'Limpiar',
+  week: 'Semana',
   month: 'Mes',
   year: 'Año',
   timeSelect: 'elegir hora',

--- a/src/locale/et_EE.ts
+++ b/src/locale/et_EE.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Tagasi tänase juurde',
   ok: 'OK',
   clear: 'Tühista',
+  week: 'Nädal',
   month: 'Kuu',
   year: 'Aasta',
   timeSelect: 'Vali aeg',

--- a/src/locale/eu_ES.ts
+++ b/src/locale/eu_ES.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Gaur itzuli',
   ok: 'OK',
   clear: 'Garbitu',
+  week: 'Asteko',
   month: 'Hilabete',
   year: 'Urte',
   timeSelect: 'Ordua aukeratu',

--- a/src/locale/fa_IR.ts
+++ b/src/locale/fa_IR.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'بازگشت به روز',
   ok: 'باشه',
   clear: 'پاک کردن',
+  week: 'هفته',
   month: 'ماه',
   year: 'سال',
   timeSelect: 'انتخاب زمان',

--- a/src/locale/fi_FI.ts
+++ b/src/locale/fi_FI.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Tämä päivä',
   ok: 'OK',
   clear: 'Tyhjennä',
+  week: 'Viikko',
   month: 'Kuukausi',
   year: 'Vuosi',
   timeSelect: 'Valise aika',

--- a/src/locale/fr_BE.ts
+++ b/src/locale/fr_BE.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: "Aujourd'hui",
   ok: 'OK',
   clear: 'Rétablir',
+  week: 'Semaine',
   month: 'Mois',
   year: 'Année',
   timeSelect: "Sélectionner l'heure",

--- a/src/locale/fr_CA.ts
+++ b/src/locale/fr_CA.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: "Aujourd'hui",
   ok: 'OK',
   clear: 'Rétablir',
+  week: 'Semaine',
   month: 'Mois',
   year: 'Année',
   timeSelect: "Sélectionner l'heure",

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: "Aujourd'hui",
   ok: 'OK',
   clear: 'Rétablir',
+  week: 'Semaine',
   month: 'Mois',
   year: 'Année',
   timeSelect: "Sélectionner l'heure",

--- a/src/locale/ga_IE.ts
+++ b/src/locale/ga_IE.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Ar ais inniu',
   ok: 'ceart go leor',
   clear: 'soiléir',
+  week: 'seachtain',
   month: 'mhí',
   year: 'bhliain',
   timeSelect: 'roghnaigh am',

--- a/src/locale/gl_ES.ts
+++ b/src/locale/gl_ES.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Voltar a hoxe',
   ok: 'Aceptar',
   clear: 'Limpar',
+  week: 'Semana',
   month: 'Mes',
   year: 'Ano',
   timeSelect: 'Seleccionar hora',

--- a/src/locale/he_IL.ts
+++ b/src/locale/he_IL.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'חזור להיום',
   ok: 'אישור',
   clear: 'איפוס',
+  week: 'שבוע',
   month: 'חודש',
   year: 'שנה',
   timeSelect: 'בחר שעה',

--- a/src/locale/hi_IN.ts
+++ b/src/locale/hi_IN.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'आज तक',
   ok: 'ठीक',
   clear: 'स्पष्ट',
+  week: 'सप्ताह',
   month: 'महीना',
   year: 'साल',
   timeSelect: 'समय का चयन करें',

--- a/src/locale/hr_HR.ts
+++ b/src/locale/hr_HR.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Natrag na danas',
   ok: 'OK',
   clear: 'Očisti',
+  week: 'Sedmica',
   month: 'Mjesec',
   year: 'Godina',
   timeSelect: 'odaberite vrijeme',

--- a/src/locale/hu_HU.ts
+++ b/src/locale/hu_HU.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Vissza a mai napra', // 'Back to today',
   ok: 'OK',
   clear: 'Törlés', // 'Clear',
+  week: 'Hét',
   month: 'Hónap', // 'Month',
   year: 'Év', // 'Year',
   timeSelect: 'Időpont kiválasztása', // 'Select time',

--- a/src/locale/id_ID.ts
+++ b/src/locale/id_ID.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Kembali ke hari ini',
   ok: 'Baik',
   clear: 'Bersih',
+  week: 'Minggu',
   month: 'Bulan',
   year: 'Tahun',
   timeSelect: 'pilih waktu',

--- a/src/locale/is_IS.ts
+++ b/src/locale/is_IS.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Til baka til dagsins í dag',
   ok: 'Í lagi',
   clear: 'Hreinsa',
+  week: 'Vika',
   month: 'Mánuður',
   year: 'Ár',
   timeSelect: 'Velja tíma',

--- a/src/locale/it_IT.ts
+++ b/src/locale/it_IT.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Torna ad oggi',
   ok: 'OK',
   clear: 'Cancella',
+  week: 'Settimana',
   month: 'Mese',
   year: 'Anno',
   timeSelect: "Seleziona l'ora",

--- a/src/locale/ja_JP.ts
+++ b/src/locale/ja_JP.ts
@@ -12,6 +12,7 @@ const locale: Locale = {
   dateSelect: '日時を選択',
   weekSelect: '週を選択',
   clear: 'クリア',
+  week: '週',
   month: '月',
   year: '年',
   previousMonth: '前月 (ページアップキー)',

--- a/src/locale/ka_GE.ts
+++ b/src/locale/ka_GE.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'მიმდინარე თარიღი',
   ok: 'OK',
   clear: 'გასუფთავება',
+  week: 'კვირა',
   month: 'თვე',
   year: 'წელი',
   timeSelect: 'დროის არჩევა',

--- a/src/locale/kk_KZ.ts
+++ b/src/locale/kk_KZ.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Ағымдағы күн',
   ok: 'Таңдау',
   clear: 'Таза',
+  week: 'Апта',
   month: 'Ай',
   year: 'Жыл',
   timeSelect: 'Уақытты таңдау',

--- a/src/locale/km_KH.ts
+++ b/src/locale/km_KH.ts
@@ -12,6 +12,7 @@ const locale: Locale = {
   dateSelect: 'ជ្រើសរើសកាលបរិច្ឆេទ',
   weekSelect: 'ជ្រើសរើសសប្តាហ៍',
   clear: 'ច្បាស់',
+  week: 'សប្តាហ៍',
   month: 'ខែ',
   year: 'ឆ្នាំ',
   previousMonth: 'ខែមុន (ឡើងទំព័រ)',

--- a/src/locale/kmr_IQ.ts
+++ b/src/locale/kmr_IQ.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Vegere îro',
   ok: 'Temam',
   clear: 'Paqij bike',
+  week: 'Sêbê',
   month: 'Meh',
   year: 'Sal',
   timeSelect: 'Demê hilbijêre',

--- a/src/locale/kn_IN.ts
+++ b/src/locale/kn_IN.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'ಇಂದು ಹಿಂದಿರುಗಿ',
   ok: 'ಸರಿ',
   clear: 'ಸ್ಪಷ್ಟ',
+  week: 'ವಾರ',
   month: 'ತಿಂಗಳು',
   year: 'ವರ್ಷ',
   timeSelect: 'ಸಮಯ ಆಯ್ಕೆಮಾಡಿ',

--- a/src/locale/ko_KR.ts
+++ b/src/locale/ko_KR.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: '오늘로 돌아가기',
   ok: '확인',
   clear: '지우기',
+  week: '주',
   month: '월',
   year: '년',
   timeSelect: '시간 선택',

--- a/src/locale/lt_LT.ts
+++ b/src/locale/lt_LT.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Rodyti šiandien',
   ok: 'Gerai',
   clear: 'Išvalyti',
+  week: 'Savaitė',
   month: 'Mėnesis',
   year: 'Metai',
   timeSelect: 'Pasirinkti laiką',

--- a/src/locale/lv_LV.ts
+++ b/src/locale/lv_LV.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Atpakaļ pie šodienas',
   ok: 'OK',
   clear: 'Skaidrs',
+  week: 'Nedēļa',
   month: 'Mēnesis',
   year: 'Gads',
   timeSelect: 'Izvēlieties laiku',

--- a/src/locale/mk_MK.ts
+++ b/src/locale/mk_MK.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Назад до денес',
   ok: 'ОК',
   clear: 'Избриши',
+  week: 'Недела',
   month: 'Месец',
   year: 'Година',
   timeSelect: 'Избери време',

--- a/src/locale/ml_IN.ts
+++ b/src/locale/ml_IN.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'ഇന്നത്തെ ദിവസത്തിലേക്ക് തിരിച്ചു പോകുക',
   ok: 'ശരിയാണ്',
   clear: 'നീക്കം ചെയ്യുക',
+  week: 'ആഴ്ച',
   month: 'മാസം',
   year: 'വർഷം',
   timeSelect: 'സമയം തിരഞ്ഞെടുക്കുക',

--- a/src/locale/mn_MN.ts
+++ b/src/locale/mn_MN.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Өнөөдөрлүү буцах',
   ok: 'OK',
   clear: 'Цэвэрлэх',
+  week: 'Долоо хоног',
   month: 'Сар',
   year: 'Жил',
   timeSelect: 'Цаг сонгох',

--- a/src/locale/ms_MY.ts
+++ b/src/locale/ms_MY.ts
@@ -12,6 +12,7 @@ const locale: Locale = {
   dateSelect: 'Pilih tarikh',
   weekSelect: 'Pilih minggu',
   clear: 'Padam',
+  week: 'Minggu',
   month: 'Bulan',
   year: 'Tahun',
   previousMonth: 'Bulan lepas',

--- a/src/locale/my_MM.ts
+++ b/src/locale/my_MM.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'ယနေ့မတိုင်ခင်သို့',
   ok: 'OK',
   clear: 'ရှင်းမည်',
+  week: 'အပတ်',
   month: 'လ',
   year: 'နှစ်',
   timeSelect: 'အချိန်ကိုရွေး',

--- a/src/locale/nb_NO.ts
+++ b/src/locale/nb_NO.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Gå til i dag',
   ok: 'OK',
   clear: 'Annuller',
+  week: 'Uke',
   month: 'Måned',
   year: 'År',
   timeSelect: 'Velg tidspunkt',

--- a/src/locale/ne_NP.ts
+++ b/src/locale/ne_NP.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'आज फर्कनुहोस्',
   ok: 'ठिक छ',
   clear: 'खाली गर्नुहोस्',
+  week: 'हप्ता',
   month: 'महिना',
   year: 'वर्ष',
   timeSelect: 'समय चयन गर्नुहोस्',

--- a/src/locale/nl_BE.ts
+++ b/src/locale/nl_BE.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Terug naar vandaag',
   ok: 'OK',
   clear: 'Reset',
+  week: 'Week',
   month: 'Maand',
   year: 'Jaar',
   timeSelect: 'Selecteer tijd',

--- a/src/locale/nl_NL.ts
+++ b/src/locale/nl_NL.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Terug naar vandaag',
   ok: 'OK',
   clear: 'Reset',
+  week: 'Week',
   month: 'Maand',
   year: 'Jaar',
   timeSelect: 'Selecteer tijd',

--- a/src/locale/pl_PL.ts
+++ b/src/locale/pl_PL.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Ustaw dzisiaj',
   ok: 'OK',
   clear: 'Wyczyść',
+  week: 'Tydzień',
   month: 'Miesiąc',
   year: 'Rok',
   timeSelect: 'Ustaw czas',

--- a/src/locale/pt_BR.ts
+++ b/src/locale/pt_BR.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Voltar para hoje',
   ok: 'OK',
   clear: 'Limpar',
+  week: 'Semana',
   month: 'Mês',
   year: 'Ano',
   timeSelect: 'Selecionar hora',

--- a/src/locale/pt_PT.ts
+++ b/src/locale/pt_PT.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Hoje',
   ok: 'OK',
   clear: 'Limpar',
+  week: 'Semana',
   month: 'Mês',
   year: 'Ano',
   timeSelect: 'Selecionar hora',

--- a/src/locale/ro_RO.ts
+++ b/src/locale/ro_RO.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Înapoi la azi',
   ok: 'OK',
   clear: 'Șterge',
+  week: 'Săptămână',
   month: 'Lună',
   year: 'An',
   timeSelect: 'selectează timpul',

--- a/src/locale/ru_RU.ts
+++ b/src/locale/ru_RU.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Текущая дата',
   ok: 'ОК',
   clear: 'Очистить',
+  week: 'Неделя',
   month: 'Месяц',
   year: 'Год',
   timeSelect: 'Выбрать время',

--- a/src/locale/si_LK.ts
+++ b/src/locale/si_LK.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'අදට ආපසු',
   ok: 'හරි',
   clear: 'හිස් කරන්න',
+  week: 'සතිය',
   month: 'මාසය',
   year: 'අවුරුද්ද',
   timeSelect: 'වේලාවක් තෝරන්න',

--- a/src/locale/sk_SK.ts
+++ b/src/locale/sk_SK.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Späť na dnes',
   ok: 'OK',
   clear: 'Vymazať',
+  week: 'Týždeň',
   month: 'Mesiac',
   year: 'Rok',
   timeSelect: 'Vybrať čas',

--- a/src/locale/sl_SI.ts
+++ b/src/locale/sl_SI.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Nazaj na danes',
   ok: 'V redu',
   clear: 'Počisti',
+  week: 'Teden',
   month: 'Mesec',
   year: 'Leto',
   timeSelect: 'Izberite čas',

--- a/src/locale/sr_Cyrl_RS.ts
+++ b/src/locale/sr_Cyrl_RS.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Врати се на данас',
   ok: 'У реду',
   clear: 'Обриши',
+  week: 'Недеља',
   month: 'Месец',
   year: 'Година',
   timeSelect: 'Изабери време',

--- a/src/locale/sr_RS.ts
+++ b/src/locale/sr_RS.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Vrati se na danas',
   ok: 'U redu',
   clear: 'Obriši',
+  week: 'Nedelja',
   month: 'Mesec',
   year: 'Godina',
   timeSelect: 'Izaberi vreme',

--- a/src/locale/sv_SE.ts
+++ b/src/locale/sv_SE.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Till idag',
   ok: 'OK',
   clear: 'Avbryt',
+  week: 'Vecka',
   month: 'Månad',
   year: 'År',
   timeSelect: 'Välj tidpunkt',

--- a/src/locale/ta_IN.ts
+++ b/src/locale/ta_IN.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'இன்றுக்கு திரும்பு',
   ok: 'சரி',
   clear: 'அழி',
+  week: 'வாரம்',
   month: 'மாதம்',
   year: 'வருடம்',
   timeSelect: 'நேரத்தைத் தேர்ந்தெடு',

--- a/src/locale/th_TH.ts
+++ b/src/locale/th_TH.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'กลับไปยังวันนี้',
   ok: 'ตกลง',
   clear: 'ลบล้าง',
+  week: 'สัปดาห์',
   month: 'เดือน',
   year: 'ปี',
   timeSelect: 'เลือกเวลา',

--- a/src/locale/tk_TK.ts
+++ b/src/locale/tk_TK.ts
@@ -10,7 +10,7 @@ const locale: Locale = {
   ok: 'Bolýar',
   clear: 'Arassala',
   month: 'Aý',
-  week: 'Gün',
+  week: 'Hepde',
   year: 'Ýyl',
   timeSelect: 'Wagt saýla',
   dateSelect: 'Gün saýla',

--- a/src/locale/tk_TK.ts
+++ b/src/locale/tk_TK.ts
@@ -10,6 +10,7 @@ const locale: Locale = {
   ok: 'Bolýar',
   clear: 'Arassala',
   month: 'Aý',
+  week: 'Gün',
   year: 'Ýyl',
   timeSelect: 'Wagt saýla',
   dateSelect: 'Gün saýla',

--- a/src/locale/tr_TR.ts
+++ b/src/locale/tr_TR.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Bugüne Geri Dön',
   ok: 'Tamam',
   clear: 'Temizle',
+  week: 'Hafta',
   month: 'Ay',
   year: 'Yıl',
   timeSelect: 'Zaman Seç',

--- a/src/locale/ug_CN.ts
+++ b/src/locale/ug_CN.ts
@@ -11,6 +11,7 @@ const locale: Locale = {
   timeSelect: 'ۋاقىت تاللاش',
   dateSelect: 'كۈن تاللاش',
   clear: 'تازىلاش',
+  week: 'ھەپتە',
   month: 'ئاي',
   year: 'يىل',
   previousMonth: 'ئالدىنقى ئاي(ئالدىنقى بەت )',

--- a/src/locale/uk_UA.ts
+++ b/src/locale/uk_UA.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Поточна дата',
   ok: 'OK',
   clear: 'Очистити',
+  week: 'Тиждень',
   month: 'Місяць',
   year: 'Рік',
   timeSelect: 'Обрати час',

--- a/src/locale/ur_PK.ts
+++ b/src/locale/ur_PK.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'آج واپس',
   ok: 'ٹھیک ہے',
   clear: 'صاف',
+  week: 'ہفتہ',
   month: 'مہینہ',
   year: 'سال',
   timeSelect: 'وقت منتخب کریں',

--- a/src/locale/uz_UZ.ts
+++ b/src/locale/uz_UZ.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Bugunga qaytish',
   ok: 'OK',
   clear: 'Toza',
+  week: 'Xafta',
   month: 'Oy',
   year: 'Yil',
   timeSelect: 'vaqtni tanlang',

--- a/src/locale/vi_VN.ts
+++ b/src/locale/vi_VN.ts
@@ -9,6 +9,7 @@ const locale: Locale = {
   backToToday: 'Trở về hôm nay',
   ok: 'OK',
   clear: 'Xóa',
+  week: 'Tuần',
   month: 'Tháng',
   year: 'Năm',
   timeSelect: 'Chọn thời gian',

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -12,6 +12,7 @@ const locale: Locale = {
   dateSelect: '选择日期',
   weekSelect: '选择周',
   clear: '清除',
+  week: '周',
   month: '月',
   year: '年',
   previousMonth: '上个月 (翻页上键)',

--- a/src/locale/zh_TW.ts
+++ b/src/locale/zh_TW.ts
@@ -13,6 +13,7 @@ const locale: Locale = {
   dateSelect: '選擇日期',
   weekSelect: '選擇周',
   clear: '清除',
+  week: '週',
   month: '月',
   year: '年',
   previousMonth: '上個月 (翻頁上鍵)',

--- a/tests/__snapshots__/panel.spec.tsx.snap
+++ b/tests/__snapshots__/panel.spec.tsx.snap
@@ -3395,9 +3395,13 @@ exports[`Picker.Panel append cell with cellRender in week 1`] = `
         >
           <thead>
             <tr>
-              <th
-                aria-label="empty cell"
-              />
+              <th>
+                <span
+                  style="width: 0px; height: 0px; position: absolute; overflow: hidden; opacity: 0;"
+                >
+                  Week
+                </span>
+              </th>
               <th>
                 Su
               </th>
@@ -6954,9 +6958,13 @@ exports[`Picker.Panel override cell with cellRender in week 1`] = `
         >
           <thead>
             <tr>
-              <th
-                aria-label="empty cell"
-              />
+              <th>
+                <span
+                  style="width: 0px; height: 0px; position: absolute; overflow: hidden; opacity: 0;"
+                >
+                  Week
+                </span>
+              </th>
               <th>
                 Su
               </th>

--- a/tests/__snapshots__/panel.spec.tsx.snap
+++ b/tests/__snapshots__/panel.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`Picker.Panel append cell with cellRender in date 1`] = `
         class="rc-picker-header"
       >
         <button
-          aria-label="super-prev-year"
+          aria-label="Last year (Control + left)"
           class="rc-picker-header-super-prev-btn"
           tabindex="-1"
           type="button"
@@ -21,7 +21,7 @@ exports[`Picker.Panel append cell with cellRender in date 1`] = `
           «
         </button>
         <button
-          aria-label="prev-year"
+          aria-label="Previous month (PageUp)"
           class="rc-picker-header-prev-btn"
           tabindex="-1"
           type="button"
@@ -32,7 +32,7 @@ exports[`Picker.Panel append cell with cellRender in date 1`] = `
           class="rc-picker-header-view"
         >
           <button
-            aria-label="month panel"
+            aria-label="Choose a month"
             class="rc-picker-month-btn"
             tabindex="-1"
             type="button"
@@ -40,7 +40,7 @@ exports[`Picker.Panel append cell with cellRender in date 1`] = `
             Sep
           </button>
           <button
-            aria-label="year panel"
+            aria-label="Choose a year"
             class="rc-picker-year-btn"
             tabindex="-1"
             type="button"
@@ -49,7 +49,7 @@ exports[`Picker.Panel append cell with cellRender in date 1`] = `
           </button>
         </div>
         <button
-          aria-label="next-year"
+          aria-label="Next month (PageDown)"
           class="rc-picker-header-next-btn"
           tabindex="-1"
           type="button"
@@ -57,7 +57,7 @@ exports[`Picker.Panel append cell with cellRender in date 1`] = `
           ›
         </button>
         <button
-          aria-label="super-next-year"
+          aria-label="Next year (Control + right)"
           class="rc-picker-header-super-next-btn"
           tabindex="-1"
           type="button"
@@ -718,7 +718,7 @@ exports[`Picker.Panel append cell with cellRender in decade 1`] = `
         class="rc-picker-header"
       >
         <button
-          aria-label="super-prev-year"
+          aria-label="Last year (Control + left)"
           class="rc-picker-header-super-prev-btn"
           tabindex="-1"
           type="button"
@@ -731,7 +731,7 @@ exports[`Picker.Panel append cell with cellRender in decade 1`] = `
           1900-1999
         </div>
         <button
-          aria-label="super-next-year"
+          aria-label="Next year (Control + right)"
           class="rc-picker-header-super-next-btn"
           tabindex="-1"
           type="button"
@@ -931,7 +931,7 @@ exports[`Picker.Panel append cell with cellRender in month 1`] = `
         class="rc-picker-header"
       >
         <button
-          aria-label="super-prev-year"
+          aria-label="Last year (Control + left)"
           class="rc-picker-header-super-prev-btn"
           tabindex="-1"
           type="button"
@@ -942,7 +942,7 @@ exports[`Picker.Panel append cell with cellRender in month 1`] = `
           class="rc-picker-header-view"
         >
           <button
-            aria-label="year panel"
+            aria-label="Choose a year"
             class="rc-picker-year-btn"
             tabindex="-1"
             type="button"
@@ -951,7 +951,7 @@ exports[`Picker.Panel append cell with cellRender in month 1`] = `
           </button>
         </div>
         <button
-          aria-label="super-next-year"
+          aria-label="Next year (Control + right)"
           class="rc-picker-header-super-next-btn"
           tabindex="-1"
           type="button"
@@ -1163,7 +1163,7 @@ exports[`Picker.Panel append cell with cellRender in quarter 1`] = `
         class="rc-picker-header"
       >
         <button
-          aria-label="super-prev-year"
+          aria-label="Last year (Control + left)"
           class="rc-picker-header-super-prev-btn"
           tabindex="-1"
           type="button"
@@ -1174,7 +1174,7 @@ exports[`Picker.Panel append cell with cellRender in quarter 1`] = `
           class="rc-picker-header-view"
         >
           <button
-            aria-label="year panel"
+            aria-label="Choose a year"
             class="rc-picker-year-btn"
             tabindex="-1"
             type="button"
@@ -1183,7 +1183,7 @@ exports[`Picker.Panel append cell with cellRender in quarter 1`] = `
           </button>
         </div>
         <button
-          aria-label="super-next-year"
+          aria-label="Next year (Control + right)"
           class="rc-picker-header-super-next-btn"
           tabindex="-1"
           type="button"
@@ -3335,7 +3335,7 @@ exports[`Picker.Panel append cell with cellRender in week 1`] = `
         class="rc-picker-header"
       >
         <button
-          aria-label="super-prev-year"
+          aria-label="Last year (Control + left)"
           class="rc-picker-header-super-prev-btn"
           tabindex="-1"
           type="button"
@@ -3343,7 +3343,7 @@ exports[`Picker.Panel append cell with cellRender in week 1`] = `
           «
         </button>
         <button
-          aria-label="prev-year"
+          aria-label="Previous month (PageUp)"
           class="rc-picker-header-prev-btn"
           tabindex="-1"
           type="button"
@@ -3354,7 +3354,7 @@ exports[`Picker.Panel append cell with cellRender in week 1`] = `
           class="rc-picker-header-view"
         >
           <button
-            aria-label="month panel"
+            aria-label="Choose a month"
             class="rc-picker-month-btn"
             tabindex="-1"
             type="button"
@@ -3362,7 +3362,7 @@ exports[`Picker.Panel append cell with cellRender in week 1`] = `
             Sep
           </button>
           <button
-            aria-label="year panel"
+            aria-label="Choose a year"
             class="rc-picker-year-btn"
             tabindex="-1"
             type="button"
@@ -3371,7 +3371,7 @@ exports[`Picker.Panel append cell with cellRender in week 1`] = `
           </button>
         </div>
         <button
-          aria-label="next-year"
+          aria-label="Next month (PageDown)"
           class="rc-picker-header-next-btn"
           tabindex="-1"
           type="button"
@@ -3379,7 +3379,7 @@ exports[`Picker.Panel append cell with cellRender in week 1`] = `
           ›
         </button>
         <button
-          aria-label="super-next-year"
+          aria-label="Next year (Control + right)"
           class="rc-picker-header-super-next-btn"
           tabindex="-1"
           type="button"
@@ -4113,7 +4113,7 @@ exports[`Picker.Panel append cell with cellRender in year 1`] = `
         class="rc-picker-header"
       >
         <button
-          aria-label="super-prev-year"
+          aria-label="Last year (Control + left)"
           class="rc-picker-header-super-prev-btn"
           tabindex="-1"
           type="button"
@@ -4124,7 +4124,7 @@ exports[`Picker.Panel append cell with cellRender in year 1`] = `
           class="rc-picker-header-view"
         >
           <button
-            aria-label="decade panel"
+            aria-label="Choose a decade"
             class="rc-picker-decade-btn"
             tabindex="-1"
             type="button"
@@ -4135,7 +4135,7 @@ exports[`Picker.Panel append cell with cellRender in year 1`] = `
           </button>
         </div>
         <button
-          aria-label="super-next-year"
+          aria-label="Next year (Control + right)"
           class="rc-picker-header-super-next-btn"
           tabindex="-1"
           type="button"
@@ -4432,7 +4432,7 @@ exports[`Picker.Panel override cell with cellRender in date 1`] = `
         class="rc-picker-header"
       >
         <button
-          aria-label="super-prev-year"
+          aria-label="Last year (Control + left)"
           class="rc-picker-header-super-prev-btn"
           tabindex="-1"
           type="button"
@@ -4440,7 +4440,7 @@ exports[`Picker.Panel override cell with cellRender in date 1`] = `
           «
         </button>
         <button
-          aria-label="prev-year"
+          aria-label="Previous month (PageUp)"
           class="rc-picker-header-prev-btn"
           tabindex="-1"
           type="button"
@@ -4451,7 +4451,7 @@ exports[`Picker.Panel override cell with cellRender in date 1`] = `
           class="rc-picker-header-view"
         >
           <button
-            aria-label="month panel"
+            aria-label="Choose a month"
             class="rc-picker-month-btn"
             tabindex="-1"
             type="button"
@@ -4459,7 +4459,7 @@ exports[`Picker.Panel override cell with cellRender in date 1`] = `
             Sep
           </button>
           <button
-            aria-label="year panel"
+            aria-label="Choose a year"
             class="rc-picker-year-btn"
             tabindex="-1"
             type="button"
@@ -4468,7 +4468,7 @@ exports[`Picker.Panel override cell with cellRender in date 1`] = `
           </button>
         </div>
         <button
-          aria-label="next-year"
+          aria-label="Next month (PageDown)"
           class="rc-picker-header-next-btn"
           tabindex="-1"
           type="button"
@@ -4476,7 +4476,7 @@ exports[`Picker.Panel override cell with cellRender in date 1`] = `
           ›
         </button>
         <button
-          aria-label="super-next-year"
+          aria-label="Next year (Control + right)"
           class="rc-picker-header-super-next-btn"
           tabindex="-1"
           type="button"
@@ -4969,7 +4969,7 @@ exports[`Picker.Panel override cell with cellRender in decade 1`] = `
         class="rc-picker-header"
       >
         <button
-          aria-label="super-prev-year"
+          aria-label="Last year (Control + left)"
           class="rc-picker-header-super-prev-btn"
           tabindex="-1"
           type="button"
@@ -4982,7 +4982,7 @@ exports[`Picker.Panel override cell with cellRender in decade 1`] = `
           1900-1999
         </div>
         <button
-          aria-label="super-next-year"
+          aria-label="Next year (Control + right)"
           class="rc-picker-header-super-next-btn"
           tabindex="-1"
           type="button"
@@ -5134,7 +5134,7 @@ exports[`Picker.Panel override cell with cellRender in month 1`] = `
         class="rc-picker-header"
       >
         <button
-          aria-label="super-prev-year"
+          aria-label="Last year (Control + left)"
           class="rc-picker-header-super-prev-btn"
           tabindex="-1"
           type="button"
@@ -5145,7 +5145,7 @@ exports[`Picker.Panel override cell with cellRender in month 1`] = `
           class="rc-picker-header-view"
         >
           <button
-            aria-label="year panel"
+            aria-label="Choose a year"
             class="rc-picker-year-btn"
             tabindex="-1"
             type="button"
@@ -5154,7 +5154,7 @@ exports[`Picker.Panel override cell with cellRender in month 1`] = `
           </button>
         </div>
         <button
-          aria-label="super-next-year"
+          aria-label="Next year (Control + right)"
           class="rc-picker-header-super-next-btn"
           tabindex="-1"
           type="button"
@@ -5318,7 +5318,7 @@ exports[`Picker.Panel override cell with cellRender in quarter 1`] = `
         class="rc-picker-header"
       >
         <button
-          aria-label="super-prev-year"
+          aria-label="Last year (Control + left)"
           class="rc-picker-header-super-prev-btn"
           tabindex="-1"
           type="button"
@@ -5329,7 +5329,7 @@ exports[`Picker.Panel override cell with cellRender in quarter 1`] = `
           class="rc-picker-header-view"
         >
           <button
-            aria-label="year panel"
+            aria-label="Choose a year"
             class="rc-picker-year-btn"
             tabindex="-1"
             type="button"
@@ -5338,7 +5338,7 @@ exports[`Picker.Panel override cell with cellRender in quarter 1`] = `
           </button>
         </div>
         <button
-          aria-label="super-next-year"
+          aria-label="Next year (Control + right)"
           class="rc-picker-header-super-next-btn"
           tabindex="-1"
           type="button"
@@ -6898,7 +6898,7 @@ exports[`Picker.Panel override cell with cellRender in week 1`] = `
         class="rc-picker-header"
       >
         <button
-          aria-label="super-prev-year"
+          aria-label="Last year (Control + left)"
           class="rc-picker-header-super-prev-btn"
           tabindex="-1"
           type="button"
@@ -6906,7 +6906,7 @@ exports[`Picker.Panel override cell with cellRender in week 1`] = `
           «
         </button>
         <button
-          aria-label="prev-year"
+          aria-label="Previous month (PageUp)"
           class="rc-picker-header-prev-btn"
           tabindex="-1"
           type="button"
@@ -6917,7 +6917,7 @@ exports[`Picker.Panel override cell with cellRender in week 1`] = `
           class="rc-picker-header-view"
         >
           <button
-            aria-label="month panel"
+            aria-label="Choose a month"
             class="rc-picker-month-btn"
             tabindex="-1"
             type="button"
@@ -6925,7 +6925,7 @@ exports[`Picker.Panel override cell with cellRender in week 1`] = `
             Sep
           </button>
           <button
-            aria-label="year panel"
+            aria-label="Choose a year"
             class="rc-picker-year-btn"
             tabindex="-1"
             type="button"
@@ -6934,7 +6934,7 @@ exports[`Picker.Panel override cell with cellRender in week 1`] = `
           </button>
         </div>
         <button
-          aria-label="next-year"
+          aria-label="Next month (PageDown)"
           class="rc-picker-header-next-btn"
           tabindex="-1"
           type="button"
@@ -6942,7 +6942,7 @@ exports[`Picker.Panel override cell with cellRender in week 1`] = `
           ›
         </button>
         <button
-          aria-label="super-next-year"
+          aria-label="Next year (Control + right)"
           class="rc-picker-header-super-next-btn"
           tabindex="-1"
           type="button"
@@ -7508,7 +7508,7 @@ exports[`Picker.Panel override cell with cellRender in year 1`] = `
         class="rc-picker-header"
       >
         <button
-          aria-label="super-prev-year"
+          aria-label="Last year (Control + left)"
           class="rc-picker-header-super-prev-btn"
           tabindex="-1"
           type="button"
@@ -7519,7 +7519,7 @@ exports[`Picker.Panel override cell with cellRender in year 1`] = `
           class="rc-picker-header-view"
         >
           <button
-            aria-label="decade panel"
+            aria-label="Choose a decade"
             class="rc-picker-decade-btn"
             tabindex="-1"
             type="button"
@@ -7530,7 +7530,7 @@ exports[`Picker.Panel override cell with cellRender in year 1`] = `
           </button>
         </div>
         <button
-          aria-label="super-next-year"
+          aria-label="Next year (Control + right)"
           class="rc-picker-header-super-next-btn"
           tabindex="-1"
           type="button"
@@ -7697,7 +7697,7 @@ exports[`Picker.Panel override cell with cellRender when pass showTime 1`] = `
           class="rc-picker-header"
         >
           <button
-            aria-label="super-prev-year"
+            aria-label="Last year (Control + left)"
             class="rc-picker-header-super-prev-btn"
             tabindex="-1"
             type="button"
@@ -7705,7 +7705,7 @@ exports[`Picker.Panel override cell with cellRender when pass showTime 1`] = `
             «
           </button>
           <button
-            aria-label="prev-year"
+            aria-label="Previous month (PageUp)"
             class="rc-picker-header-prev-btn"
             tabindex="-1"
             type="button"
@@ -7716,7 +7716,7 @@ exports[`Picker.Panel override cell with cellRender when pass showTime 1`] = `
             class="rc-picker-header-view"
           >
             <button
-              aria-label="month panel"
+              aria-label="Choose a month"
               class="rc-picker-month-btn"
               tabindex="-1"
               type="button"
@@ -7724,7 +7724,7 @@ exports[`Picker.Panel override cell with cellRender when pass showTime 1`] = `
               Sep
             </button>
             <button
-              aria-label="year panel"
+              aria-label="Choose a year"
               class="rc-picker-year-btn"
               tabindex="-1"
               type="button"
@@ -7733,7 +7733,7 @@ exports[`Picker.Panel override cell with cellRender when pass showTime 1`] = `
             </button>
           </div>
           <button
-            aria-label="next-year"
+            aria-label="Next month (PageDown)"
             class="rc-picker-header-next-btn"
             tabindex="-1"
             type="button"
@@ -7741,7 +7741,7 @@ exports[`Picker.Panel override cell with cellRender when pass showTime 1`] = `
             ›
           </button>
           <button
-            aria-label="super-next-year"
+            aria-label="Next year (Control + right)"
             class="rc-picker-header-super-next-btn"
             tabindex="-1"
             type="button"
@@ -9840,7 +9840,7 @@ exports[`Picker.Panel should render correctly in rtl 1`] = `
         class="rc-picker-header"
       >
         <button
-          aria-label="super-prev-year"
+          aria-label="Last year (Control + left)"
           class="rc-picker-header-super-prev-btn"
           tabindex="-1"
           type="button"
@@ -9848,7 +9848,7 @@ exports[`Picker.Panel should render correctly in rtl 1`] = `
           «
         </button>
         <button
-          aria-label="prev-year"
+          aria-label="Previous month (PageUp)"
           class="rc-picker-header-prev-btn"
           tabindex="-1"
           type="button"
@@ -9859,7 +9859,7 @@ exports[`Picker.Panel should render correctly in rtl 1`] = `
           class="rc-picker-header-view"
         >
           <button
-            aria-label="month panel"
+            aria-label="Choose a month"
             class="rc-picker-month-btn"
             tabindex="-1"
             type="button"
@@ -9867,7 +9867,7 @@ exports[`Picker.Panel should render correctly in rtl 1`] = `
             Sep
           </button>
           <button
-            aria-label="year panel"
+            aria-label="Choose a year"
             class="rc-picker-year-btn"
             tabindex="-1"
             type="button"
@@ -9876,7 +9876,7 @@ exports[`Picker.Panel should render correctly in rtl 1`] = `
           </button>
         </div>
         <button
-          aria-label="next-year"
+          aria-label="Next month (PageDown)"
           class="rc-picker-header-next-btn"
           tabindex="-1"
           type="button"
@@ -9884,7 +9884,7 @@ exports[`Picker.Panel should render correctly in rtl 1`] = `
           ›
         </button>
         <button
-          aria-label="super-next-year"
+          aria-label="Next year (Control + right)"
           class="rc-picker-header-super-next-btn"
           tabindex="-1"
           type="button"

--- a/tests/__snapshots__/range.spec.tsx.snap
+++ b/tests/__snapshots__/range.spec.tsx.snap
@@ -275,7 +275,7 @@ exports[`Picker.Range use dateRender and monthCellRender in date range picker 1`
                       class="rc-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="上一年 (Control键加左方向键)"
                         class="rc-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -283,7 +283,7 @@ exports[`Picker.Range use dateRender and monthCellRender in date range picker 1`
                         «
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="上个月 (翻页上键)"
                         class="rc-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -294,7 +294,7 @@ exports[`Picker.Range use dateRender and monthCellRender in date range picker 1`
                         class="rc-picker-header-view"
                       >
                         <button
-                          aria-label="year panel"
+                          aria-label="选择年份"
                           class="rc-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -302,7 +302,7 @@ exports[`Picker.Range use dateRender and monthCellRender in date range picker 1`
                           1990年
                         </button>
                         <button
-                          aria-label="month panel"
+                          aria-label="选择月份"
                           class="rc-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -311,7 +311,7 @@ exports[`Picker.Range use dateRender and monthCellRender in date range picker 1`
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="下个月 (翻页下键)"
                         class="rc-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -320,7 +320,7 @@ exports[`Picker.Range use dateRender and monthCellRender in date range picker 1`
                         ›
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="下一年 (Control键加右方向键)"
                         class="rc-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -767,7 +767,7 @@ exports[`Picker.Range use dateRender and monthCellRender in date range picker 1`
                       class="rc-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="上一年 (Control键加左方向键)"
                         class="rc-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -776,7 +776,7 @@ exports[`Picker.Range use dateRender and monthCellRender in date range picker 1`
                         «
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="上个月 (翻页上键)"
                         class="rc-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -788,7 +788,7 @@ exports[`Picker.Range use dateRender and monthCellRender in date range picker 1`
                         class="rc-picker-header-view"
                       >
                         <button
-                          aria-label="year panel"
+                          aria-label="选择年份"
                           class="rc-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -796,7 +796,7 @@ exports[`Picker.Range use dateRender and monthCellRender in date range picker 1`
                           1990年
                         </button>
                         <button
-                          aria-label="month panel"
+                          aria-label="选择月份"
                           class="rc-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -805,7 +805,7 @@ exports[`Picker.Range use dateRender and monthCellRender in date range picker 1`
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="下个月 (翻页下键)"
                         class="rc-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -813,7 +813,7 @@ exports[`Picker.Range use dateRender and monthCellRender in date range picker 1`
                         ›
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="下一年 (Control键加右方向键)"
                         class="rc-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -1332,7 +1332,7 @@ exports[`Picker.Range use dateRender and monthCellRender in month range picker 1
                       class="rc-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="上一年 (Control键加左方向键)"
                         class="rc-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -1343,7 +1343,7 @@ exports[`Picker.Range use dateRender and monthCellRender in month range picker 1
                         class="rc-picker-header-view"
                       >
                         <button
-                          aria-label="year panel"
+                          aria-label="选择年份"
                           class="rc-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -1352,7 +1352,7 @@ exports[`Picker.Range use dateRender and monthCellRender in month range picker 1
                         </button>
                       </div>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="下一年 (Control键加右方向键)"
                         class="rc-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -1500,7 +1500,7 @@ exports[`Picker.Range use dateRender and monthCellRender in month range picker 1
                       class="rc-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="上一年 (Control键加左方向键)"
                         class="rc-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -1512,7 +1512,7 @@ exports[`Picker.Range use dateRender and monthCellRender in month range picker 1
                         class="rc-picker-header-view"
                       >
                         <button
-                          aria-label="year panel"
+                          aria-label="选择年份"
                           class="rc-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -1521,7 +1521,7 @@ exports[`Picker.Range use dateRender and monthCellRender in month range picker 1
                         </button>
                       </div>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="下一年 (Control键加右方向键)"
                         class="rc-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"


### PR DESCRIPTION
空表头单元格影响读屏器理解表格结构
顺便给读屏器内容添加了国际化支持

![QQ_1737701389560](https://github.com/user-attachments/assets/a2e4e043-ee54-477e-ba5c-8bd8e49b49d8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **无障碍性改进**
	- 为日期面板中的空单元格和按钮添加了本地化的屏幕阅读器友好标签
	- 改进了各个面板的按钮可访问性，使用动态的本地化字符串替代静态标签
- **本地化增强**
	- 在多种语言的本地化文件中添加了“week”属性，提供对应语言的“周”翻译

<!-- end of auto-generated comment: release notes by coderabbit.ai -->