### PR TITLE
fix: remove outdated `dateFormat`/ `dateTimeFormat` from locale files

### DIFF
--- a/src/PickerInput/Selector/hooks/useInputProps.ts
+++ b/src/PickerInput/Selector/hooks/useInputProps.ts
@@ -4,6 +4,7 @@ import * as React from 'react';
 import type { SelectorProps } from '../../../interface';
 import { formatValue } from '../../../utils/dateUtil';
 import type { InputProps } from '../Input';
+import { toArray } from '../../../utils/miscUtil';
 
 export default function useInputProps<DateType extends object = any>(
   props: Pick<
@@ -128,7 +129,7 @@ export default function useInputProps<DateType extends object = any>(
   // ======================== Input =========================
   const getInputProps = (index?: number): InputProps => {
     function getProp<T>(propValue: T | T[]): T {
-      return index !== undefined ? propValue[index] : propValue;
+      return toArray(propValue)[index || 0];
     }
 
     const pickedAttrs = pickAttrs(props, {

--- a/src/locale/am_ET.ts
+++ b/src/locale/am_ET.ts
@@ -17,7 +17,6 @@ const locale: Locale = {
   yearSelect: 'አመት ምረጥ',
   decadeSelect: 'አስርት አመታት ምረጥ',
   yearFormat: 'YYYY',
-  dateFormat: 'D/M/YYYY',
   dayFormat: 'D',
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
   monthBeforeYear: true,

--- a/src/locale/am_ET.ts
+++ b/src/locale/am_ET.ts
@@ -18,7 +18,6 @@ const locale: Locale = {
   decadeSelect: 'አስርት አመታት ምረጥ',
   yearFormat: 'YYYY',
   dayFormat: 'D',
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
   monthBeforeYear: true,
   previousMonth: 'ያለፈው ወር (PageUp)',
   nextMonth: 'ቀጣይ ወር (PageDown)',

--- a/src/locale/ar_EG.ts
+++ b/src/locale/ar_EG.ts
@@ -17,7 +17,6 @@ const locale: Locale = {
   monthSelect: 'اختيار الشهر',
   yearSelect: 'اختيار السنة',
   decadeSelect: 'اختيار العقد',
-  dateTimeFormat: 'M/D/YYYY HH:mm:ss',
   previousMonth: 'الشهر السابق (PageUp)',
   nextMonth: 'الشهر التالى(PageDown)',
   previousYear: 'العام السابق (Control + left)',

--- a/src/locale/ar_EG.ts
+++ b/src/locale/ar_EG.ts
@@ -17,7 +17,6 @@ const locale: Locale = {
   monthSelect: 'اختيار الشهر',
   yearSelect: 'اختيار السنة',
   decadeSelect: 'اختيار العقد',
-  dateFormat: 'M/D/YYYY',
   dateTimeFormat: 'M/D/YYYY HH:mm:ss',
   previousMonth: 'الشهر السابق (PageUp)',
   nextMonth: 'الشهر التالى(PageDown)',

--- a/src/locale/az_AZ.ts
+++ b/src/locale/az_AZ.ts
@@ -18,7 +18,6 @@ const locale: Locale = {
   monthSelect: 'Ay seç',
   yearSelect: 'il seç',
   decadeSelect: 'Onillik seçin',
-  dateFormat: 'D.M.YYYY',
   dateTimeFormat: 'D.M.YYYY HH:mm:ss',
   previousMonth: 'Əvvəlki ay (PageUp)',
   nextMonth: 'Növbəti ay (PageDown)',

--- a/src/locale/az_AZ.ts
+++ b/src/locale/az_AZ.ts
@@ -18,7 +18,6 @@ const locale: Locale = {
   monthSelect: 'Ay seç',
   yearSelect: 'il seç',
   decadeSelect: 'Onillik seçin',
-  dateTimeFormat: 'D.M.YYYY HH:mm:ss',
   previousMonth: 'Əvvəlki ay (PageUp)',
   nextMonth: 'Növbəti ay (PageDown)',
   previousYear: 'Sonuncu il (Control + left)',

--- a/src/locale/bg_BG.ts
+++ b/src/locale/bg_BG.ts
@@ -17,7 +17,6 @@ const locale: Locale = {
   monthSelect: 'Избор на месец',
   yearSelect: 'Избор на година',
   decadeSelect: 'Десетилетие',
-  dateFormat: 'D M YYYY',
   dateTimeFormat: 'D M YYYY HH:mm:ss',
   previousMonth: 'Предишен месец (PageUp)',
   nextMonth: 'Следващ месец (PageDown)',

--- a/src/locale/bg_BG.ts
+++ b/src/locale/bg_BG.ts
@@ -17,7 +17,6 @@ const locale: Locale = {
   monthSelect: 'Избор на месец',
   yearSelect: 'Избор на година',
   decadeSelect: 'Десетилетие',
-  dateTimeFormat: 'D M YYYY HH:mm:ss',
   previousMonth: 'Предишен месец (PageUp)',
   nextMonth: 'Следващ месец (PageDown)',
   previousYear: 'Последна година (Control + left)',

--- a/src/locale/bn_BD.ts
+++ b/src/locale/bn_BD.ts
@@ -18,7 +18,6 @@ const locale: Locale = {
   monthSelect: 'মাস পছন্দ করুন',
   yearSelect: 'বছর পছন্দ করুন',
   decadeSelect: 'একটি দশক পছন্দ করুন',
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
   previousMonth: 'গত মাস (PageUp)',
   nextMonth: 'আগামী মাস (PageDown)',
   previousYear: 'গত বছর (Control + left)',

--- a/src/locale/bn_BD.ts
+++ b/src/locale/bn_BD.ts
@@ -18,7 +18,6 @@ const locale: Locale = {
   monthSelect: 'মাস পছন্দ করুন',
   yearSelect: 'বছর পছন্দ করুন',
   decadeSelect: 'একটি দশক পছন্দ করুন',
-  dateFormat: 'M/D/YYYY',
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
   previousMonth: 'গত মাস (PageUp)',
   nextMonth: 'আগামী মাস (PageDown)',

--- a/src/locale/by_BY.ts
+++ b/src/locale/by_BY.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Выбраць год',
   decadeSelect: 'Выбраць дзесяцігоддзе',
 
-  dateFormat: 'D-M-YYYY',
-
   dateTimeFormat: 'D-M-YYYY HH:mm:ss',
 
   previousMonth: 'Папярэдні месяц (PageUp)',

--- a/src/locale/by_BY.ts
+++ b/src/locale/by_BY.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Выбраць год',
   decadeSelect: 'Выбраць дзесяцігоддзе',
 
-  dateTimeFormat: 'D-M-YYYY HH:mm:ss',
-
   previousMonth: 'Папярэдні месяц (PageUp)',
   nextMonth: 'Наступны месяц (PageDown)',
   previousYear: 'Папярэдні год (Control + left)',

--- a/src/locale/ca_ES.ts
+++ b/src/locale/ca_ES.ts
@@ -17,7 +17,6 @@ const locale: Locale = {
   monthSelect: 'Escollir un mes',
   yearSelect: 'Escollir un any',
   decadeSelect: 'Escollir una dècada',
-  dateFormat: 'D/M/YYYY',
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
   previousMonth: 'Mes anterior (PageUp)',
   nextMonth: 'Mes següent (PageDown)',

--- a/src/locale/ca_ES.ts
+++ b/src/locale/ca_ES.ts
@@ -17,7 +17,6 @@ const locale: Locale = {
   monthSelect: 'Escollir un mes',
   yearSelect: 'Escollir un any',
   decadeSelect: 'Escollir una dècada',
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
   previousMonth: 'Mes anterior (PageUp)',
   nextMonth: 'Mes següent (PageDown)',
   previousYear: 'Any anterior (Control + left)',

--- a/src/locale/cs_CZ.ts
+++ b/src/locale/cs_CZ.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Vyberte rok',
   decadeSelect: 'Vyberte dekádu',
 
-  dateTimeFormat: 'D.M.YYYY HH:mm:ss',
-
   previousMonth: 'Předchozí měsíc (PageUp)',
   nextMonth: 'Následující (PageDown)',
   previousYear: 'Předchozí rok (Control + left)',

--- a/src/locale/cs_CZ.ts
+++ b/src/locale/cs_CZ.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Vyberte rok',
   decadeSelect: 'Vyberte dekádu',
 
-  dateFormat: 'D.M.YYYY',
-
   dateTimeFormat: 'D.M.YYYY HH:mm:ss',
 
   previousMonth: 'Předchozí měsíc (PageUp)',

--- a/src/locale/da_DK.ts
+++ b/src/locale/da_DK.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Vælg år',
   decadeSelect: 'Vælg årti',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Forrige måned (Page Up)',
   nextMonth: 'Næste måned (Page Down)',
   previousYear: 'Forrige år (Ctrl-venstre pil)',

--- a/src/locale/da_DK.ts
+++ b/src/locale/da_DK.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Vælg år',
   decadeSelect: 'Vælg årti',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Forrige måned (Page Up)',

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Wähle ein Jahr',
   decadeSelect: 'Wähle ein Jahrzehnt',
 
-  dateFormat: 'D.M.YYYY',
-
   dateTimeFormat: 'D.M.YYYY HH:mm:ss',
 
   previousMonth: 'Vorheriger Monat (PageUp)',

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Wähle ein Jahr',
   decadeSelect: 'Wähle ein Jahrzehnt',
 
-  dateTimeFormat: 'D.M.YYYY HH:mm:ss',
-
   previousMonth: 'Vorheriger Monat (PageUp)',
   nextMonth: 'Nächster Monat (PageDown)',
   previousYear: 'Vorheriges Jahr (Ctrl + left)',

--- a/src/locale/el_GR.ts
+++ b/src/locale/el_GR.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Επιλογή έτους',
   decadeSelect: 'Επιλογή δεκαετίας',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Προηγούμενος μήνας (PageUp)',

--- a/src/locale/el_GR.ts
+++ b/src/locale/el_GR.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Επιλογή έτους',
   decadeSelect: 'Επιλογή δεκαετίας',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Προηγούμενος μήνας (PageUp)',
   nextMonth: 'Επόμενος μήνας (PageDown)',
   previousYear: 'Προηγούμενο έτος (Control + αριστερά)',

--- a/src/locale/en_GB.ts
+++ b/src/locale/en_GB.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Choose a year',
   decadeSelect: 'Choose a decade',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Previous month (PageUp)',

--- a/src/locale/en_GB.ts
+++ b/src/locale/en_GB.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Choose a year',
   decadeSelect: 'Choose a decade',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Previous month (PageUp)',
   nextMonth: 'Next month (PageDown)',
   previousYear: 'Last year (Control + left)',

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Choose a year',
   decadeSelect: 'Choose a decade',
 
-  dateFormat: 'M/D/YYYY',
-
   dateTimeFormat: 'M/D/YYYY HH:mm:ss',
 
   previousMonth: 'Previous month (PageUp)',

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Choose a year',
   decadeSelect: 'Choose a decade',
 
-  dateTimeFormat: 'M/D/YYYY HH:mm:ss',
-
   previousMonth: 'Previous month (PageUp)',
   nextMonth: 'Next month (PageDown)',
   previousYear: 'Last year (Control + left)',

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Elegir un año',
   decadeSelect: 'Elegir una década',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Mes anterior (PageUp)',

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Elegir un año',
   decadeSelect: 'Elegir una década',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Mes anterior (PageUp)',
   nextMonth: 'Mes siguiente (PageDown)',
   previousYear: 'Año anterior (Control + left)',

--- a/src/locale/es_MX.ts
+++ b/src/locale/es_MX.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Seleccionar año',
   decadeSelect: 'Seleccionar década',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Mes anterior (PageUp)',
   nextMonth: 'Mes siguiente (PageDown)',
   previousYear: 'Año anterior (Control + Left)',

--- a/src/locale/es_MX.ts
+++ b/src/locale/es_MX.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Seleccionar año',
   decadeSelect: 'Seleccionar década',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Mes anterior (PageUp)',

--- a/src/locale/et_EE.ts
+++ b/src/locale/et_EE.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Vali aasta',
   decadeSelect: 'Vali dekaad',
 
-  dateFormat: 'D.M.YYYY',
-
   dateTimeFormat: 'D.M.YYYY HH:mm:ss',
 
   previousMonth: 'Eelmine kuu (PageUp)',

--- a/src/locale/et_EE.ts
+++ b/src/locale/et_EE.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Vali aasta',
   decadeSelect: 'Vali dekaad',
 
-  dateTimeFormat: 'D.M.YYYY HH:mm:ss',
-
   previousMonth: 'Eelmine kuu (PageUp)',
   nextMonth: 'Järgmine kuu (PageDown)',
   previousYear: 'Eelmine aasta (Control + left)',

--- a/src/locale/eu_ES.ts
+++ b/src/locale/eu_ES.ts
@@ -18,7 +18,6 @@ const locale: Locale = {
   monthSelect: 'Hilabetea aukeratu',
   yearSelect: 'Urtea aukeratu',
   decadeSelect: 'Hamarkada aukeratu',
-  dateFormat: 'YYYY/M/D',
   dateTimeFormat: 'YYYY/M/D HH:mm:ss',
   monthBeforeYear: false,
   previousMonth: 'Aurreko hilabetea (RePag)',

--- a/src/locale/eu_ES.ts
+++ b/src/locale/eu_ES.ts
@@ -18,7 +18,6 @@ const locale: Locale = {
   monthSelect: 'Hilabetea aukeratu',
   yearSelect: 'Urtea aukeratu',
   decadeSelect: 'Hamarkada aukeratu',
-  dateTimeFormat: 'YYYY/M/D HH:mm:ss',
   monthBeforeYear: false,
   previousMonth: 'Aurreko hilabetea (RePag)',
   nextMonth: 'Urrengo hilabetea (AvPag)',

--- a/src/locale/fa_IR.ts
+++ b/src/locale/fa_IR.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'یک سال را انتخاب کنید',
   decadeSelect: 'یک دهه را انتخاب کنید',
 
-  dateTimeFormat: 'M/D/YYYY HH:mm:ss',
-
   previousMonth: 'ماه قبل (PageUp)',
   nextMonth: 'ماه بعد (PageDown)',
   previousYear: 'سال قبل (Control + left)',

--- a/src/locale/fa_IR.ts
+++ b/src/locale/fa_IR.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'یک سال را انتخاب کنید',
   decadeSelect: 'یک دهه را انتخاب کنید',
 
-  dateFormat: 'M/D/YYYY',
-
   dateTimeFormat: 'M/D/YYYY HH:mm:ss',
 
   previousMonth: 'ماه قبل (PageUp)',

--- a/src/locale/fi_FI.ts
+++ b/src/locale/fi_FI.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Valitse vuosi',
   decadeSelect: 'Valitse vuosikymmen',
 
-  dateTimeFormat: 'D.M.YYYY HH:mm:ss',
-
   previousMonth: 'Edellinen kuukausi (PageUp)',
   nextMonth: 'Seuraava kuukausi (PageDown)',
   previousYear: 'Edellinen vuosi (Control + left)',

--- a/src/locale/fi_FI.ts
+++ b/src/locale/fi_FI.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Valitse vuosi',
   decadeSelect: 'Valitse vuosikymmen',
 
-  dateFormat: 'D.M.YYYY',
-
   dateTimeFormat: 'D.M.YYYY HH:mm:ss',
 
   previousMonth: 'Edellinen kuukausi (PageUp)',

--- a/src/locale/fr_BE.ts
+++ b/src/locale/fr_BE.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Choisissez une année',
   decadeSelect: 'Choisissez une décennie',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Mois précédent (PageUp)',

--- a/src/locale/fr_BE.ts
+++ b/src/locale/fr_BE.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Choisissez une année',
   decadeSelect: 'Choisissez une décennie',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Mois précédent (PageUp)',
   nextMonth: 'Mois suivant (PageDown)',
   previousYear: 'Année précédente (Ctrl + gauche)',

--- a/src/locale/fr_CA.ts
+++ b/src/locale/fr_CA.ts
@@ -19,7 +19,6 @@ const locale: Locale = {
   decadeSelect: 'Choisissez une décennie',
 
   dayFormat: 'DD',
-  dateTimeFormat: 'DD/MM/YYYY HH:mm:ss',
 
   previousMonth: 'Mois précédent (PageUp)',
   nextMonth: 'Mois suivant (PageDown)',

--- a/src/locale/fr_CA.ts
+++ b/src/locale/fr_CA.ts
@@ -18,7 +18,6 @@ const locale: Locale = {
   yearSelect: 'Choisissez une année',
   decadeSelect: 'Choisissez une décennie',
 
-  dateFormat: 'DD/MM/YYYY',
   dayFormat: 'DD',
   dateTimeFormat: 'DD/MM/YYYY HH:mm:ss',
 

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -19,7 +19,6 @@ const locale: Locale = {
   decadeSelect: 'Choisissez une décennie',
 
   dayFormat: 'DD',
-  dateTimeFormat: 'DD/MM/YYYY HH:mm:ss',
 
   previousMonth: 'Mois précédent (PageUp)',
   nextMonth: 'Mois suivant (PageDown)',

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -18,7 +18,6 @@ const locale: Locale = {
   yearSelect: 'Choisissez une année',
   decadeSelect: 'Choisissez une décennie',
 
-  dateFormat: 'DD/MM/YYYY',
   dayFormat: 'DD',
   dateTimeFormat: 'DD/MM/YYYY HH:mm:ss',
 

--- a/src/locale/ga_IE.ts
+++ b/src/locale/ga_IE.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Roghnaigh bliain',
   decadeSelect: 'Roghnaigh deich mbliana',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'An mhí roimhe seo (PageUp)',

--- a/src/locale/ga_IE.ts
+++ b/src/locale/ga_IE.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Roghnaigh bliain',
   decadeSelect: 'Roghnaigh deich mbliana',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'An mhí roimhe seo (PageUp)',
   nextMonth: 'An mhí seo chugainn (PageDown)',
   previousYear: 'Anuraidh (Control + left)',

--- a/src/locale/gl_ES.ts
+++ b/src/locale/gl_ES.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Elexir un año',
   decadeSelect: 'Elexir unha década',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Mes anterior (PageUp)',

--- a/src/locale/gl_ES.ts
+++ b/src/locale/gl_ES.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Elexir un año',
   decadeSelect: 'Elexir unha década',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Mes anterior (PageUp)',
   nextMonth: 'Mes seguinte (PageDown)',
   previousYear: 'Ano anterior (Control + left)',

--- a/src/locale/he_IL.ts
+++ b/src/locale/he_IL.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'בחר שנה',
   decadeSelect: 'בחר עשור',
 
-  dateFormat: 'M/D/YYYY',
-
   dateTimeFormat: 'M/D/YYYY HH:mm:ss',
 
   previousMonth: 'חודש קודם (PageUp)',

--- a/src/locale/he_IL.ts
+++ b/src/locale/he_IL.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'בחר שנה',
   decadeSelect: 'בחר עשור',
 
-  dateTimeFormat: 'M/D/YYYY HH:mm:ss',
-
   previousMonth: 'חודש קודם (PageUp)',
   nextMonth: 'חודש הבא (PageDown)',
   previousYear: 'שנה שעברה (Control + left)',

--- a/src/locale/hi_IN.ts
+++ b/src/locale/hi_IN.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'एक वर्ष चुनें',
   decadeSelect: 'एक दशक चुनें',
 
-  dateTimeFormat: 'M/D/YYYY HH:mm:ss',
-
   previousMonth: 'पिछला महीना (पेजअप)',
   nextMonth: 'अगले महीने (पेजडाउन)',
   previousYear: 'पिछले साल (Ctrl + बाएं)',

--- a/src/locale/hi_IN.ts
+++ b/src/locale/hi_IN.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'एक वर्ष चुनें',
   decadeSelect: 'एक दशक चुनें',
 
-  dateFormat: 'M/D/YYYY',
-
   dateTimeFormat: 'M/D/YYYY HH:mm:ss',
 
   previousMonth: 'पिछला महीना (पेजअप)',

--- a/src/locale/hr_HR.ts
+++ b/src/locale/hr_HR.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Odaberite godinu',
   decadeSelect: 'Odaberite desetljeće',
 
-  dateTimeFormat: 'D.M.YYYY HH:mm:ss',
-
   previousMonth: 'Prošli mjesec (PageUp)',
   nextMonth: 'Sljedeći mjesec (PageDown)',
   previousYear: 'Prošla godina (Control + left)',

--- a/src/locale/hr_HR.ts
+++ b/src/locale/hr_HR.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Odaberite godinu',
   decadeSelect: 'Odaberite desetljeće',
 
-  dateFormat: 'D.M.YYYY',
-
   dateTimeFormat: 'D.M.YYYY HH:mm:ss',
 
   previousMonth: 'Prošli mjesec (PageUp)',

--- a/src/locale/hu_HU.ts
+++ b/src/locale/hu_HU.ts
@@ -18,7 +18,6 @@ const locale: Locale = {
   yearSelect: 'Év kiválasztása', // 'Choose a year',
   decadeSelect: 'Évtized kiválasztása', // 'Choose a decade',
 
-  dateFormat: 'YYYY/MM/DD', // 'M/D/YYYY',
   dayFormat: 'DD', // 'D',
   dateTimeFormat: 'YYYY/MM/DD HH:mm:ss', // 'M/D/YYYY HH:mm:ss',
 

--- a/src/locale/hu_HU.ts
+++ b/src/locale/hu_HU.ts
@@ -19,7 +19,6 @@ const locale: Locale = {
   decadeSelect: 'Évtized kiválasztása', // 'Choose a decade',
 
   dayFormat: 'DD', // 'D',
-  dateTimeFormat: 'YYYY/MM/DD HH:mm:ss', // 'M/D/YYYY HH:mm:ss',
 
   previousMonth: 'Előző hónap (PageUp)', // 'Previous month (PageUp)',
   nextMonth: 'Következő hónap (PageDown)', // 'Next month (PageDown)',

--- a/src/locale/id_ID.ts
+++ b/src/locale/id_ID.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Pilih satu tahun',
   decadeSelect: 'Pilih satu dekade',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Bulan sebelumnya (PageUp)',

--- a/src/locale/id_ID.ts
+++ b/src/locale/id_ID.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Pilih satu tahun',
   decadeSelect: 'Pilih satu dekade',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Bulan sebelumnya (PageUp)',
   nextMonth: 'Bulan selanjutnya (PageDown)',
   previousYear: 'Tahun lalu (Control + kiri)',

--- a/src/locale/is_IS.ts
+++ b/src/locale/is_IS.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Velja ár',
   decadeSelect: 'Velja áratug',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Fyrri mánuður (PageUp)',
   nextMonth: 'Næsti mánuður (PageDown)',
   previousYear: 'Fyrra ár (Control + left)',

--- a/src/locale/is_IS.ts
+++ b/src/locale/is_IS.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Velja ár',
   decadeSelect: 'Velja áratug',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Fyrri mánuður (PageUp)',

--- a/src/locale/it_IT.ts
+++ b/src/locale/it_IT.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: "Seleziona l'anno",
   decadeSelect: 'Seleziona il decennio',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Il mese scorso (PageUp)',

--- a/src/locale/it_IT.ts
+++ b/src/locale/it_IT.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: "Seleziona l'anno",
   decadeSelect: 'Seleziona il decennio',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Il mese scorso (PageUp)',
   nextMonth: 'Il prossimo mese (PageDown)',
   previousYear: "L'anno scorso (Control + sinistra)",

--- a/src/locale/ja_JP.ts
+++ b/src/locale/ja_JP.ts
@@ -21,7 +21,6 @@ const locale: Locale = {
   yearSelect: '年を選択',
   decadeSelect: '年代を選択',
   yearFormat: 'YYYY年',
-  dateFormat: 'YYYY年M月D日',
   dateTimeFormat: 'YYYY年M月D日 HH時mm分ss秒',
   previousYear: '前年 (Controlを押しながら左キー)',
   nextYear: '翌年 (Controlを押しながら右キー)',

--- a/src/locale/ja_JP.ts
+++ b/src/locale/ja_JP.ts
@@ -21,7 +21,6 @@ const locale: Locale = {
   yearSelect: '年を選択',
   decadeSelect: '年代を選択',
   yearFormat: 'YYYY年',
-  dateTimeFormat: 'YYYY年M月D日 HH時mm分ss秒',
   previousYear: '前年 (Controlを押しながら左キー)',
   nextYear: '翌年 (Controlを押しながら右キー)',
   previousDecade: '前の年代',

--- a/src/locale/ka_GE.ts
+++ b/src/locale/ka_GE.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'წლის არჩევა',
   decadeSelect: 'ათწლეულის არჩევა',
 
-  dateTimeFormat: 'M/D/YYYY HH:mm:ss',
-
   previousMonth: 'წინა თვე (PageUp)',
   nextMonth: 'მომდევნო თვე (PageDown)',
   previousYear: 'წინა წელი (Control + left)',

--- a/src/locale/ka_GE.ts
+++ b/src/locale/ka_GE.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'წლის არჩევა',
   decadeSelect: 'ათწლეულის არჩევა',
 
-  dateFormat: 'M/D/YYYY',
-
   dateTimeFormat: 'M/D/YYYY HH:mm:ss',
 
   previousMonth: 'წინა თვე (PageUp)',

--- a/src/locale/kk_KZ.ts
+++ b/src/locale/kk_KZ.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Жылды таңдаңыз',
   decadeSelect: 'Онжылды таңдаңыз',
 
-  dateFormat: 'D-M-YYYY',
-
   dateTimeFormat: 'D-M-YYYY HH:mm:ss',
 
   previousMonth: 'Алдыңғы ай (PageUp)',

--- a/src/locale/kk_KZ.ts
+++ b/src/locale/kk_KZ.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Жылды таңдаңыз',
   decadeSelect: 'Онжылды таңдаңыз',
 
-  dateTimeFormat: 'D-M-YYYY HH:mm:ss',
-
   previousMonth: 'Алдыңғы ай (PageUp)',
   nextMonth: 'Келесі ай (PageDown)',
   previousYear: 'Алдыңғы жыл (Control + left)',

--- a/src/locale/km_KH.ts
+++ b/src/locale/km_KH.ts
@@ -21,7 +21,6 @@ const locale: Locale = {
   yearSelect: 'ជ្រើសរើសឆ្នាំ',
   decadeSelect: 'ជ្រើសរើសអាយុ',
 
-  dateTimeFormat: 'YYYY-M-D HH:mm:ss',
   previousYear: 'ឆ្នាំមុន (Controlគ្រាប់ចុចបូកព្រួញខាងឆ្វេង)',
   nextYear: 'ឆ្នាំក្រោយ (Control គ្រាប់ចុចបូកព្រួញស្ដាំ)',
   previousDecade: 'ជំនាន់ចុងក្រោយ',

--- a/src/locale/km_KH.ts
+++ b/src/locale/km_KH.ts
@@ -21,7 +21,6 @@ const locale: Locale = {
   yearSelect: 'ជ្រើសរើសឆ្នាំ',
   decadeSelect: 'ជ្រើសរើសអាយុ',
 
-  dateFormat: 'YYYY-M-D',
   dateTimeFormat: 'YYYY-M-D HH:mm:ss',
   previousYear: 'ឆ្នាំមុន (Controlគ្រាប់ចុចបូកព្រួញខាងឆ្វេង)',
   nextYear: 'ឆ្នាំក្រោយ (Control គ្រាប់ចុចបូកព្រួញស្ដាំ)',

--- a/src/locale/kmr_IQ.ts
+++ b/src/locale/kmr_IQ.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Sal hilbijêre',
   decadeSelect: 'Dehsal hilbijêre',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Meha peş (PageUp))',

--- a/src/locale/kmr_IQ.ts
+++ b/src/locale/kmr_IQ.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Sal hilbijêre',
   decadeSelect: 'Dehsal hilbijêre',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Meha peş (PageUp))',
   nextMonth: 'Meha paş (PageDown)',
   previousYear: 'Sala peş (Control + şep)',

--- a/src/locale/kn_IN.ts
+++ b/src/locale/kn_IN.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'ಒಂದು ವರ್ಷ ಆರಿಸಿ',
   decadeSelect: 'ಒಂದು ದಶಕದ ಆಯ್ಕೆಮಾಡಿ',
 
-  dateTimeFormat: 'M/D/YYYY HH:mm:ss',
-
   previousMonth: 'ಹಿಂದಿನ ತಿಂಗಳು (ಪೇಜ್ಅಪ್)',
   nextMonth: 'ಮುಂದಿನ ತಿಂಗಳು (ಪೇಜ್ಡೌನ್)',
   previousYear: 'ಕಳೆದ ವರ್ಷ (Ctrl + ಎಡ)',

--- a/src/locale/kn_IN.ts
+++ b/src/locale/kn_IN.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'ಒಂದು ವರ್ಷ ಆರಿಸಿ',
   decadeSelect: 'ಒಂದು ದಶಕದ ಆಯ್ಕೆಮಾಡಿ',
 
-  dateFormat: 'M/D/YYYY',
-
   dateTimeFormat: 'M/D/YYYY HH:mm:ss',
 
   previousMonth: 'ಹಿಂದಿನ ತಿಂಗಳು (ಪೇಜ್ಅಪ್)',

--- a/src/locale/ko_KR.ts
+++ b/src/locale/ko_KR.ts
@@ -18,7 +18,6 @@ const locale: Locale = {
   yearSelect: '연 선택',
   decadeSelect: '연대 선택',
   yearFormat: 'YYYY년',
-  dateTimeFormat: 'YYYY-MM-DD HH:mm:ss',
   monthBeforeYear: false,
   previousMonth: '이전 달 (PageUp)',
   nextMonth: '다음 달 (PageDown)',

--- a/src/locale/ko_KR.ts
+++ b/src/locale/ko_KR.ts
@@ -18,7 +18,6 @@ const locale: Locale = {
   yearSelect: '연 선택',
   decadeSelect: '연대 선택',
   yearFormat: 'YYYY년',
-  dateFormat: 'YYYY-MM-DD',
   dateTimeFormat: 'YYYY-MM-DD HH:mm:ss',
   monthBeforeYear: false,
   previousMonth: '이전 달 (PageUp)',

--- a/src/locale/lt_LT.ts
+++ b/src/locale/lt_LT.ts
@@ -20,7 +20,6 @@ const locale: Locale = {
   decadeSelect: 'Pasirinkti dešimtmetį',
 
   dayFormat: 'DD',
-  dateTimeFormat: 'YYYY-MM-DD HH:MM:SS',
 
   previousMonth: 'Buvęs mėnesis (PageUp)',
   nextMonth: 'Kitas mėnesis (PageDown)',

--- a/src/locale/lt_LT.ts
+++ b/src/locale/lt_LT.ts
@@ -19,7 +19,6 @@ const locale: Locale = {
   yearSelect: 'Pasirinkti metus',
   decadeSelect: 'Pasirinkti dešimtmetį',
 
-  dateFormat: 'YYYY-MM-DD',
   dayFormat: 'DD',
   dateTimeFormat: 'YYYY-MM-DD HH:MM:SS',
 

--- a/src/locale/lv_LV.ts
+++ b/src/locale/lv_LV.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Izvēlieties gadu',
   decadeSelect: 'Izvēlieties desmit gadus',
 
-  dateTimeFormat: 'D.M.YYYY HH:mm:ss',
-
   previousMonth: 'Iepriekšējais mēnesis (PageUp)',
   nextMonth: 'Nākammēnes (PageDown)',
   previousYear: 'Pagājušais gads (Control + left)',

--- a/src/locale/lv_LV.ts
+++ b/src/locale/lv_LV.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Izvēlieties gadu',
   decadeSelect: 'Izvēlieties desmit gadus',
 
-  dateFormat: 'D.M.YYYY',
-
   dateTimeFormat: 'D.M.YYYY HH:mm:ss',
 
   previousMonth: 'Iepriekšējais mēnesis (PageUp)',

--- a/src/locale/mk_MK.ts
+++ b/src/locale/mk_MK.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Избери година',
   decadeSelect: 'Избери деценија',
 
-  dateFormat: 'D.M.YYYY',
-
   dateTimeFormat: 'D.M.YYYY HH:mm:ss',
 
   previousMonth: 'Претходен месец (PageUp)',

--- a/src/locale/mk_MK.ts
+++ b/src/locale/mk_MK.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Избери година',
   decadeSelect: 'Избери деценија',
 
-  dateTimeFormat: 'D.M.YYYY HH:mm:ss',
-
   previousMonth: 'Претходен месец (PageUp)',
   nextMonth: 'Нареден месец (PageDown)',
   previousYear: 'Претходна година (Control + left)',

--- a/src/locale/ml_IN.ts
+++ b/src/locale/ml_IN.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'വർഷം തിരഞ്ഞെടുക്കുക',
   decadeSelect: 'ദശാബ്ദം തിരഞ്ഞെടുക്കുക',
 
-  dateTimeFormat: 'M/D/YYYY HH:mm:ss',
-
   previousMonth: 'കഴിഞ്ഞ മാസം (PageUp)',
   nextMonth: 'അടുത്ത മാസം (PageDown)',
   previousYear: 'കഴിഞ്ഞ വർഷം (Control + left)',

--- a/src/locale/ml_IN.ts
+++ b/src/locale/ml_IN.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'വർഷം തിരഞ്ഞെടുക്കുക',
   decadeSelect: 'ദശാബ്ദം തിരഞ്ഞെടുക്കുക',
 
-  dateFormat: 'M/D/YYYY',
-
   dateTimeFormat: 'M/D/YYYY HH:mm:ss',
 
   previousMonth: 'കഴിഞ്ഞ മാസം (PageUp)',

--- a/src/locale/mn_MN.ts
+++ b/src/locale/mn_MN.ts
@@ -19,7 +19,6 @@ const locale: Locale = {
   yearSelect: 'Жил сонгох',
   decadeSelect: 'Арван сонгох',
 
-  dateFormat: 'YYYY/MM/DD',
   dayFormat: 'DD',
   dateTimeFormat: 'YYYY/MM/DD HH:mm:ss',
 

--- a/src/locale/mn_MN.ts
+++ b/src/locale/mn_MN.ts
@@ -20,7 +20,6 @@ const locale: Locale = {
   decadeSelect: 'Арван сонгох',
 
   dayFormat: 'DD',
-  dateTimeFormat: 'YYYY/MM/DD HH:mm:ss',
 
   previousMonth: 'Өмнөх сар (PageUp)',
   nextMonth: 'Дараа сар (PageDown)',

--- a/src/locale/ms_MY.ts
+++ b/src/locale/ms_MY.ts
@@ -21,7 +21,6 @@ const locale: Locale = {
   yearSelect: 'Pilih tahun',
   decadeSelect: 'Pilih dekad',
 
-  dateTimeFormat: 'M/D/YYYY HH:mm:ss',
   previousYear: 'Tahun lepas (Ctrl+left)',
   nextYear: 'Tahun depan (Ctrl+right)',
   previousDecade: 'Dekad lepas',

--- a/src/locale/ms_MY.ts
+++ b/src/locale/ms_MY.ts
@@ -21,7 +21,6 @@ const locale: Locale = {
   yearSelect: 'Pilih tahun',
   decadeSelect: 'Pilih dekad',
 
-  dateFormat: 'M/D/YYYY',
   dateTimeFormat: 'M/D/YYYY HH:mm:ss',
   previousYear: 'Tahun lepas (Ctrl+left)',
   nextYear: 'Tahun depan (Ctrl+right)',

--- a/src/locale/my_MM.ts
+++ b/src/locale/my_MM.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'နှစ်ကိုရွေး',
   decadeSelect: 'ဆယ်စုနှစ်ကိုရွေး',
 
-  dateFormat: 'M/D/YYYY',
-
   dateTimeFormat: 'M/D/YYYY HH:mm:ss',
 
   previousMonth: 'ယခင်လ (PageUp)',

--- a/src/locale/my_MM.ts
+++ b/src/locale/my_MM.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'နှစ်ကိုရွေး',
   decadeSelect: 'ဆယ်စုနှစ်ကိုရွေး',
 
-  dateTimeFormat: 'M/D/YYYY HH:mm:ss',
-
   previousMonth: 'ယခင်လ (PageUp)',
   nextMonth: 'နောက်လ (PageDown)',
   previousYear: 'ယခင်နှစ် (Control + left)',

--- a/src/locale/nb_NO.ts
+++ b/src/locale/nb_NO.ts
@@ -20,7 +20,6 @@ const locale: Locale = {
   decadeSelect: 'Velg tiår',
 
   dayFormat: 'DD',
-  dateTimeFormat: 'DD.MM.YYYY HH:mm:ss',
 
   previousMonth: 'Forrige måned (PageUp)',
   nextMonth: 'Neste måned (PageDown)',

--- a/src/locale/nb_NO.ts
+++ b/src/locale/nb_NO.ts
@@ -19,7 +19,6 @@ const locale: Locale = {
   yearSelect: 'Velg år',
   decadeSelect: 'Velg tiår',
 
-  dateFormat: 'DD.MM.YYYY',
   dayFormat: 'DD',
   dateTimeFormat: 'DD.MM.YYYY HH:mm:ss',
 

--- a/src/locale/ne_NP.ts
+++ b/src/locale/ne_NP.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'एक वर्ष छान्नुहोस्',
   decadeSelect: 'एक दशक छान्नुहोस्',
 
-  dateFormat: 'M/D/YYYY',
-
   dateTimeFormat: 'M/D/YYYY HH:mm:ss',
 
   previousMonth: 'अघिल्लो महिना (पृष्ठ माथि)',

--- a/src/locale/ne_NP.ts
+++ b/src/locale/ne_NP.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'एक वर्ष छान्नुहोस्',
   decadeSelect: 'एक दशक छान्नुहोस्',
 
-  dateTimeFormat: 'M/D/YYYY HH:mm:ss',
-
   previousMonth: 'अघिल्लो महिना (पृष्ठ माथि)',
   nextMonth: 'अर्को महिना (पृष्ठ तल)',
   previousYear: 'गत वर्ष (Control + left)',

--- a/src/locale/nl_BE.ts
+++ b/src/locale/nl_BE.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Kies een jaar',
   decadeSelect: 'Kies een decennium',
 
-  dateTimeFormat: 'D-M-YYYY HH:mm:ss',
-
   previousMonth: 'Vorige maand (PageUp)',
   nextMonth: 'Volgende maand (PageDown)',
   previousYear: 'Vorig jaar (Control + left)',

--- a/src/locale/nl_BE.ts
+++ b/src/locale/nl_BE.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Kies een jaar',
   decadeSelect: 'Kies een decennium',
 
-  dateFormat: 'D-M-YYYY',
-
   dateTimeFormat: 'D-M-YYYY HH:mm:ss',
 
   previousMonth: 'Vorige maand (PageUp)',

--- a/src/locale/nl_NL.ts
+++ b/src/locale/nl_NL.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Kies een jaar',
   decadeSelect: 'Kies een decennium',
 
-  dateTimeFormat: 'D-M-YYYY HH:mm:ss',
-
   previousMonth: 'Vorige maand (PageUp)',
   nextMonth: 'Volgende maand (PageDown)',
   previousYear: 'Vorig jaar (Control + left)',

--- a/src/locale/nl_NL.ts
+++ b/src/locale/nl_NL.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Kies een jaar',
   decadeSelect: 'Kies een decennium',
 
-  dateFormat: 'D-M-YYYY',
-
   dateTimeFormat: 'D-M-YYYY HH:mm:ss',
 
   previousMonth: 'Vorige maand (PageUp)',

--- a/src/locale/pl_PL.ts
+++ b/src/locale/pl_PL.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Wybierz rok',
   decadeSelect: 'Wybierz dekadę',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Poprzedni miesiąc (PageUp)',

--- a/src/locale/pl_PL.ts
+++ b/src/locale/pl_PL.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Wybierz rok',
   decadeSelect: 'Wybierz dekadę',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Poprzedni miesiąc (PageUp)',
   nextMonth: 'Następny miesiąc (PageDown)',
   previousYear: 'Ostatni rok (Ctrl + left)',

--- a/src/locale/pt_BR.ts
+++ b/src/locale/pt_BR.ts
@@ -17,7 +17,6 @@ const locale: Locale = {
   monthSelect: 'Escolher mês',
   yearSelect: 'Escolher ano',
   decadeSelect: 'Escolher década',
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
   monthBeforeYear: false,
   previousMonth: 'Mês anterior (PageUp)',
   nextMonth: 'Próximo mês (PageDown)',

--- a/src/locale/pt_BR.ts
+++ b/src/locale/pt_BR.ts
@@ -17,7 +17,6 @@ const locale: Locale = {
   monthSelect: 'Escolher mês',
   yearSelect: 'Escolher ano',
   decadeSelect: 'Escolher década',
-  dateFormat: 'D/M/YYYY',
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
   monthBeforeYear: false,
   previousMonth: 'Mês anterior (PageUp)',

--- a/src/locale/pt_PT.ts
+++ b/src/locale/pt_PT.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Selecionar ano',
   decadeSelect: 'Selecionar década',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Mês anterior (PageUp)',
   nextMonth: 'Mês seguinte (PageDown)',
   previousYear: 'Ano anterior (Control + left)',

--- a/src/locale/pt_PT.ts
+++ b/src/locale/pt_PT.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Selecionar ano',
   decadeSelect: 'Selecionar década',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Mês anterior (PageUp)',

--- a/src/locale/ro_RO.ts
+++ b/src/locale/ro_RO.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Alege un an',
   decadeSelect: 'Alege un deceniu',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Luna anterioară (PageUp)',

--- a/src/locale/ro_RO.ts
+++ b/src/locale/ro_RO.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Alege un an',
   decadeSelect: 'Alege un deceniu',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Luna anterioară (PageUp)',
   nextMonth: 'Luna următoare (PageDown)',
   previousYear: 'Anul anterior (Control + stânga)',

--- a/src/locale/ru_RU.ts
+++ b/src/locale/ru_RU.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Выбрать год',
   decadeSelect: 'Выбрать десятилетие',
 
-  dateTimeFormat: 'D-M-YYYY HH:mm:ss',
-
   previousMonth: 'Предыдущий месяц (PageUp)',
   nextMonth: 'Следующий месяц (PageDown)',
   previousYear: 'Предыдущий год (Control + left)',

--- a/src/locale/ru_RU.ts
+++ b/src/locale/ru_RU.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Выбрать год',
   decadeSelect: 'Выбрать десятилетие',
 
-  dateFormat: 'D-M-YYYY',
-
   dateTimeFormat: 'D-M-YYYY HH:mm:ss',
 
   previousMonth: 'Предыдущий месяц (PageUp)',

--- a/src/locale/si_LK.ts
+++ b/src/locale/si_LK.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'අවුරුද්දක් තෝරන්න',
   decadeSelect: 'දශකයක් තෝරන්න',
 
-  dateFormat: 'YYYY/M/D',
-
   dateTimeFormat: 'YYYY/M/D HH:mm:ss',
   monthBeforeYear: false,
   previousMonth: 'කලින් මාසය (පිටුව ඉහළට)',

--- a/src/locale/si_LK.ts
+++ b/src/locale/si_LK.ts
@@ -19,7 +19,6 @@ const locale: Locale = {
   yearSelect: 'අවුරුද්දක් තෝරන්න',
   decadeSelect: 'දශකයක් තෝරන්න',
 
-  dateTimeFormat: 'YYYY/M/D HH:mm:ss',
   monthBeforeYear: false,
   previousMonth: 'කලින් මාසය (පිටුව ඉහළට)',
   nextMonth: 'ඊළඟ මාසය (පිටුව පහළට)',

--- a/src/locale/sk_SK.ts
+++ b/src/locale/sk_SK.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Vybrať rok',
   decadeSelect: 'Vybrať dekádu',
 
-  dateTimeFormat: 'D.M.YYYY HH:mm:ss',
-
   previousMonth: 'Predchádzajúci mesiac (PageUp)',
   nextMonth: 'Nasledujúci mesiac (PageDown)',
   previousYear: 'Predchádzajúci rok (Control + left)',

--- a/src/locale/sk_SK.ts
+++ b/src/locale/sk_SK.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Vybrať rok',
   decadeSelect: 'Vybrať dekádu',
 
-  dateFormat: 'D.M.YYYY',
-
   dateTimeFormat: 'D.M.YYYY HH:mm:ss',
 
   previousMonth: 'Predchádzajúci mesiac (PageUp)',

--- a/src/locale/sl_SI.ts
+++ b/src/locale/sl_SI.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Izberite leto',
   decadeSelect: 'Izberite desetletje',
 
-  dateTimeFormat: 'DD.MM.YYYY HH:mm:ss',
-
   previousMonth: 'Prejšnji mesec (PageUp)',
   nextMonth: 'Naslednji mesec (PageDown)',
   previousYear: 'Prejšnje leto (Control + left)',

--- a/src/locale/sl_SI.ts
+++ b/src/locale/sl_SI.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Izberite leto',
   decadeSelect: 'Izberite desetletje',
 
-  dateFormat: 'DD.MM.YYYY',
-
   dateTimeFormat: 'DD.MM.YYYY HH:mm:ss',
 
   previousMonth: 'Prejšnji mesec (PageUp)',

--- a/src/locale/sr_Cyrl_RS.ts
+++ b/src/locale/sr_Cyrl_RS.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Изабери годину',
   decadeSelect: 'Изабери деценију',
 
-  dateFormat: 'DD.MM.YYYY',
-
   dateTimeFormat: 'DD.MM.YYYY HH:mm:ss',
 
   previousMonth: 'Претходни месец (PageUp)',

--- a/src/locale/sr_Cyrl_RS.ts
+++ b/src/locale/sr_Cyrl_RS.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Изабери годину',
   decadeSelect: 'Изабери деценију',
 
-  dateTimeFormat: 'DD.MM.YYYY HH:mm:ss',
-
   previousMonth: 'Претходни месец (PageUp)',
   nextMonth: 'Следећи месец (PageDown)',
   previousYear: 'Претходна година (Control + left)',

--- a/src/locale/sr_RS.ts
+++ b/src/locale/sr_RS.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Izaberi godinu',
   decadeSelect: 'Izaberi deceniju',
 
-  dateFormat: 'DD.MM.YYYY',
-
   dateTimeFormat: 'DD.MM.YYYY HH:mm:ss',
 
   previousMonth: 'Prethodni mesec (PageUp)',

--- a/src/locale/sr_RS.ts
+++ b/src/locale/sr_RS.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Izaberi godinu',
   decadeSelect: 'Izaberi deceniju',
 
-  dateTimeFormat: 'DD.MM.YYYY HH:mm:ss',
-
   previousMonth: 'Prethodni mesec (PageUp)',
   nextMonth: 'Sledeći mesec (PageDown)',
   previousYear: 'Prethodna godina (Control + left)',

--- a/src/locale/sv_SE.ts
+++ b/src/locale/sv_SE.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Välj år',
   decadeSelect: 'Välj årtionde',
 
-  dateTimeFormat: 'YYYY-MM-DD H:mm:ss',
-
   previousMonth: 'Förra månaden (PageUp)',
   nextMonth: 'Nästa månad (PageDown)',
   previousYear: 'Föreg år (Control + left)',

--- a/src/locale/sv_SE.ts
+++ b/src/locale/sv_SE.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Välj år',
   decadeSelect: 'Välj årtionde',
 
-  dateFormat: 'YYYY-MM-DD',
-
   dateTimeFormat: 'YYYY-MM-DD H:mm:ss',
 
   previousMonth: 'Förra månaden (PageUp)',

--- a/src/locale/ta_IN.ts
+++ b/src/locale/ta_IN.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'வருடத்தைத் தேர்வுசெய்க',
   decadeSelect: 'தசாப்தத்தைத் தேர்வுசெய்க',
 
-  dateTimeFormat: 'M/D/YYYY HH:mm:ss',
-
   previousMonth: 'முந்தைய மாதம் (PageUp)',
   nextMonth: 'அடுத்த மாதம் (PageDown)',
   previousYear: 'முந்தைய வருடம் (Control + left)',

--- a/src/locale/ta_IN.ts
+++ b/src/locale/ta_IN.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'வருடத்தைத் தேர்வுசெய்க',
   decadeSelect: 'தசாப்தத்தைத் தேர்வுசெய்க',
 
-  dateFormat: 'M/D/YYYY',
-
   dateTimeFormat: 'M/D/YYYY HH:mm:ss',
 
   previousMonth: 'முந்தைய மாதம் (PageUp)',

--- a/src/locale/th_TH.ts
+++ b/src/locale/th_TH.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'เลือกปี',
   decadeSelect: 'เลือกทศวรรษ',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'เดือนก่อนหน้า (PageUp)',

--- a/src/locale/th_TH.ts
+++ b/src/locale/th_TH.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'เลือกปี',
   decadeSelect: 'เลือกทศวรรษ',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'เดือนก่อนหน้า (PageUp)',
   nextMonth: 'เดือนถัดไป (PageDown)',
   previousYear: 'ปีก่อนหน้า (Control + left)',

--- a/src/locale/tk_TK.ts
+++ b/src/locale/tk_TK.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Ýyl saýla',
   decadeSelect: 'On ýyllygy saýla',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Öňki aý (PageUp)',

--- a/src/locale/tk_TK.ts
+++ b/src/locale/tk_TK.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Ýyl saýla',
   decadeSelect: 'On ýyllygy saýla',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Öňki aý (PageUp)',
   nextMonth: 'Soňky aý (PageDown)',
   previousYear: 'Öňki ýyl (Control + çep)',

--- a/src/locale/tr_TR.ts
+++ b/src/locale/tr_TR.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Yıl Seç',
   decadeSelect: 'On Yıl Seç',
 
-  dateFormat: 'DD/MM/YYYY',
-
   dateTimeFormat: 'DD/MM/YYYY HH:mm:ss',
 
   previousMonth: 'Önceki Ay (PageUp)',

--- a/src/locale/tr_TR.ts
+++ b/src/locale/tr_TR.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Yıl Seç',
   decadeSelect: 'On Yıl Seç',
 
-  dateTimeFormat: 'DD/MM/YYYY HH:mm:ss',
-
   previousMonth: 'Önceki Ay (PageUp)',
   nextMonth: 'Sonraki Ay (PageDown)',
   previousYear: 'Önceki Yıl (Control + Sol)',

--- a/src/locale/ug_CN.ts
+++ b/src/locale/ug_CN.ts
@@ -21,7 +21,6 @@ const locale: Locale = {
   decadeSelect: 'يىللارنى تاللاش',
   yearFormat: 'YYYY-يىلى',
   dayFormat: 'D-كۈنى',
-  dateTimeFormat: 'YYYY-يىلىM—ئاينىڭD-كۈنى، HH:mm:ss',
   previousYear: 'ئالدىنقى يىلى (Controlبىلەن يۆنىلىش كونۇپكىسى)',
   nextYear: 'كېلەركى يىلى (Controlبىلەن يۆنىلىش كونۇپكىسى)',
   previousDecade: 'ئالدىنقى يىللار',

--- a/src/locale/ug_CN.ts
+++ b/src/locale/ug_CN.ts
@@ -21,7 +21,6 @@ const locale: Locale = {
   decadeSelect: 'يىللارنى تاللاش',
   yearFormat: 'YYYY-يىلى',
   dayFormat: 'D-كۈنى',
-  dateFormat: 'YYYY-يىلىM-ئاينىڭD-كۈنى',
   dateTimeFormat: 'YYYY-يىلىM—ئاينىڭD-كۈنى، HH:mm:ss',
   previousYear: 'ئالدىنقى يىلى (Controlبىلەن يۆنىلىش كونۇپكىسى)',
   nextYear: 'كېلەركى يىلى (Controlبىلەن يۆنىلىش كونۇپكىسى)',

--- a/src/locale/uk_UA.ts
+++ b/src/locale/uk_UA.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Обрати рік',
   decadeSelect: 'Обрати десятиріччя',
 
-  dateTimeFormat: 'D-M-YYYY HH:mm:ss',
-
   previousMonth: 'Попередній місяць (PageUp)',
   nextMonth: 'Наступний місяць (PageDown)',
   previousYear: 'Попередній рік (Control + left)',

--- a/src/locale/uk_UA.ts
+++ b/src/locale/uk_UA.ts
@@ -18,8 +18,6 @@ const locale: Locale = {
   yearSelect: 'Обрати рік',
   decadeSelect: 'Обрати десятиріччя',
 
-  dateFormat: 'D-M-YYYY',
-
   dateTimeFormat: 'D-M-YYYY HH:mm:ss',
 
   previousMonth: 'Попередній місяць (PageUp)',

--- a/src/locale/ur_PK.ts
+++ b/src/locale/ur_PK.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'ایک سال کا انتخاب کریں',
   decadeSelect: 'ایک دہائی کا انتخاب کریں',
 
-  dateFormat: 'M/D/YYYY',
-
   dateTimeFormat: 'M/D/YYYY HH:mm:ss',
 
   previousMonth: 'پچھلے مہینے (PageUp)',

--- a/src/locale/ur_PK.ts
+++ b/src/locale/ur_PK.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'ایک سال کا انتخاب کریں',
   decadeSelect: 'ایک دہائی کا انتخاب کریں',
 
-  dateTimeFormat: 'M/D/YYYY HH:mm:ss',
-
   previousMonth: 'پچھلے مہینے (PageUp)',
   nextMonth: 'اگلے مہینے (PageDown)',
   previousYear: 'گزشتہ سال (Control + left)',

--- a/src/locale/uz_UZ.ts
+++ b/src/locale/uz_UZ.ts
@@ -18,7 +18,6 @@ const locale: Locale = {
   monthSelect: 'Oyni tanlang',
   yearSelect: 'Yilni tanlang',
   decadeSelect: "O'n yilni tanlang",
-  dateFormat: 'M/D/YYYY',
   dateTimeFormat: 'M/D/YYYY HH:mm:ss',
   previousMonth: 'Oldingi oy (PageUp)',
   nextMonth: 'Keyingi oy (PageDown)',

--- a/src/locale/uz_UZ.ts
+++ b/src/locale/uz_UZ.ts
@@ -18,7 +18,6 @@ const locale: Locale = {
   monthSelect: 'Oyni tanlang',
   yearSelect: 'Yilni tanlang',
   decadeSelect: "O'n yilni tanlang",
-  dateTimeFormat: 'M/D/YYYY HH:mm:ss',
   previousMonth: 'Oldingi oy (PageUp)',
   nextMonth: 'Keyingi oy (PageDown)',
   previousYear: "O'tgan yili (Control + left)",

--- a/src/locale/vi_VN.ts
+++ b/src/locale/vi_VN.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Chọn năm',
   decadeSelect: 'Chọn thập kỷ',
 
-  dateFormat: 'D/M/YYYY',
-
   dateTimeFormat: 'D/M/YYYY HH:mm:ss',
 
   previousMonth: 'Tháng trước (PageUp)',

--- a/src/locale/vi_VN.ts
+++ b/src/locale/vi_VN.ts
@@ -19,8 +19,6 @@ const locale: Locale = {
   yearSelect: 'Chọn năm',
   decadeSelect: 'Chọn thập kỷ',
 
-  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
-
   previousMonth: 'Tháng trước (PageUp)',
   nextMonth: 'Tháng sau (PageDown)',
   previousYear: 'Năm trước (Control + left)',

--- a/src/locale/zh_TW.ts
+++ b/src/locale/zh_TW.ts
@@ -23,7 +23,6 @@ const locale: Locale = {
   decadeSelect: '選擇年代',
   yearFormat: 'YYYY年',
 
-  dateTimeFormat: 'YYYY年M月D日 HH時mm分ss秒',
   previousYear: '上一年 (Control鍵加左方向鍵)',
   nextYear: '下一年 (Control鍵加右方向鍵)',
   previousDecade: '上一年代',

--- a/src/locale/zh_TW.ts
+++ b/src/locale/zh_TW.ts
@@ -23,7 +23,6 @@ const locale: Locale = {
   decadeSelect: '選擇年代',
   yearFormat: 'YYYY年',
 
-  dateFormat: 'YYYY年M月D日',
   dateTimeFormat: 'YYYY年M月D日 HH時mm分ss秒',
   previousYear: '上一年 (Control鍵加左方向鍵)',
   nextYear: '下一年 (Control鍵加右方向鍵)',


### PR DESCRIPTION
这部分内容其实已经没有用了

`fieldDateTimeFormat` 在[这里](https://github.com/react-component/picker/blob/rc-picker-v4/src/hooks/useLocale.ts#L82) 的 fallback 逻辑可能更好，不足之处可能是 前半部分的 `YYYY-MM-DD` 是无法自定义的。而后面的格式化是根据 props 动态生成的， 所以说可能会更好

`dateFormat` 可能会有点用，但是同样根据[这里的](https://github.com/react-component/picker/blob/rc-picker-v4/src/hooks/useLocale.ts#L83) 的逻辑，如果将其保留并且用 `fieldDateFormat` 替换的话会导致 test 需要调整。 具体我新建了另外一个 PR https://github.com/react-component/picker/pull/918