### PR TITLE
fix: When value is null, the dateString in onchange is null

### DIFF
--- a/src/PickerInput/hooks/useRangeValue.ts
+++ b/src/PickerInput/hooks/useRangeValue.ts
@@ -283,10 +283,11 @@ export default function useRangeValue<ValueType extends DateType[], DateType ext
 
       // Trigger `onChange` if needed
       if (onChange && !isSameMergedDates) {
+        const everyEmpty = clone.every((val) => !val);
         onChange(
           // Return null directly if all date are empty
-          isNullValue && clone.every((val) => !val) ? null : clone,
-          getDateTexts(clone),
+          isNullValue && everyEmpty ? null : clone,
+          everyEmpty ? null : getDateTexts(clone),
         );
       }
     }

--- a/tests/multiple.spec.tsx
+++ b/tests/multiple.spec.tsx
@@ -2,7 +2,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import { resetWarned } from '@rc-component/util/lib/warning';
 import React from 'react';
-import { DayPicker, getDay, isOpen, openPicker, selectCell } from './util/commonUtil';
+import { clearValue, DayPicker, getDay, isOpen, openPicker, selectCell } from './util/commonUtil';
 
 const fakeTime = getDay('1990-09-03 00:00:00').valueOf();
 
@@ -57,6 +57,8 @@ describe('Picker.Multiple', () => {
     ]);
 
     expect(onChange.mock.calls[0][0]).toHaveLength(3);
+    clearValue();
+    expect(onChange).toHaveBeenCalledWith(null, null);
   });
 
   it('panel click to remove', () => {

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -283,7 +283,7 @@ describe('Picker.Basic', () => {
         onChange.mockReset();
 
         clearValue();
-        expect(onChange).toHaveBeenCalledWith(null, '');
+        expect(onChange).toHaveBeenCalledWith(null, null);
         expect(isOpen()).toBeFalsy();
 
         openPicker(container);

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -202,7 +202,7 @@ describe('Picker.Range', () => {
     expect(onChange).toHaveBeenCalledWith([expect.anything(), null], ['1990-09-11', '']);
 
     clearValue();
-    expect(onChange).toHaveBeenCalledWith(null, ['', '']);
+    expect(onChange).toHaveBeenCalledWith(null, null);
     onChange.mockReset();
 
     // Not allow empty with startDate


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/54867
当清空数据，onChange 内 dateString 设置为null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 测试
  - 调整用例以覆盖“清空值”流程，验证重置后回调参数符合预期，场景更贴近真实交互。
  - 优化断言与执行顺序，提升测试稳定性与可维护性，降低误报风险。
  - 加强对状态重置后的行为验证，为后续改动提供更可靠保护网。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->