### PR TITLE
fix: needConfirm false should not trigger open in SinglePicker

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
 module.exports = {
-  setupFiles: ['./tests/setup.js'],
   coveragePathIgnorePatterns: ['src/locale/', 'tests/'],
 };

--- a/src/PickerInput/SinglePicker.tsx
+++ b/src/PickerInput/SinglePicker.tsx
@@ -603,7 +603,6 @@ function Picker<DateType extends object = any>(
 
     // Submit with complex picker
     if (!mergedOpen && complexPicker && !needConfirm && lastOp === 'panel') {
-      triggerOpen(true);
       triggerConfirm();
     }
   }, [mergedOpen]);

--- a/tests/new-range.spec.tsx
+++ b/tests/new-range.spec.tsx
@@ -785,6 +785,32 @@ describe('NewPicker.Range', () => {
       expect(container.querySelectorAll('input')[0]).toHaveValue('1990-09-05');
       expect(container.querySelectorAll('input')[1]).toHaveValue('1990-09-05');
     });
+
+    it('not trigger open when !needConfirm', () => {
+      const onChange = jest.fn();
+      const onOpenChange = jest.fn();
+
+      const { container } = render(
+        <DayPicker showTime onChange={onChange} onOpenChange={onOpenChange} needConfirm={false} />,
+      );
+      openPicker(container);
+
+      fireEvent.click(findCell(5));
+
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+
+      // Window click to close
+      fireEvent.mouseDown(document.body);
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(onOpenChange).toHaveBeenCalledTimes(2);
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
   });
 
   describe('open', () => {


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/52973

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 优化了选择器组件的交互逻辑：当操作无需确认时，选择器不再自动展开，避免了意外触发，确保用户操作更加精准和流畅，整体体验更为直观。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->