### PR TITLE
fix: value is not work when set to null (pick of #913)

### DIFF
--- a/src/PickerInput/hooks/useRangeValue.ts
+++ b/src/PickerInput/hooks/useRangeValue.ts
@@ -116,9 +116,10 @@ export function useInnerValue<ValueType extends DateType[], DateType extends obj
   ) => void,
   onOk?: (dates: ValueType) => void,
 ) {
+  const isNullValue = value === null;
   // This is the root value which will sync with controlled or uncontrolled value
   const [innerValue, setInnerValue] = useMergedState(defaultValue, {
-    value,
+    value: isNullValue ? undefined : value,
   });
   const mergedValue = innerValue || (EMPTY_VALUE as ValueType);
 


### PR DESCRIPTION
* fix: value is not work when set to null

* fix: innerValue only judge null

(cherry picked from commit 6bc9cb4e986f53c915ff1623cd195728d41b88d3)

# Conflicts:
#	src/PickerInput/hooks/useRangeValue.ts