### PR TITLE
feat: add additional exports to package.json for backwards compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,46 @@
       "types": "./es/locale/*.d.ts",
       "import": "./es/locale/*.js",
       "require": "./lib/locale/*.js"
+    },
+    "./lib/generate": {
+      "types": "./es/generate/index.d.ts",
+      "import": "./es/generate/index.js",
+      "require": "./lib/generate/index.js"
+    },
+    "./lib/generate/*": {
+      "types": "./es/generate/*.d.ts",
+      "import": "./es/generate/*.js",
+      "require": "./lib/generate/*.js"
+    },
+    "./lib/interface": {
+      "types": "./es/interface.d.ts",
+      "import": "./es/interface.js",
+      "require": "./lib/interface.js"
+    },
+    "./lib/locale/*": {
+      "types": "./es/locale/*.d.ts",
+      "import": "./es/locale/*.js",
+      "require": "./lib/locale/*.js"
+    },
+    "./es/generate": {
+      "types": "./es/generate/index.d.ts",
+      "import": "./es/generate/index.js",
+      "require": "./lib/generate/index.js"
+    },
+    "./es/generate/*": {
+      "types": "./es/generate/*.d.ts",
+      "import": "./es/generate/*.js",
+      "require": "./lib/generate/*.js"
+    },
+    "./es/interface": {
+      "types": "./es/interface.d.ts",
+      "import": "./es/interface.js",
+      "require": "./lib/interface.js"
+    },
+    "./es/locale/*": {
+      "types": "./es/locale/*.d.ts",
+      "import": "./es/locale/*.js",
+      "require": "./lib/locale/*.js"
     }
   },
   "files": [


### PR DESCRIPTION
兼容旧的 `/lib/` 和 `/es/` import 用法

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 扩展了包导出路径，现在支持从./lib和./es目录下直接导入多个子模块（包括生成器、接口和区域配置），提供更灵活便捷的导入方式和更多模块组织选项。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->