### PR TITLE
fix: add 'preset-click' operation type to RangePicker

### DIFF
--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -495,6 +495,7 @@ function RangePicker<DateType extends object = any>(
     const passed = triggerSubmitChange(nextValues);
 
     if (passed) {
+      lastOperation('preset-click');
       triggerOpen(false, { force: true });
     }
   };

--- a/src/PickerInput/hooks/useRangeActive.ts
+++ b/src/PickerInput/hooks/useRangeActive.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { RangeValueType } from '../RangePicker';
 import useLockEffect from './useLockEffect';
 
-export type OperationType = 'input' | 'panel';
+export type OperationType = 'input' | 'panel' | 'preset-click';
 
 export type NextActive<DateType> = (nextValue: RangeValueType<DateType>) => number | null;
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
fix: [https://github.com/ant-design/ant-design/issues/54436](https://github.com/ant-design/ant-design/issues/54436)

### 💡 Background and Solution
DatePicker with needConfirm={false}, showTime, and presets settings fails to auto-close the dropdown when a preset option is clicked.
DatePicker 设置 needConfirm={false} / showTime / presets 的时候，点击 presets 选项后无法自动关闭弹出层；翻译成为英文

onPresetSubmit 回调中调用 lastOperation 方法传入 preset-click；

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix popup not auto-closing when clicking presets after setting presets / needConfirm={false} |
| 🇨🇳 Chinese | 修复设置 presets / needConfirm={false} 后点击 presets 无法自动关闭弹出层 |

