### PR TITLE
fix: value is not work when set to null

### DIFF
--- a/src/PickerInput/hooks/useRangeValue.ts
+++ b/src/PickerInput/hooks/useRangeValue.ts
@@ -116,9 +116,10 @@ export function useInnerValue<ValueType extends DateType[], DateType extends obj
   ) => void,
   onOk?: (dates: ValueType) => void,
 ) {
+  const isNullValue = value === null;
   // This is the root value which will sync with controlled or uncontrolled value
   const [innerValue, setInnerValue] = useMergedState(defaultValue, {
-    value: value || undefined,
+    value: isNullValue ? undefined : value,
   });
   const mergedValue = innerValue || (EMPTY_VALUE as ValueType);
 

--- a/src/PickerInput/hooks/useRangeValue.ts
+++ b/src/PickerInput/hooks/useRangeValue.ts
@@ -117,7 +117,9 @@ export function useInnerValue<ValueType extends DateType[], DateType extends obj
   onOk?: (dates: ValueType) => void,
 ) {
   // This is the root value which will sync with controlled or uncontrolled value
-  const [innerValue, setInnerValue] = useMergedState(defaultValue, { value });
+  const [innerValue, setInnerValue] = useMergedState(defaultValue, {
+    value: value || undefined,
+  });
   const mergedValue = innerValue || (EMPTY_VALUE as ValueType);
 
   // ========================= Inner Values =========================


### PR DESCRIPTION
The root cause is that the useMergedState hook in the rc-utils library does not handle the case where value is null correctly.

It considers null as hasValue, which leads to incorrect state management.

Half a year ago, we encountered the issue where defaultValue did not work when value was null, and we patched it specifically for defaultValue.

However, recently we discovered that when value is null, the UI also becomes completely non-functional, which is confusing.

If rc-util cannot be updated for some reason, then we will have to handle the update and compatibility at the application level. After all, it is very abnormal that passing null to value does not work, while passing undefined works as expected.

The solution is to replace null with undefined when the value is empty, as useMergedState can handle undefined properly.

fix: https://github.com/react-component/picker/issues/912
refer:  https://github.com/react-component/util/pull/578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 优化了组件在处理空值时的状态初始化，确保更明确地将 `null` 值处理为 `undefined`，提高了整体的可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->