### PR TITLE
refactor: Semantic structure

### DIFF
--- a/docs/examples/basic.tsx
+++ b/docs/examples/basic.tsx
@@ -51,7 +51,16 @@ export default () => {
       <div style={{ display: 'flex', flexWrap: 'wrap' }}>
         <div style={{ margin: '0 8px' }}>
           <h3>Basic</h3>
-          <Picker<Moment> {...sharedProps} locale={zhCN} suffixIcon="SUFFIX" />
+          <Picker<Moment>
+            {...sharedProps}
+            locale={zhCN}
+            suffixIcon="SUFFIX"
+            rootClassName="bamboo"
+            className="little"
+            classNames={{
+              root: 'light',
+            }}
+          />
           <Picker<Moment> {...sharedProps} locale={enUS} />
         </div>
         <div style={{ margin: '0 8px' }}>

--- a/src/PickerInput/Popup/Footer.tsx
+++ b/src/PickerInput/Popup/Footer.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import cls from 'classnames';
 import * as React from 'react';
 import type { GenerateConfig } from '../../generate';
 import useTimeInfo from '../../hooks/useTimeInfo';
@@ -42,7 +42,13 @@ export default function Footer(props: FooterProps) {
     disabledDate,
   } = props;
 
-  const { prefixCls, locale, button: Button = 'button' } = React.useContext(PickerContext);
+  const {
+    prefixCls,
+    locale,
+    button: Button = 'button',
+    classNames,
+    styles,
+  } = React.useContext(PickerContext);
 
   // >>> Now
   const now = generateConfig.getNow();
@@ -70,7 +76,7 @@ export default function Footer(props: FooterProps) {
   const presetNode = showNow && (
     <li className={nowPrefixCls}>
       <a
-        className={classNames(nowBtnPrefixCls, nowDisabled && `${nowBtnPrefixCls}-disabled`)}
+        className={cls(nowBtnPrefixCls, nowDisabled && `${nowBtnPrefixCls}-disabled`)}
         aria-disabled={nowDisabled}
         onClick={onInternalNow}
       >
@@ -101,7 +107,10 @@ export default function Footer(props: FooterProps) {
   }
 
   return (
-    <div className={`${prefixCls}-footer`}>
+    <div
+      className={cls(`${prefixCls}-footer`, classNames.popup.footer)}
+      style={styles.popup.footer}
+    >
       {extraNode && <div className={`${prefixCls}-footer-extra`}>{extraNode}</div>}
       {rangeNode}
     </div>

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -1,4 +1,5 @@
 import { useEvent, useMergedState } from '@rc-component/util';
+import cls from 'classnames';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import omit from '@rc-component/util/lib/omit';
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
@@ -159,6 +160,7 @@ function RangePicker<DateType extends object = any>(
   const {
     // Style
     prefixCls,
+    rootClassName,
     styles: propStyles,
     classNames: propClassNames,
 
@@ -770,7 +772,7 @@ function RangePicker<DateType extends object = any>(
         {...pickTriggerProps(filledProps)}
         popupElement={panel}
         popupStyle={mergedStyles.popup.root}
-        popupClassName={mergedClassNames.popup.root}
+        popupClassName={cls(rootClassName, mergedClassNames.popup.root)}
         // Visible
         visible={mergedOpen}
         onClose={onPopupClose}
@@ -782,6 +784,12 @@ function RangePicker<DateType extends object = any>(
           {...filledProps}
           // Ref
           ref={selectorRef}
+          // Style
+          className={cls(filledProps.className, rootClassName, mergedClassNames.root)}
+          style={{
+            ...mergedStyles.root,
+            ...filledProps.style,
+          }}
           // Icon
           suffixIcon={suffixIcon}
           // Active

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -35,6 +35,7 @@ import useRangeValue, { useInnerValue } from './hooks/useRangeValue';
 import useShowNow from './hooks/useShowNow';
 import Popup, { type PopupShowTimeConfig } from './Popup';
 import RangeSelector, { type SelectorIdType } from './Selector/RangeSelector';
+import useSemantic from '../hooks/useSemantic';
 
 function separateConfig<T>(config: T | [T, T] | null | undefined, defaultConfig: T): [T, T] {
   const singleConfig = config ?? defaultConfig;
@@ -158,8 +159,8 @@ function RangePicker<DateType extends object = any>(
   const {
     // Style
     prefixCls,
-    styles,
-    classNames,
+    styles: propStyles,
+    classNames: propClassNames,
 
     // Value
     defaultValue,
@@ -223,6 +224,9 @@ function RangePicker<DateType extends object = any>(
 
   // ========================= Refs =========================
   const selectorRef = usePickerRef(ref);
+
+  // ======================= Semantic =======================
+  const [mergedClassNames, mergedStyles] = useSemantic(propClassNames, propStyles);
 
   // ========================= Open =========================
   const [mergedOpen, setMergeOpen] = useOpen(open, defaultOpen, disabled, onOpenChange);
@@ -562,6 +566,8 @@ function RangePicker<DateType extends object = any>(
       'className',
       'onPanelChange',
       'disabledTime',
+      'classNames',
+      'styles',
     ]);
     return restProps;
   }, [filledProps]);
@@ -693,10 +699,18 @@ function RangePicker<DateType extends object = any>(
       generateConfig,
       button: components.button,
       input: components.input,
-      styles,
-      classNames,
+      classNames: mergedClassNames,
+      styles: mergedStyles,
     }),
-    [prefixCls, locale, generateConfig, components.button, components.input, classNames, styles],
+    [
+      prefixCls,
+      locale,
+      generateConfig,
+      components.button,
+      components.input,
+      mergedClassNames,
+      mergedStyles,
+    ],
   );
 
   // ======================== Effect ========================
@@ -755,8 +769,8 @@ function RangePicker<DateType extends object = any>(
       <PickerTrigger
         {...pickTriggerProps(filledProps)}
         popupElement={panel}
-        popupStyle={styles.popup}
-        popupClassName={classNames.popup}
+        popupStyle={mergedStyles.popup.root}
+        popupClassName={mergedClassNames.popup.root}
         // Visible
         visible={mergedOpen}
         onClose={onPopupClose}

--- a/src/PickerInput/Selector/Icon.tsx
+++ b/src/PickerInput/Selector/Icon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PickerContext from '../context';
-import classNames from 'classnames';
+import cls from 'classnames';
 
 export interface IconProps extends React.HtmlHTMLAttributes<HTMLElement> {
   icon?: React.ReactNode;
@@ -9,12 +9,12 @@ export interface IconProps extends React.HtmlHTMLAttributes<HTMLElement> {
 
 export default function Icon(props: IconProps) {
   const { icon, type, ...restProps } = props;
-  const { prefixCls, classNames: iconClassNames, styles } = React.useContext(PickerContext);
+  const { prefixCls, classNames, styles } = React.useContext(PickerContext);
 
   return icon ? (
     <span
-      className={classNames(`${prefixCls}-${type}`, iconClassNames?.suffix)}
-      style={styles?.suffix}
+      className={cls(`${prefixCls}-${type}`, classNames.suffix)}
+      style={styles.suffix}
       {...restProps}
     >
       {icon}

--- a/src/PickerInput/Selector/Input.tsx
+++ b/src/PickerInput/Selector/Input.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import cls from 'classnames';
 import { useEvent } from '@rc-component/util';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import raf from '@rc-component/util/lib/raf';
@@ -75,7 +75,7 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
   const {
     prefixCls,
     input: Component = 'input',
-    classNames: inputClassNames,
+    classNames,
     styles,
   } = React.useContext(PickerContext);
   const inputPrefixCls = `${prefixCls}-input`;
@@ -383,7 +383,7 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
   return (
     <div
       ref={holderRef}
-      className={classNames(
+      className={cls(
         inputPrefixCls,
         {
           [`${inputPrefixCls}-active`]: active && showActiveCls,
@@ -404,8 +404,8 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
         // Value
         value={inputValue}
         onChange={onInternalChange}
-        className={inputClassNames?.input}
-        style={styles?.input}
+        className={classNames.input}
+        style={styles.input}
       />
       <Icon type="suffix" icon={suffixIcon} />
       {clearIcon}

--- a/src/PickerInput/Selector/Input.tsx
+++ b/src/PickerInput/Selector/Input.tsx
@@ -385,14 +385,12 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
       ref={holderRef}
       className={classNames(
         inputPrefixCls,
-        inputClassNames?.input,
         {
           [`${inputPrefixCls}-active`]: active && showActiveCls,
           [`${inputPrefixCls}-placeholder`]: helped,
         },
         className,
       )}
-      style={styles?.input}
     >
       <Component
         ref={inputRef}
@@ -406,6 +404,8 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
         // Value
         value={inputValue}
         onChange={onInternalChange}
+        className={inputClassNames?.input}
+        style={styles?.input}
       />
       <Icon type="suffix" icon={suffixIcon} />
       {clearIcon}

--- a/src/PickerInput/Selector/RangeSelector.tsx
+++ b/src/PickerInput/Selector/RangeSelector.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import cls from 'classnames';
 import ResizeObserver from '@rc-component/resize-observer';
 import { useEvent } from '@rc-component/util';
 import * as React from 'react';
@@ -121,7 +121,7 @@ function RangeSelector<DateType extends object = any>(
   const rtl = direction === 'rtl';
 
   // ======================== Prefix ========================
-  const { prefixCls, classNames: selectorClassNames, styles } = React.useContext(PickerContext);
+  const { prefixCls, classNames, styles } = React.useContext(PickerContext);
 
   // ========================== Id ==========================
   const ids = React.useMemo(() => {
@@ -211,7 +211,7 @@ function RangeSelector<DateType extends object = any>(
     <ResizeObserver onResize={syncActiveOffset}>
       <div
         {...rootProps}
-        className={classNames(
+        className={cls(
           prefixCls,
           `${prefixCls}-range`,
           {
@@ -239,10 +239,7 @@ function RangeSelector<DateType extends object = any>(
         }}
       >
         {prefix && (
-          <div
-            className={classNames(`${prefixCls}-prefix`, selectorClassNames?.prefix)}
-            style={styles?.prefix}
-          >
+          <div className={cls(`${prefixCls}-prefix`, classNames.prefix)} style={styles.prefix}>
             {prefix}
           </div>
         )}

--- a/src/PickerInput/Selector/SingleSelector/index.tsx
+++ b/src/PickerInput/Selector/SingleSelector/index.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import cls from 'classnames';
 import * as React from 'react';
 import type { InternalMode, PickerRef, SelectorProps } from '../../../interface';
 import { isSame } from '../../../utils/dateUtil';
@@ -110,7 +110,7 @@ function SingleSelector<DateType extends object = any>(
   const rtl = direction === 'rtl';
 
   // ======================== Prefix ========================
-  const { prefixCls, classNames: selectorClassNames, styles } = React.useContext(PickerContext);
+  const { prefixCls, classNames, styles } = React.useContext(PickerContext);
 
   // ========================= Refs =========================
   const rootRef = React.useRef<HTMLDivElement>();
@@ -201,7 +201,7 @@ function SingleSelector<DateType extends object = any>(
   return (
     <div
       {...rootProps}
-      className={classNames(
+      className={cls(
         prefixCls,
         {
           [`${prefixCls}-multiple`]: multiple,
@@ -226,10 +226,7 @@ function SingleSelector<DateType extends object = any>(
       }}
     >
       {prefix && (
-        <div
-          className={classNames(`${prefixCls}-prefix`, selectorClassNames?.prefix)}
-          style={styles?.prefix}
-        >
+        <div className={cls(`${prefixCls}-prefix`, classNames.prefix)} style={styles.prefix}>
           {prefix}
         </div>
       )}

--- a/src/PickerInput/SinglePicker.tsx
+++ b/src/PickerInput/SinglePicker.tsx
@@ -1,4 +1,5 @@
 import { useEvent, useMergedState } from '@rc-component/util';
+import cls from 'classnames';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import omit from '@rc-component/util/lib/omit';
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
@@ -123,6 +124,7 @@ function Picker<DateType extends object = any>(
   const {
     // Style
     prefixCls,
+    rootClassName,
     styles: propStyles,
     classNames: propClassNames,
 
@@ -630,7 +632,7 @@ function Picker<DateType extends object = any>(
         {...pickTriggerProps(filledProps)}
         popupElement={panel}
         popupStyle={mergedStyles.popup.root}
-        popupClassName={mergedClassNames.popup.root}
+        popupClassName={cls(rootClassName, mergedClassNames.popup.root)}
         // Visible
         visible={mergedOpen}
         onClose={onPopupClose}
@@ -640,6 +642,12 @@ function Picker<DateType extends object = any>(
           {...filledProps}
           // Ref
           ref={selectorRef}
+          // Style
+          className={cls(filledProps.className, rootClassName, mergedClassNames.root)}
+          style={{
+            ...mergedStyles.root,
+            ...filledProps.style,
+          }}
           // Icon
           suffixIcon={suffixIcon}
           removeIcon={removeIcon}

--- a/src/PickerInput/SinglePicker.tsx
+++ b/src/PickerInput/SinglePicker.tsx
@@ -31,6 +31,7 @@ import useRangeValue, { useInnerValue } from './hooks/useRangeValue';
 import useShowNow from './hooks/useShowNow';
 import Popup from './Popup';
 import SingleSelector from './Selector/SingleSelector';
+import useSemantic from '../hooks/useSemantic';
 
 // TODO: isInvalidateDate with showTime.disabledTime should not provide `range` prop
 
@@ -122,8 +123,8 @@ function Picker<DateType extends object = any>(
   const {
     // Style
     prefixCls,
-    styles,
-    classNames,
+    styles: propStyles,
+    classNames: propClassNames,
 
     // Value
     order,
@@ -201,6 +202,9 @@ function Picker<DateType extends object = any>(
   }
 
   const toggleDates = useToggleDates(generateConfig, locale, internalPicker);
+
+  // ======================= Semantic =======================
+  const [mergedClassNames, mergedStyles] = useSemantic(propClassNames, propStyles);
 
   // ========================= Open =========================
   const [mergedOpen, triggerOpen] = useOpen(open, defaultOpen, [disabled], onOpenChange);
@@ -478,6 +482,8 @@ function Picker<DateType extends object = any>(
       'style',
       'className',
       'onPanelChange',
+      'classNames',
+      'styles',
     ]);
     return {
       ...restProps,
@@ -577,10 +583,18 @@ function Picker<DateType extends object = any>(
       generateConfig,
       button: components.button,
       input: components.input,
-      styles,
-      classNames,
+      classNames: mergedClassNames,
+      styles: mergedStyles,
     }),
-    [prefixCls, locale, generateConfig, components.button, components.input, styles, classNames],
+    [
+      prefixCls,
+      locale,
+      generateConfig,
+      components.button,
+      components.input,
+      mergedClassNames,
+      mergedStyles,
+    ],
   );
 
   // ======================== Effect ========================
@@ -615,8 +629,8 @@ function Picker<DateType extends object = any>(
       <PickerTrigger
         {...pickTriggerProps(filledProps)}
         popupElement={panel}
-        popupStyle={styles.popup}
-        popupClassName={classNames.popup}
+        popupStyle={mergedStyles.popup.root}
+        popupClassName={mergedClassNames.popup.root}
         // Visible
         visible={mergedOpen}
         onClose={onPopupClose}

--- a/src/PickerInput/context.tsx
+++ b/src/PickerInput/context.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { GenerateConfig } from '../generate';
-import type { Components, Locale, SemanticStructure } from '../interface';
+import type { Components, Locale } from '../interface';
+import type { FilledClassNames, FilledStyles } from '../hooks/useSemantic';
 
 export interface PickerContextProps<DateType = any> {
   prefixCls: string;
@@ -9,8 +10,8 @@ export interface PickerContextProps<DateType = any> {
   /** Customize button component */
   button?: Components['button'];
   input?: Components['input'];
-  styles?: Partial<Record<SemanticStructure, React.CSSProperties>>;
-  classNames?: Partial<Record<SemanticStructure, string>>;
+  classNames: FilledClassNames;
+  styles: FilledStyles;
 }
 
 const PickerContext = React.createContext<PickerContextProps>(null!);

--- a/src/PickerPanel/PanelBody.tsx
+++ b/src/PickerPanel/PanelBody.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import cls from 'classnames';
 import * as React from 'react';
 import type { DisabledDate } from '../interface';
 import { formatValue, isInRange, isSame } from '../utils/dateUtil';
@@ -45,6 +45,8 @@ export default function PanelBody<DateType extends object = any>(props: PanelBod
 
   const {
     prefixCls,
+    classNames,
+    styles,
     panelType: type,
     now,
     disabledDate: contextDisabledDate,
@@ -63,11 +65,7 @@ export default function PanelBody<DateType extends object = any>(props: PanelBod
   const cellPrefixCls = `${prefixCls}-cell`;
 
   // ============================= Context ==============================
-  const {
-    onCellDblClick,
-    classNames: pickerClassNames,
-    styles,
-  } = React.useContext(PickerHackContext);
+  const { onCellDblClick } = React.useContext(PickerHackContext);
 
   // ============================== Value ===============================
   const matchValues = (date: DateType) =>
@@ -127,7 +125,7 @@ export default function PanelBody<DateType extends object = any>(props: PanelBod
         <td
           key={col}
           title={title}
-          className={classNames(cellPrefixCls, pickerClassNames?.popupItem, {
+          className={cls(cellPrefixCls, classNames.item, {
             [`${cellPrefixCls}-disabled`]: disabled,
             [`${cellPrefixCls}-hover`]: (hoverValue || []).some((date) =>
               isSame(generateConfig, locale, currentDate, date, type),
@@ -142,7 +140,7 @@ export default function PanelBody<DateType extends object = any>(props: PanelBod
               matchValues(currentDate),
             ...getCellClassName(currentDate),
           })}
-          style={styles?.popupItem}
+          style={styles.item}
           onClick={() => {
             if (!disabled) {
               onSelect(currentDate);
@@ -186,14 +184,8 @@ export default function PanelBody<DateType extends object = any>(props: PanelBod
 
   // ============================== Render ==============================
   return (
-    <div
-      className={classNames(`${prefixCls}-body`, pickerClassNames?.popupBody)}
-      style={styles?.popupBody}
-    >
-      <table
-        className={classNames(`${prefixCls}-content`, pickerClassNames?.popupContent)}
-        style={styles?.popupContent}
-      >
+    <div className={cls(`${prefixCls}-body`, classNames.body)} style={styles.body}>
+      <table className={cls(`${prefixCls}-content`, classNames.content)} style={styles.content}>
         {headerCells && (
           <thead>
             <tr>{headerCells}</tr>

--- a/src/PickerPanel/PanelHeader.tsx
+++ b/src/PickerPanel/PanelHeader.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import cls from 'classnames';
 import * as React from 'react';
 import { isSameOrAfter } from '../utils/dateUtil';
 import { PickerHackContext, usePanelContext } from './context';
@@ -33,6 +33,8 @@ function PanelHeader<DateType extends object>(props: HeaderProps<DateType>) {
 
   const {
     prefixCls,
+    classNames,
+    styles,
 
     // Icons
     prevIcon = '\u2039',
@@ -118,17 +120,14 @@ function PanelHeader<DateType extends object>(props: HeaderProps<DateType>) {
   const superNextBtnCls = `${headerPrefixCls}-super-next-btn`;
 
   return (
-    <div className={headerPrefixCls}>
+    <div className={cls(headerPrefixCls, classNames.header)} style={styles.header}>
       {superOffset && (
         <button
           type="button"
           aria-label={locale.previousYear}
           onClick={() => onSuperOffset(-1)}
           tabIndex={-1}
-          className={classNames(
-            superPrevBtnCls,
-            disabledSuperOffsetPrev && `${superPrevBtnCls}-disabled`,
-          )}
+          className={cls(superPrevBtnCls, disabledSuperOffsetPrev && `${superPrevBtnCls}-disabled`)}
           disabled={disabledSuperOffsetPrev}
           style={hidePrev ? HIDDEN_STYLE : {}}
         >
@@ -141,7 +140,7 @@ function PanelHeader<DateType extends object>(props: HeaderProps<DateType>) {
           aria-label={locale.previousMonth}
           onClick={() => onOffset(-1)}
           tabIndex={-1}
-          className={classNames(prevBtnCls, disabledOffsetPrev && `${prevBtnCls}-disabled`)}
+          className={cls(prevBtnCls, disabledOffsetPrev && `${prevBtnCls}-disabled`)}
           disabled={disabledOffsetPrev}
           style={hidePrev ? HIDDEN_STYLE : {}}
         >
@@ -155,7 +154,7 @@ function PanelHeader<DateType extends object>(props: HeaderProps<DateType>) {
           aria-label={locale.nextMonth}
           onClick={() => onOffset(1)}
           tabIndex={-1}
-          className={classNames(nextBtnCls, disabledOffsetNext && `${nextBtnCls}-disabled`)}
+          className={cls(nextBtnCls, disabledOffsetNext && `${nextBtnCls}-disabled`)}
           disabled={disabledOffsetNext}
           style={hideNext ? HIDDEN_STYLE : {}}
         >
@@ -168,10 +167,7 @@ function PanelHeader<DateType extends object>(props: HeaderProps<DateType>) {
           aria-label={locale.nextYear}
           onClick={() => onSuperOffset(1)}
           tabIndex={-1}
-          className={classNames(
-            superNextBtnCls,
-            disabledSuperOffsetNext && `${superNextBtnCls}-disabled`,
-          )}
+          className={cls(superNextBtnCls, disabledSuperOffsetNext && `${superNextBtnCls}-disabled`)}
           disabled={disabledSuperOffsetNext}
           style={hideNext ? HIDDEN_STYLE : {}}
         >

--- a/src/PickerPanel/TimePanel/TimePanelBody/TimeColumn.tsx
+++ b/src/PickerPanel/TimePanel/TimePanelBody/TimeColumn.tsx
@@ -1,7 +1,7 @@
-import classNames from 'classnames';
+import cls from 'classnames';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import * as React from 'react';
-import { PickerHackContext, usePanelContext } from '../../context';
+import { usePanelContext } from '../../context';
 import useScrollTo from './useScrollTo';
 
 const SCROLL_DELAY = 300;
@@ -32,8 +32,7 @@ export default function TimeColumn<DateType extends object>(props: TimeUnitColum
   const { units, value, optionalValue, type, onChange, onHover, onDblClick, changeOnScroll } =
     props;
 
-  const { prefixCls, cellRender, now, locale } = usePanelContext<DateType>();
-  const { classNames: pickerClassNames, styles } = React.useContext(PickerHackContext);
+  const { prefixCls, cellRender, now, locale, classNames, styles } = usePanelContext<DateType>();
 
   const panelPrefixCls = `${prefixCls}-time-panel`;
   const cellPrefixCls = `${prefixCls}-time-panel-cell`;
@@ -104,8 +103,8 @@ export default function TimeColumn<DateType extends object>(props: TimeUnitColum
         return (
           <li
             key={unitValue}
-            style={styles?.popupItem}
-            className={classNames(cellPrefixCls, pickerClassNames?.popupItem, {
+            style={styles.item}
+            className={cls(cellPrefixCls, classNames.item, {
               [`${cellPrefixCls}-selected`]: value === unitValue,
               [`${cellPrefixCls}-disabled`]: disabled,
             })}

--- a/src/PickerPanel/TimePanel/TimePanelBody/index.tsx
+++ b/src/PickerPanel/TimePanel/TimePanelBody/index.tsx
@@ -4,7 +4,7 @@ import type { SharedPanelProps, SharedTimeProps } from '../../../interface';
 import { formatValue } from '../../../utils/dateUtil';
 import { PickerHackContext, usePanelContext } from '../../context';
 import TimeColumn, { type Unit } from './TimeColumn';
-import classNames from 'classnames';
+import cls from 'classnames';
 
 function isAM(hour: number) {
   return hour < 12;
@@ -29,6 +29,8 @@ export default function TimePanelBody<DateType extends object = any>(
 
   const {
     prefixCls,
+    classNames,
+    styles,
     values,
     generateConfig,
     locale,
@@ -39,11 +41,7 @@ export default function TimePanelBody<DateType extends object = any>(
 
   const value = values?.[0] || null;
 
-  const {
-    onCellDblClick,
-    classNames: pickerClassNames,
-    styles,
-  } = React.useContext(PickerHackContext);
+  const { onCellDblClick } = React.useContext(PickerHackContext);
 
   // ========================== Info ==========================
   const [getValidTime, rowHourUnits, getMinuteUnits, getSecondUnits, getMillisecondUnits] =
@@ -273,10 +271,7 @@ export default function TimePanelBody<DateType extends object = any>(
   };
 
   return (
-    <div
-      className={classNames(`${prefixCls}-content`, pickerClassNames?.popupContent)}
-      style={styles?.popupContent}
-    >
+    <div className={cls(`${prefixCls}-content`, classNames.content)} style={styles.content}>
       {showHour && (
         <TimeColumn
           units={hourUnits}

--- a/src/PickerPanel/context.ts
+++ b/src/PickerPanel/context.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import type { PanelMode, SemanticStructure, SharedPanelProps } from '../interface';
+import type { PanelMode, SharedPanelProps } from '../interface';
+import type { FilledPanelClassNames, FilledPanelStyles } from '../hooks/useSemantic';
 
 export interface PanelContextProps<DateType extends object = any>
   extends Pick<
@@ -31,6 +32,9 @@ export interface PanelContextProps<DateType extends object = any>
 
   // Shared
   now: DateType;
+
+  classNames: FilledPanelClassNames;
+  styles: FilledPanelStyles;
 }
 
 /** Used for each single Panel. e.g. DatePanel */
@@ -49,7 +53,7 @@ export function useInfo<DateType extends object = any>(
 ): [sharedProps: PanelContextProps<DateType>, now: DateType] {
   const {
     prefixCls,
-    generateConfig,
+    // generateConfig,
     locale,
     disabledDate,
     minDate,
@@ -69,6 +73,9 @@ export function useInfo<DateType extends object = any>(
     superNextIcon,
   } = props;
 
+  // ======================= Context ========================
+  const { classNames, styles, generateConfig } = usePanelContext();
+
   // ========================= MISC =========================
   const now = generateConfig.getNow();
 
@@ -78,6 +85,8 @@ export function useInfo<DateType extends object = any>(
     values,
     pickerValue,
     prefixCls,
+    classNames,
+    styles,
     disabledDate,
     minDate,
     maxDate,
@@ -106,8 +115,6 @@ export interface PickerHackContextProps {
   hideNext?: boolean;
   hideHeader?: boolean;
   onCellDblClick?: () => void;
-  styles?: Partial<Record<SemanticStructure, React.CSSProperties>>;
-  classNames?: Partial<Record<SemanticStructure, string>>;
 }
 
 /**

--- a/src/PickerPanel/context.ts
+++ b/src/PickerPanel/context.ts
@@ -39,6 +39,9 @@ export interface PanelContextProps<DateType extends object = any>
 
   // Shared
   now: DateType;
+
+  classNames: FilledPanelClassNames;
+  styles: FilledPanelStyles;
 }
 
 /** Used for each single Panel. e.g. DatePanel */

--- a/src/PickerPanel/context.ts
+++ b/src/PickerPanel/context.ts
@@ -2,6 +2,13 @@ import * as React from 'react';
 import type { PanelMode, SharedPanelProps } from '../interface';
 import type { FilledPanelClassNames, FilledPanelStyles } from '../hooks/useSemantic';
 
+export interface SharedPanelContextProps {
+  classNames: FilledPanelClassNames;
+  styles: FilledPanelStyles;
+}
+
+export const SharedPanelContext = React.createContext<SharedPanelContextProps>(null!);
+
 export interface PanelContextProps<DateType extends object = any>
   extends Pick<
     SharedPanelProps<DateType>,
@@ -32,9 +39,6 @@ export interface PanelContextProps<DateType extends object = any>
 
   // Shared
   now: DateType;
-
-  classNames: FilledPanelClassNames;
-  styles: FilledPanelStyles;
 }
 
 /** Used for each single Panel. e.g. DatePanel */
@@ -51,9 +55,11 @@ export function useInfo<DateType extends object = any>(
   props: SharedPanelProps<DateType>,
   panelType: PanelMode,
 ): [sharedProps: PanelContextProps<DateType>, now: DateType] {
+  // TODO: this is not good to get from each props.
+  // Should move to `SharedPanelContext` instead.
   const {
     prefixCls,
-    // generateConfig,
+    generateConfig,
     locale,
     disabledDate,
     minDate,
@@ -74,7 +80,7 @@ export function useInfo<DateType extends object = any>(
   } = props;
 
   // ======================= Context ========================
-  const { classNames, styles, generateConfig } = usePanelContext();
+  const { classNames, styles } = React.useContext(SharedPanelContext);
 
   // ========================= MISC =========================
   const now = generateConfig.getNow();

--- a/src/PickerPanel/index.tsx
+++ b/src/PickerPanel/index.tsx
@@ -378,17 +378,15 @@ function PickerPanel<DateType extends object = any>(
     DatePanel) as typeof DatePanel;
 
   // ======================== Context =========================
-  const mergedStyles = pickerStyles ?? panelStyles;
-  const mergedClassNames = pickerClassNames ?? panelClassNames;
   const parentHackContext = React.useContext(PickerHackContext);
   const pickerPanelContext = React.useMemo(
     () => ({
       ...parentHackContext,
       hideHeader,
-      classNames: mergedClassNames,
-      styles: mergedStyles,
+      classNames: pickerClassNames ?? panelClassNames ?? {},
+      styles: pickerStyles ?? panelStyles ?? {},
     }),
-    [parentHackContext, hideHeader, mergedClassNames, mergedStyles],
+    [parentHackContext, hideHeader, pickerClassNames, panelClassNames, pickerStyles, panelStyles],
   );
 
   // ======================== Warnings ========================

--- a/src/PickerPanel/index.tsx
+++ b/src/PickerPanel/index.tsx
@@ -11,6 +11,7 @@ import type {
   Locale,
   OnPanelChange,
   PanelMode,
+  PanelSemanticName,
   PickerMode,
   SharedPanelProps,
   SharedTimeProps,
@@ -19,7 +20,7 @@ import PickerContext from '../PickerInput/context';
 import useCellRender from '../PickerInput/hooks/useCellRender';
 import { isSame } from '../utils/dateUtil';
 import { pickProps, toArray } from '../utils/miscUtil';
-import { PickerHackContext } from './context';
+import { PickerHackContext, SharedPanelContext } from './context';
 import DatePanel from './DatePanel';
 import DateTimePanel from './DateTimePanel';
 import DecadePanel from './DecadePanel';
@@ -127,7 +128,6 @@ export interface SinglePickerPanelProps<DateType extends object = any>
   onChange?: (date: DateType) => void;
 }
 
-type PanelSemanticName = 'popupBody' | 'popupContent' | 'popupItem';
 export type PickerPanelProps<DateType extends object = any> = BasePickerPanelProps<DateType> & {
   /** multiple selection. Not support time or datetime picker */
   multiple?: boolean;
@@ -378,15 +378,21 @@ function PickerPanel<DateType extends object = any>(
     DatePanel) as typeof DatePanel;
 
   // ======================== Context =========================
+  const sharedPanelContext = React.useMemo(
+    () => ({
+      classNames: pickerClassNames?.popup ?? panelClassNames ?? {},
+      styles: pickerStyles?.popup ?? panelStyles ?? {},
+    }),
+    [pickerClassNames, panelClassNames, pickerStyles, panelStyles],
+  );
+
   const parentHackContext = React.useContext(PickerHackContext);
   const pickerPanelContext = React.useMemo(
     () => ({
       ...parentHackContext,
       hideHeader,
-      classNames: pickerClassNames ?? panelClassNames ?? {},
-      styles: pickerStyles ?? panelStyles ?? {},
     }),
-    [parentHackContext, hideHeader, pickerClassNames, panelClassNames, pickerStyles, panelStyles],
+    [parentHackContext, hideHeader],
   );
 
   // ======================== Warnings ========================
@@ -420,40 +426,42 @@ function PickerPanel<DateType extends object = any>(
   ]);
 
   return (
-    <PickerHackContext.Provider value={pickerPanelContext}>
-      <div
-        ref={rootRef}
-        tabIndex={tabIndex}
-        className={classNames(panelCls, {
-          [`${panelCls}-rtl`]: direction === 'rtl',
-        })}
-      >
-        <PanelComponent
-          {...panelProps}
-          // Time
-          showTime={mergedShowTime}
-          // MISC
-          prefixCls={mergedPrefixCls}
-          locale={filledLocale}
-          generateConfig={generateConfig}
-          // Mode
-          onModeChange={triggerModeChange}
-          // Value
-          pickerValue={mergedPickerValue}
-          onPickerValueChange={(nextPickerValue) => {
-            setPickerValue(nextPickerValue, true);
-          }}
-          value={mergedValue[0]}
-          onSelect={onPanelValueSelect}
-          values={mergedValue}
-          // Render
-          cellRender={onInternalCellRender}
-          // Hover
-          hoverRangeValue={hoverRangeDate}
-          hoverValue={hoverValue}
-        />
-      </div>
-    </PickerHackContext.Provider>
+    <SharedPanelContext.Provider value={sharedPanelContext}>
+      <PickerHackContext.Provider value={pickerPanelContext}>
+        <div
+          ref={rootRef}
+          tabIndex={tabIndex}
+          className={classNames(panelCls, {
+            [`${panelCls}-rtl`]: direction === 'rtl',
+          })}
+        >
+          <PanelComponent
+            {...panelProps}
+            // Time
+            showTime={mergedShowTime}
+            // MISC
+            prefixCls={mergedPrefixCls}
+            locale={filledLocale}
+            generateConfig={generateConfig}
+            // Mode
+            onModeChange={triggerModeChange}
+            // Value
+            pickerValue={mergedPickerValue}
+            onPickerValueChange={(nextPickerValue) => {
+              setPickerValue(nextPickerValue, true);
+            }}
+            value={mergedValue[0]}
+            onSelect={onPanelValueSelect}
+            values={mergedValue}
+            // Render
+            cellRender={onInternalCellRender}
+            // Hover
+            hoverRangeValue={hoverRangeDate}
+            hoverValue={hoverValue}
+          />
+        </div>
+      </PickerHackContext.Provider>
+    </SharedPanelContext.Provider>
   );
 }
 

--- a/src/hooks/useSemantic.ts
+++ b/src/hooks/useSemantic.ts
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+import type { SharedPickerProps } from '../interface';
+
+export type FilledClassNames = NonNullable<SharedPickerProps['classNames']> & {
+  popup: NonNullable<SharedPickerProps['classNames']>['popup'];
+};
+
+export type FilledStyles = NonNullable<SharedPickerProps['styles']> & {
+  popup: NonNullable<SharedPickerProps['styles']>['popup'];
+};
+
+/**
+ * Convert `classNames` & `styles` to a fully filled object
+ */
+export default function useSemantic(
+  classNames?: SharedPickerProps['classNames'],
+  styles?: SharedPickerProps['styles'],
+) {
+  return useMemo(() => {
+    const mergedClassNames: FilledClassNames = {
+      ...classNames,
+      popup: classNames?.popup || {},
+    };
+
+    const mergedStyles: FilledStyles = {
+      ...styles,
+      popup: styles?.popup || {},
+    };
+
+    return [mergedClassNames, mergedStyles] as const;
+  }, [classNames, styles]);
+}

--- a/src/hooks/useSemantic.ts
+++ b/src/hooks/useSemantic.ts
@@ -1,12 +1,16 @@
 import { useMemo } from 'react';
 import type { SharedPickerProps } from '../interface';
 
+export type FilledPanelClassNames = NonNullable<SharedPickerProps['classNames']>['popup'];
+
+export type FilledPanelStyles = NonNullable<SharedPickerProps['styles']>['popup'];
+
 export type FilledClassNames = NonNullable<SharedPickerProps['classNames']> & {
-  popup: NonNullable<SharedPickerProps['classNames']>['popup'];
+  popup: FilledPanelClassNames;
 };
 
 export type FilledStyles = NonNullable<SharedPickerProps['styles']> & {
-  popup: NonNullable<SharedPickerProps['styles']>['popup'];
+  popup: FilledPanelStyles;
 };
 
 /**

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -329,12 +329,13 @@ export interface SharedPickerProps<DateType extends object = any>
   prefixCls?: string;
   className?: string;
   style?: React.CSSProperties;
+  rootClassName?: string;
 
   styles?: Partial<Record<SemanticName, React.CSSProperties>> & {
-    popup: Partial<Record<PanelSemanticName, React.CSSProperties>>;
+    popup?: Partial<Record<PanelSemanticName, React.CSSProperties>>;
   };
   classNames?: Partial<Record<SemanticName, string>> & {
-    popup: Partial<Record<PanelSemanticName, string>>;
+    popup?: Partial<Record<PanelSemanticName, string>>;
   };
 
   // Config

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -281,8 +281,6 @@ export type Components<DateType extends object = any> = Partial<
 >;
 
 // ========================= Picker =========================
-export type SemanticStructure = 'popup' | 'popupBody' | 'popupContent' | 'popupItem' | 'suffix' | 'prefix' | 'input';
-
 export type CustomFormat<DateType> = (value: DateType) => string;
 
 export type FormatType<DateType = any> = string | CustomFormat<DateType>;
@@ -313,6 +311,10 @@ export type LegacyOnKeyDown = (
   preventDefault: VoidFunction,
 ) => void;
 
+export type SemanticName = 'root' | 'prefix' | 'input' | 'suffix';
+
+export type PanelSemanticName = 'root' | 'header' | 'body' | 'content' | 'item' | 'footer';
+
 export interface SharedPickerProps<DateType extends object = any>
   extends SharedHTMLAttrs,
     Pick<
@@ -328,8 +330,12 @@ export interface SharedPickerProps<DateType extends object = any>
   className?: string;
   style?: React.CSSProperties;
 
-  styles?: Partial<Record<SemanticStructure, React.CSSProperties>>;
-  classNames?: Partial<Record<SemanticStructure, string>>;
+  styles?: Partial<Record<SemanticName, React.CSSProperties>> & {
+    popup: Partial<Record<PanelSemanticName, React.CSSProperties>>;
+  };
+  classNames?: Partial<Record<SemanticName, string>> & {
+    popup: Partial<Record<PanelSemanticName, string>>;
+  };
 
   // Config
   locale: Locale;

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -1432,6 +1432,7 @@ describe('Picker.Basic', () => {
 
   it('classNames and styles should support time panel', async () => {
     const testClassNames = {
+      root: 'test-root',
       input: 'test-input',
       prefix: 'test-prefix',
       suffix: 'test-suffix',
@@ -1442,6 +1443,7 @@ describe('Picker.Basic', () => {
     };
 
     const testStyles = {
+      root: { color: 'red' },
       input: { color: 'red' },
       prefix: { color: 'green' },
       suffix: { color: 'blue' },
@@ -1470,15 +1472,20 @@ describe('Picker.Basic', () => {
         generateConfig={momentGenerateConfig}
       />,
     );
+    const root = container.querySelector('.rc-picker');
     const input = container.querySelectorAll('.rc-picker-input input')[0];
     const prefix = container.querySelector('.rc-picker-prefix');
     const suffix = container.querySelector('.rc-picker-suffix');
+
+    expect(root).toHaveClass(testClassNames.root);
+    expect(root).toHaveStyle(testStyles.root);
     expect(input).toHaveClass(testClassNames.input);
     expect(input).toHaveStyle(testStyles.input);
     expect(prefix).toHaveClass(testClassNames.prefix);
     expect(prefix).toHaveStyle(testStyles.prefix);
     expect(suffix).toHaveClass(testClassNames.suffix);
     expect(suffix).toHaveStyle(testStyles.suffix);
+
     const { container: panel } = render(
       <PickerPanel
         classNames={testPopupClassNames}
@@ -1494,6 +1501,14 @@ describe('Picker.Basic', () => {
     expect(content).toHaveStyle(testPopupStyles.content);
     expect(item).toHaveClass(testPopupClassNames.item);
     expect(item).toHaveStyle(testPopupStyles.item);
+  });
+
+  it('rootClassName', () => {
+    render(<DayPicker rootClassName="bamboo" open />);
+
+    expect(document.body.querySelectorAll('.bamboo')).toHaveLength(2);
+    expect(document.body.querySelector('.rc-picker')).toHaveClass('bamboo');
+    expect(document.body.querySelector('.rc-picker-dropdown')).toHaveClass('bamboo');
   });
 
   it('showTime config should have format', () => {

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -1351,42 +1351,53 @@ describe('Picker.Basic', () => {
   });
 
   it('support classNames and styles', () => {
-    const customClassNames = {
-      popup: 'custom-popup',
-      popupBody: 'custom-body',
-      popupContent: 'custom-content',
-      popupItem: 'custom-item',
+    const popupClassNames = {
+      root: 'custom-popup',
+      body: 'custom-body',
+      content: 'custom-content',
+      item: 'custom-item',
     };
-    const customStyles = {
-      popup: { color: 'red' },
-      popupBody: { color: 'green' },
-      popupContent: { color: 'blue' },
-      popupItem: { color: 'yellow' },
+    const popupStyles = {
+      root: { color: 'red' },
+      body: { color: 'green' },
+      content: { color: 'blue' },
+      item: { color: 'yellow' },
     };
-    render(<DayPicker classNames={customClassNames} styles={customStyles} open />);
+    render(
+      <DayPicker
+        classNames={{
+          popup: popupClassNames,
+        }}
+        styles={{
+          popup: popupStyles,
+        }}
+        open
+      />,
+    );
 
-    expect(document.querySelector('.rc-picker-dropdown')).toHaveClass(customClassNames.popup);
-    expect(document.querySelector('.rc-picker-dropdown')).toHaveStyle(customStyles.popup);
+    expect(document.querySelector('.rc-picker-dropdown')).toHaveClass(popupClassNames.root);
+    expect(document.querySelector('.rc-picker-dropdown')).toHaveStyle(popupStyles.root);
     const content = document.querySelector('.rc-picker-content');
     const body = document.querySelector('.rc-picker-body');
     const item = document.querySelector('.rc-picker-cell');
-    expect(content).toHaveClass(customClassNames.popupContent);
-    expect(content).toHaveStyle(customStyles.popupContent);
-    expect(body).toHaveClass(customClassNames.popupBody);
-    expect(body).toHaveStyle(customStyles.popupBody);
-    expect(item).toHaveClass(customClassNames.popupItem);
-    expect(item).toHaveStyle(customStyles.popupItem);
+    expect(content).toHaveClass(popupClassNames.content);
+    expect(content).toHaveStyle(popupStyles.content);
+    expect(body).toHaveClass(popupClassNames.body);
+    expect(body).toHaveStyle(popupStyles.body);
+    expect(item).toHaveClass(popupClassNames.item);
+    expect(item).toHaveStyle(popupStyles.item);
   });
+
   it('support classNames and styles for panel', () => {
     const customClassNames = {
-      popupBody: 'custom-body',
-      popupContent: 'custom-content',
-      popupItem: 'custom-item',
+      body: 'custom-body',
+      content: 'custom-content',
+      item: 'custom-item',
     };
     const customStyles = {
-      popupBody: { color: 'green' },
-      popupContent: { color: 'blue' },
-      popupItem: { color: 'yellow' },
+      body: { color: 'green' },
+      content: { color: 'blue' },
+      item: { color: 'yellow' },
     };
     render(
       <PickerPanel
@@ -1399,33 +1410,43 @@ describe('Picker.Basic', () => {
     const content = document.querySelector('.rc-picker-content');
     const body = document.querySelector('.rc-picker-body');
     const item = document.querySelector('.rc-picker-cell');
-    expect(content).toHaveClass(customClassNames.popupContent);
-    expect(content).toHaveStyle(customStyles.popupContent);
-    expect(body).toHaveClass(customClassNames.popupBody);
-    expect(body).toHaveStyle(customStyles.popupBody);
-    expect(item).toHaveClass(customClassNames.popupItem);
-    expect(item).toHaveStyle(customStyles.popupItem);
+    expect(content).toHaveClass(customClassNames.content);
+    expect(content).toHaveStyle(customStyles.content);
+    expect(body).toHaveClass(customClassNames.body);
+    expect(body).toHaveStyle(customStyles.body);
+    expect(item).toHaveClass(customClassNames.item);
+    expect(item).toHaveStyle(customStyles.item);
   });
+
   it('classNames and styles should support time panel', async () => {
     const testClassNames = {
       input: 'test-input',
       prefix: 'test-prefix',
       suffix: 'test-suffix',
-      popupContent: 'custom-content',
-      popupItem: 'custom-item',
     };
+    const testPopupClassNames = {
+      content: 'test-popup-content',
+      item: 'test-popup-item',
+    };
+
     const testStyles = {
       input: { color: 'red' },
       prefix: { color: 'green' },
       suffix: { color: 'blue' },
-      popupContent: { color: 'blue' },
-      popupItem: { color: 'yellow' },
     };
+    const testPopupStyles = {
+      content: { color: 'blue' },
+      item: { color: 'yellow' },
+    };
+
     const defaultValue = moment('2019-11-28 01:02:03');
     const { container } = render(
       <Picker
-        classNames={testClassNames}
-        styles={testStyles}
+        classNames={{ ...testClassNames, popup: testPopupClassNames }}
+        styles={{
+          ...testStyles,
+          popup: testPopupStyles,
+        }}
         prefix="prefix"
         suffixIcon="suffix"
         defaultValue={defaultValue}
@@ -1437,7 +1458,7 @@ describe('Picker.Basic', () => {
         generateConfig={momentGenerateConfig}
       />,
     );
-    const input = container.querySelectorAll('.rc-picker-input')[0];
+    const input = container.querySelectorAll('.rc-picker-input input')[0];
     const prefix = container.querySelector('.rc-picker-prefix');
     const suffix = container.querySelector('.rc-picker-suffix');
     expect(input).toHaveClass(testClassNames.input);
@@ -1448,8 +1469,8 @@ describe('Picker.Basic', () => {
     expect(suffix).toHaveStyle(testStyles.suffix);
     const { container: panel } = render(
       <PickerPanel
-        classNames={testClassNames}
-        styles={testStyles}
+        classNames={testPopupClassNames}
+        styles={testPopupStyles}
         picker="time"
         locale={enUS}
         generateConfig={momentGenerateConfig}
@@ -1457,11 +1478,12 @@ describe('Picker.Basic', () => {
     );
     const content = panel.querySelector('.rc-picker-content');
     const item = panel.querySelector('.rc-picker-time-panel-cell');
-    expect(content).toHaveClass(testClassNames.popupContent);
-    expect(content).toHaveStyle(testStyles.popupContent);
-    expect(item).toHaveClass(testClassNames.popupItem);
-    expect(item).toHaveStyle(testStyles.popupItem);
+    expect(content).toHaveClass(testPopupClassNames.content);
+    expect(content).toHaveStyle(testPopupStyles.content);
+    expect(item).toHaveClass(testPopupClassNames.item);
+    expect(item).toHaveStyle(testPopupStyles.item);
   });
+
   it('showTime config should have format', () => {
     render(
       <DayPicker

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -1353,12 +1353,14 @@ describe('Picker.Basic', () => {
   it('support classNames and styles', () => {
     const popupClassNames = {
       root: 'custom-popup',
+      header: 'custom-header',
       body: 'custom-body',
       content: 'custom-content',
       item: 'custom-item',
     };
     const popupStyles = {
       root: { color: 'red' },
+      header: { color: 'purple' },
       body: { color: 'green' },
       content: { color: 'blue' },
       item: { color: 'yellow' },
@@ -1377,13 +1379,18 @@ describe('Picker.Basic', () => {
 
     expect(document.querySelector('.rc-picker-dropdown')).toHaveClass(popupClassNames.root);
     expect(document.querySelector('.rc-picker-dropdown')).toHaveStyle(popupStyles.root);
-    const content = document.querySelector('.rc-picker-content');
+
+    const header = document.querySelector('.rc-picker-header');
     const body = document.querySelector('.rc-picker-body');
+    const content = document.querySelector('.rc-picker-content');
     const item = document.querySelector('.rc-picker-cell');
-    expect(content).toHaveClass(popupClassNames.content);
-    expect(content).toHaveStyle(popupStyles.content);
+
+    expect(header).toHaveClass(popupClassNames.header);
+    expect(header).toHaveStyle(popupStyles.header);
     expect(body).toHaveClass(popupClassNames.body);
     expect(body).toHaveStyle(popupStyles.body);
+    expect(content).toHaveClass(popupClassNames.content);
+    expect(content).toHaveStyle(popupStyles.content);
     expect(item).toHaveClass(popupClassNames.item);
     expect(item).toHaveStyle(popupStyles.item);
   });

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -1357,6 +1357,7 @@ describe('Picker.Basic', () => {
       body: 'custom-body',
       content: 'custom-content',
       item: 'custom-item',
+      footer: 'custom-footer',
     };
     const popupStyles = {
       root: { color: 'red' },
@@ -1364,6 +1365,7 @@ describe('Picker.Basic', () => {
       body: { color: 'green' },
       content: { color: 'blue' },
       item: { color: 'yellow' },
+      footer: { color: 'orange' },
     };
     render(
       <DayPicker
@@ -1384,6 +1386,7 @@ describe('Picker.Basic', () => {
     const body = document.querySelector('.rc-picker-body');
     const content = document.querySelector('.rc-picker-content');
     const item = document.querySelector('.rc-picker-cell');
+    const footer = document.querySelector('.rc-picker-footer');
 
     expect(header).toHaveClass(popupClassNames.header);
     expect(header).toHaveStyle(popupStyles.header);
@@ -1393,6 +1396,8 @@ describe('Picker.Basic', () => {
     expect(content).toHaveStyle(popupStyles.content);
     expect(item).toHaveClass(popupClassNames.item);
     expect(item).toHaveStyle(popupStyles.item);
+    expect(footer).toHaveClass(popupClassNames.footer);
+    expect(footer).toHaveStyle(popupStyles.footer);
   });
 
   it('support classNames and styles for panel', () => {


### PR DESCRIPTION
* 把 antd 侧的逻辑全部下沉到 rc-picker 中以优化体积同时简化处理逻辑。
* 将弹窗语义化结构收到 popup 中
* 添加 rootClassName 支持
* 微调 Context 逻辑，添加一个 TODO 标记问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持通过 `rootClassName` 属性自定义根节点和下拉弹窗的类名。
  - 支持更细粒度的样式和类名定制，可为弹窗各部分（如 header、body、content、item、footer）分别设置 classNames 和 styles。

- **重构**
  - 统一和优化了样式与类名的传递方式，引入了新的语义化样式处理机制，提升了样式管理的灵活性和一致性。

- **测试**
  - 增强了对 classNames、styles 及 rootClassName 应用效果的测试覆盖，确保各部分样式和类名正确生效。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->