### PR TITLE
refactor: Upgrade utils and replace useMergedState

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@rc-component/resize-observer": "^1.0.0",
     "@rc-component/trigger": "^3.0.0",
-    "@rc-component/util": "^1.2.1",
+    "@rc-component/util": "^1.3.0",
     "classnames": "^2.2.1",
     "rc-overflow": "^1.3.2"
   },

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -1,4 +1,4 @@
-import { useEvent, useMergedState } from '@rc-component/util';
+import { useEvent, useControlledState } from '@rc-component/util';
 import cls from 'classnames';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import omit from '@rc-component/util/lib/omit';
@@ -310,9 +310,7 @@ function RangePicker<DateType extends object = any>(
   }, [showTime, activeIndex, calendarValue, activeIndexList]);
 
   // ========================= Mode =========================
-  const [modes, setModes] = useMergedState<[PanelMode, PanelMode]>([picker, picker], {
-    value: mode,
-  });
+  const [modes, setModes] = useControlledState<[PanelMode, PanelMode]>([picker, picker], mode);
 
   const mergedMode = modes[activeIndex] || picker;
 

--- a/src/PickerInput/SinglePicker.tsx
+++ b/src/PickerInput/SinglePicker.tsx
@@ -1,4 +1,4 @@
-import { useEvent, useMergedState } from '@rc-component/util';
+import { useEvent, useControlledState } from '@rc-component/util';
 import cls from 'classnames';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import omit from '@rc-component/util/lib/omit';
@@ -259,9 +259,7 @@ function Picker<DateType extends object = any>(
   };
 
   // ========================= Mode =========================
-  const [mergedMode, setMode] = useMergedState(picker, {
-    value: mode,
-  });
+  const [mergedMode, setMode] = useControlledState(picker, mode);
 
   /** Extends from `mergedMode` to patch `datetime` mode */
   const internalMode: InternalMode = mergedMode === 'date' && showTime ? 'datetime' : mergedMode;

--- a/src/PickerInput/hooks/useDelayState.ts
+++ b/src/PickerInput/hooks/useDelayState.ts
@@ -1,4 +1,4 @@
-import { useEvent, useMergedState } from '@rc-component/util';
+import { useEvent, useControlledState } from '@rc-component/util';
 import raf from '@rc-component/util/lib/raf';
 import React from 'react';
 
@@ -11,7 +11,7 @@ export default function useDelayState<T>(
   defaultValue?: T,
   onChange?: (next: T) => void,
 ): [state: T, setState: (nextState: T, immediately?: boolean) => void] {
-  const [state, setState] = useMergedState<T>(defaultValue, { value });
+  const [state, setState] = useControlledState<T>(defaultValue, value);
 
   const nextValueRef = React.useRef<T>(value);
 

--- a/src/PickerInput/hooks/useDelayState.ts
+++ b/src/PickerInput/hooks/useDelayState.ts
@@ -1,4 +1,4 @@
-import { useEvent, useControlledState } from '@rc-component/util';
+import { useEvent, useControlledState, useMergedState } from '@rc-component/util';
 import raf from '@rc-component/util/lib/raf';
 import React from 'react';
 
@@ -13,6 +13,14 @@ export default function useDelayState<T>(
 ): [state: T, setState: (nextState: T, immediately?: boolean) => void] {
   const [state, setState] = useControlledState<T>(defaultValue, value);
 
+  // Need force update to ensure React re-render
+  const [, forceUpdate] = React.useState({});
+
+  const triggerUpdate = useEvent((nextState: T) => {
+    setState(nextState);
+    forceUpdate({});
+  });
+
   const nextValueRef = React.useRef<T>(value);
 
   // ============================= Update =============================
@@ -22,7 +30,7 @@ export default function useDelayState<T>(
   };
 
   const doUpdate = useEvent(() => {
-    setState(nextValueRef.current);
+    triggerUpdate(nextValueRef.current);
 
     if (onChange && state !== nextValueRef.current) {
       onChange(nextValueRef.current);

--- a/src/PickerInput/hooks/useDelayState.ts
+++ b/src/PickerInput/hooks/useDelayState.ts
@@ -1,4 +1,4 @@
-import { useEvent, useControlledState, useMergedState } from '@rc-component/util';
+import { useEvent, useControlledState } from '@rc-component/util';
 import raf from '@rc-component/util/lib/raf';
 import React from 'react';
 

--- a/src/PickerInput/hooks/useRangePickerValue.ts
+++ b/src/PickerInput/hooks/useRangePickerValue.ts
@@ -1,4 +1,4 @@
-import { useMergedState } from '@rc-component/util';
+import { useControlledState } from '@rc-component/util';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import * as React from 'react';
 import type { GenerateConfig } from '../../generate';
@@ -72,14 +72,15 @@ export default function useRangePickerValue<DateType extends object, ValueType e
   const [startPickerValue, endPickerValue] = pickerValue;
 
   // PickerValue state
-  const [mergedStartPickerValue, setStartPickerValue] = useMergedState(
-    () => getDefaultPickerValue(0),
-    { value: startPickerValue },
+  const [mergedStartPickerValue, setStartPickerValue] = useControlledState(
+    getDefaultPickerValue(0),
+    startPickerValue,
   );
 
-  const [mergedEndPickerValue, setEndPickerValue] = useMergedState(() => getDefaultPickerValue(1), {
-    value: endPickerValue,
-  });
+  const [mergedEndPickerValue, setEndPickerValue] = useControlledState(
+    getDefaultPickerValue(1),
+    endPickerValue,
+  );
 
   // Current PickerValue
   const currentPickerValue = React.useMemo(() => {

--- a/src/PickerInput/hooks/useRangePickerValue.ts
+++ b/src/PickerInput/hooks/useRangePickerValue.ts
@@ -73,12 +73,12 @@ export default function useRangePickerValue<DateType extends object, ValueType e
 
   // PickerValue state
   const [mergedStartPickerValue, setStartPickerValue] = useControlledState(
-    getDefaultPickerValue(0),
+    () => getDefaultPickerValue(0),
     startPickerValue,
   );
 
   const [mergedEndPickerValue, setEndPickerValue] = useControlledState(
-    getDefaultPickerValue(1),
+    () => getDefaultPickerValue(1),
     endPickerValue,
   );
 

--- a/src/PickerInput/hooks/useRangeValue.ts
+++ b/src/PickerInput/hooks/useRangeValue.ts
@@ -1,4 +1,4 @@
-import { useEvent, useMergedState } from '@rc-component/util';
+import { useEvent, useControlledState } from '@rc-component/util';
 import * as React from 'react';
 import type { GenerateConfig } from '../../generate';
 import useSyncState from '../../hooks/useSyncState';
@@ -117,7 +117,7 @@ export function useInnerValue<ValueType extends DateType[], DateType extends obj
   onOk?: (dates: ValueType) => void,
 ) {
   // This is the root value which will sync with controlled or uncontrolled value
-  const [innerValue, setInnerValue] = useMergedState(defaultValue, { value });
+  const [innerValue, setInnerValue] = useControlledState(defaultValue, value);
   const mergedValue = innerValue || (EMPTY_VALUE as ValueType);
 
   // ========================= Inner Values =========================

--- a/src/PickerPanel/index.tsx
+++ b/src/PickerPanel/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { useEvent, useMergedState, warning } from '@rc-component/util';
+import { useEvent, useControlledState, warning } from '@rc-component/util';
 import * as React from 'react';
 import useLocale from '../hooks/useLocale';
 import { fillShowTimeConfig, getTimeProps } from '../hooks/useTimeConfig';
@@ -227,10 +227,7 @@ function PickerPanel<DateType extends object = any>(
   const now = generateConfig.getNow();
 
   // ========================== Mode ==========================
-  const [mergedMode, setMergedMode] = useMergedState<PanelMode>(picker, {
-    value: mode,
-    postState: (val) => val || 'date',
-  });
+  const [mergedMode, setMergedMode] = useControlledState<PanelMode>(picker || 'date', mode);
 
   const internalMode: InternalMode =
     mergedMode === 'date' && mergedShowTime ? 'datetime' : mergedMode;
@@ -241,9 +238,7 @@ function PickerPanel<DateType extends object = any>(
   // ========================= Value ==========================
   // >>> Real value
   // Interactive with `onChange` event which only trigger when the `mode` is `picker`
-  const [innerValue, setMergedValue] = useMergedState(defaultValue, {
-    value,
-  });
+  const [innerValue, setMergedValue] = useControlledState(defaultValue, value);
 
   const mergedValue = React.useMemo(() => {
     // Clean up `[null]`
@@ -282,11 +277,9 @@ function PickerPanel<DateType extends object = any>(
 
   // >>> PickerValue
   // PickerValue is used to control the current displaying panel
-  const [mergedPickerValue, setInternalPickerValue] = useMergedState(
+  const [mergedPickerValue, setInternalPickerValue] = useControlledState(
     defaultPickerValue || mergedValue[0] || now,
-    {
-      value: pickerValue,
-    },
+    pickerValue,
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
关联issue：https://github.com/ant-design/ant-design/issues/54854
替换 useMergedState 为 useControlledState

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 重构
  - 统一将多个日期/范围选择器及相关 hooks 的内部状态管理切换为更一致的受控模式，提升模式、开始/结束值与内部值的可预测性与同步性，对外行为与 API 未变。
- 杂务
  - 升级依赖 @rc-component/util 到 1.3.0，优化内部状态钩子实现与渲染一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->