### PR TITLE
fix: Fix Popup localization issue when NeedConfirm=false

### DIFF
--- a/docs/examples/range.tsx
+++ b/docs/examples/range.tsx
@@ -213,6 +213,19 @@ export default () => {
             disabledDate={disabledDate}
           />
         </div>
+        <div>
+          <h3>needConfirm is false</h3>
+          <RangePicker<Moment>
+            {...sharedProps}
+            value={undefined}
+            locale={zhCN}
+            needConfirm={false}
+            picker="time"
+            ranges={{
+              test: [moment(), moment().add(1, 'hour')],
+            }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/PickerInput/Popup/index.tsx
+++ b/src/PickerInput/Popup/index.tsx
@@ -60,7 +60,7 @@ export default function Popup<DateType extends object = any>(props: PopupProps<D
     range,
     multiple,
     activeInfo = [0, 0, 0],
-    index = 0,
+    index,
     // Presets
     presets,
     onPresetHover,

--- a/src/PickerInput/Popup/index.tsx
+++ b/src/PickerInput/Popup/index.tsx
@@ -119,7 +119,12 @@ export default function Popup<DateType extends object = any>(props: PopupProps<D
       // Arrow Offset
       const wrapperRect = wrapperRef.current.getBoundingClientRect();
       if (!wrapperRect.height || wrapperRect.right < 0) {
-        // Index is designed to be compatible with the bug of inconsistency between React 18 useEffect and React 19
+        // This is a workaround to bypass the inconsistent useEffect behavior in React 18.
+        // When wrapperRef.current.getBoundingClientRect() fails to calculate the position correctly, it enters the retry logic.
+        // Under normal circumstances, retryTimes - 1 should equal 9, and useEffect would re-execute the side effect if dependencies change.
+        // However, in React 18, the side effect is no longer re-executed in such cases.
+        // By subtracting the index of the currently active input field (index, which is either 0 or 1), we compensate for this additional execution.
+        // Related issue: https://github.com/ant-design/ant-design/issues/54885
         setRetryTimes((times) => Math.max(0, times - index - 1));
         return;
       }

--- a/src/PickerInput/Popup/index.tsx
+++ b/src/PickerInput/Popup/index.tsx
@@ -34,6 +34,8 @@ export interface PopupProps<DateType extends object = any, PresetValue = DateTyp
   activeInfo?: [activeInputLeft: number, activeInputRight: number, selectorWidth: number];
   // Direction
   direction?: 'ltr' | 'rtl';
+  // focus index
+  index: number;
 
   // Fill
   /** TimePicker or showTime only */
@@ -58,7 +60,7 @@ export default function Popup<DateType extends object = any>(props: PopupProps<D
     range,
     multiple,
     activeInfo = [0, 0, 0],
-
+    index = 0,
     // Presets
     presets,
     onPresetHover,
@@ -80,7 +82,6 @@ export default function Popup<DateType extends object = any>(props: PopupProps<D
     onOk,
     onSubmit,
   } = props;
-
   const { prefixCls } = React.useContext(PickerContext);
   const panelPrefixCls = `${prefixCls}-panel`;
 
@@ -118,7 +119,8 @@ export default function Popup<DateType extends object = any>(props: PopupProps<D
       // Arrow Offset
       const wrapperRect = wrapperRef.current.getBoundingClientRect();
       if (!wrapperRect.height || wrapperRect.right < 0) {
-        setRetryTimes((times) => Math.max(0, times - 1));
+        // Index is designed to be compatible with the bug of inconsistency between React 18 useEffect and React 19
+        setRetryTimes((times) => Math.max(0, times - index - 1));
         return;
       }
 
@@ -138,7 +140,16 @@ export default function Popup<DateType extends object = any>(props: PopupProps<D
         setContainerOffset(0);
       }
     }
-  }, [retryTimes, rtl, containerWidth, activeInputLeft, activeInputRight, selectorWidth, range]);
+  }, [
+    retryTimes,
+    rtl,
+    containerWidth,
+    activeInputLeft,
+    activeInputRight,
+    selectorWidth,
+    range,
+    index,
+  ]);
 
   // ======================== Custom ========================
   function filterEmpty<T>(list: T[]) {

--- a/src/PickerInput/Popup/index.tsx
+++ b/src/PickerInput/Popup/index.tsx
@@ -34,8 +34,8 @@ export interface PopupProps<DateType extends object = any, PresetValue = DateTyp
   activeInfo?: [activeInputLeft: number, activeInputRight: number, selectorWidth: number];
   // Direction
   direction?: 'ltr' | 'rtl';
-  // focus index
-  index: number;
+  /** @internal: active input index for layout retry. Not part of public API. */
+  index?: number;
 
   // Fill
   /** TimePicker or showTime only */

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -592,6 +592,7 @@ function RangePicker<DateType extends object = any>(
       range
       multiplePanel={multiplePanel}
       activeInfo={activeInfo}
+      index={activeIndex}
       // Disabled
       disabledDate={mergedDisabledDate}
       // Focus

--- a/src/PickerInput/SinglePicker.tsx
+++ b/src/PickerInput/SinglePicker.tsx
@@ -513,6 +513,7 @@ function Picker<DateType extends object = any>(
       // Focus
       onFocus={onPanelFocus}
       onBlur={onSharedBlur}
+      index={activeIndex}
       // Mode
       picker={picker}
       mode={mergedMode}


### PR DESCRIPTION
关联issue：https://github.com/ant-design/ant-design/issues/54885

通过当前聚焦input的顺序，在进入到重试逻辑时相减的次数不同，来兼容/绕过react 18 useEffect的问题；

本质原因我认为是react 18的原因，但因为我提供不了最小复现路径所以还没有给react 提issue 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 文档
  - 新增 RangePicker 时间选择（无需确认）的示例，包含中文本地化、预设时间范围与非受控用法，便于参考使用。

- Bug 修复
  - 优化弹层在切换面板或聚焦不同输入时的位置重算与重试策略，减少弹层错位或不显示，交互更稳定顺畅。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->