### PR TITLE
feat: support exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
       "import": "./es/index.js",
       "require": "./lib/index.js"
     },
+    "./assets/*": "./assets/*",
     "./generate": {
       "types": "./es/generate/index.d.ts",
       "import": "./es/generate/index.js",


### PR DESCRIPTION
目前 antd 中有大量硬编码 `/lib/` 的写法：

```js
import dayjsGenerateConfig from '@rc-component/picker/lib/generate/dayjs';
```

虽然 antd 有编译时自动切换 `/lib/` 和 `/es/` 的能力，但是写法不够优雅现代。

通过此 exports 映射之后，可以去掉硬编码 `/lib/` `/es/` 部分：

```js
import dayjsGenerateConfig from '@rc-component/picker/generate/dayjs';
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 改进了包的导出配置，定义了多个公共入口点以增强模块化访问与按需加载
  * 增加了顶层 TypeScript 声明字段，完善了类型支持，提升开发者体验
  * 将 Node.js 最低版本要求从 8.x 提升至 12.x，以保证更好的兼容性与新特性支持

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->