### PR TITLE
feat: support tagRender in multiple picker

### DIFF
--- a/docs/examples/multiple.tsx
+++ b/docs/examples/multiple.tsx
@@ -30,10 +30,43 @@ export default () => {
     <div>
       <SinglePicker {...sharedLocale} multiple ref={singleRef} onOpenChange={console.error} />
       <SinglePicker {...sharedLocale} multiple ref={singleRef} needConfirm />
-      <SinglePicker {...sharedLocale} multiple picker="week" defaultValue={[
-        dayjs('2021-01-01'),
-        dayjs('2021-01-08'),
-      ]} />
+      <SinglePicker
+        {...sharedLocale}
+        multiple
+        picker="week"
+        defaultValue={[dayjs('2021-01-01'), dayjs('2021-01-08')]}
+      />
+      <SinglePicker
+        {...sharedLocale}
+        multiple
+        defaultValue={[dayjs('2021-01-01'), dayjs('2021-01-08')]}
+        tagRender={({ label, value, onClose }) => {
+          const locked = value.isBefore(dayjs('2021-01-05'), 'day');
+
+          return (
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+                marginInlineEnd: 4,
+                padding: '0 6px',
+                border: '1px solid #1677ff',
+                borderRadius: 12,
+              }}
+            >
+              <span>{label}</span>
+              {locked ? (
+                <span>locked</span>
+              ) : (
+                <button type="button" onClick={onClose}>
+                  remove
+                </button>
+              )}
+            </span>
+          );
+        }}
+      />
     </div>
   );
 };

--- a/docs/examples/multiple.tsx
+++ b/docs/examples/multiple.tsx
@@ -29,7 +29,7 @@ export default () => {
   return (
     <div>
       <SinglePicker {...sharedLocale} multiple ref={singleRef} onOpenChange={console.error} />
-      <SinglePicker {...sharedLocale} multiple ref={singleRef} needConfirm />
+      <SinglePicker {...sharedLocale} multiple needConfirm />
       <SinglePicker
         {...sharedLocale}
         multiple
@@ -40,7 +40,7 @@ export default () => {
         {...sharedLocale}
         multiple
         defaultValue={[dayjs('2021-01-01'), dayjs('2021-01-08')]}
-        tagRender={({ label, value, onClose }) => {
+        tagRender={({ label, value, closable, onClose }) => {
           const locked = value.isBefore(dayjs('2021-01-05'), 'day');
 
           return (
@@ -56,10 +56,16 @@ export default () => {
               }}
             >
               <span>{label}</span>
-              {locked ? (
+              {!closable || locked ? (
                 <span>locked</span>
               ) : (
-                <button type="button" onClick={onClose}>
+                <button
+                  type="button"
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                  }}
+                  onClick={onClose}
+                >
                   remove
                 </button>
               )}

--- a/src/PickerInput/Selector/SingleSelector/MultipleDates.tsx
+++ b/src/PickerInput/Selector/SingleSelector/MultipleDates.tsx
@@ -2,11 +2,11 @@ import { clsx } from 'clsx';
 import Overflow from '@rc-component/overflow';
 import * as React from 'react';
 import type { MouseEventHandler } from 'react';
-import type { PickerProps } from '../../SinglePicker';
+import type { CustomTagProps, PickerProps } from '../../SinglePicker';
 
 export interface MultipleDatesProps<DateType extends object = any> extends Pick<
   PickerProps,
-  'maxTagCount'
+  'maxTagCount' | 'tagRender'
 > {
   prefixCls: string;
   value: DateType[];
@@ -28,6 +28,7 @@ export default function MultipleDates<DateType extends object = any>(
     formatDate,
     disabled,
     maxTagCount,
+    tagRender,
     placeholder,
   } = props;
 
@@ -60,11 +61,22 @@ export default function MultipleDates<DateType extends object = any>(
 
   function renderItem(date: DateType) {
     const displayLabel: React.ReactNode = formatDate(date);
+    const closable = !disabled;
 
-    const onClose = (event?: React.MouseEvent) => {
+    const onClose: CustomTagProps<DateType>['onClose'] = (event) => {
       if (event) event.stopPropagation();
       onRemove(date);
     };
+
+    if (tagRender) {
+      return tagRender({
+        label: displayLabel,
+        value: date,
+        disabled: !!disabled,
+        closable,
+        onClose,
+      });
+    }
 
     return renderSelector(displayLabel, onClose);
   }

--- a/src/PickerInput/Selector/SingleSelector/MultipleDates.tsx
+++ b/src/PickerInput/Selector/SingleSelector/MultipleDates.tsx
@@ -65,7 +65,9 @@ export default function MultipleDates<DateType extends object = any>(
 
     const onClose: CustomTagProps<DateType>['onClose'] = (event) => {
       if (event) event.stopPropagation();
-      onRemove(date);
+      if (!disabled) {
+        onRemove(date);
+      }
     };
 
     if (tagRender) {

--- a/src/PickerInput/Selector/SingleSelector/index.tsx
+++ b/src/PickerInput/Selector/SingleSelector/index.tsx
@@ -11,8 +11,7 @@ import useRootProps from '../hooks/useRootProps';
 import MultipleDates from './MultipleDates';
 
 export interface SingleSelectorProps<DateType extends object = any>
-  extends SelectorProps<DateType>,
-    Pick<PickerProps, 'multiple' | 'maxTagCount'> {
+  extends SelectorProps<DateType>, Pick<PickerProps, 'multiple' | 'maxTagCount' | 'tagRender'> {
   id?: string;
 
   value?: DateType[];
@@ -75,6 +74,7 @@ function SingleSelector<DateType extends object = any>(
     onInputChange,
     multiple,
     maxTagCount,
+    tagRender,
 
     // Valid
     format,
@@ -170,6 +170,7 @@ function SingleSelector<DateType extends object = any>(
         onRemove={onMultipleRemove}
         formatDate={getText}
         maxTagCount={maxTagCount}
+        tagRender={tagRender}
         disabled={disabled}
         removeIcon={removeIcon}
         placeholder={placeholder}

--- a/src/PickerInput/SinglePicker.tsx
+++ b/src/PickerInput/SinglePicker.tsx
@@ -36,8 +36,17 @@ import useSemantic from '../hooks/useSemantic';
 
 // TODO: isInvalidateDate with showTime.disabledTime should not provide `range` prop
 
-export interface BasePickerProps<DateType extends object = any>
-  extends SharedPickerProps<DateType> {
+export interface CustomTagProps<DateType extends object = any> {
+  label: React.ReactNode;
+  value: DateType;
+  disabled: boolean;
+  onClose: (event?: React.MouseEvent<HTMLElement>) => void;
+  closable: boolean;
+}
+
+export interface BasePickerProps<
+  DateType extends object = any,
+> extends SharedPickerProps<DateType> {
   // Structure
   id?: string;
 
@@ -46,6 +55,8 @@ export interface BasePickerProps<DateType extends object = any>
   removeIcon?: React.ReactNode;
   /** Only work when `multiple` is in used */
   maxTagCount?: number | 'responsive';
+  /** Only work when `multiple` is in used */
+  tagRender?: (props: CustomTagProps<DateType>) => React.ReactNode;
 
   // Value
   value?: DateType | DateType[] | null;
@@ -100,8 +111,7 @@ export interface BasePickerProps<DateType extends object = any>
 }
 
 export interface PickerProps<DateType extends object = any>
-  extends BasePickerProps<DateType>,
-    Omit<SharedTimeProps<DateType>, 'format' | 'defaultValue'> {}
+  extends BasePickerProps<DateType>, Omit<SharedTimeProps<DateType>, 'format' | 'defaultValue'> {}
 
 /** Internal usage. For cross function get same aligned props */
 export type ReplacedPickerProps<DateType extends object = any> = {
@@ -174,6 +184,7 @@ function Picker<DateType extends object = any>(
 
     suffixIcon,
     removeIcon,
+    tagRender,
 
     // Focus
     onFocus,
@@ -657,6 +668,7 @@ function Picker<DateType extends object = any>(
           // Icon
           suffixIcon={suffixIcon}
           removeIcon={removeIcon}
+          tagRender={tagRender}
           // Active
           activeHelp={!!internalHoverValue}
           allHelp={!!internalHoverValue && hoverSource === 'preset'}

--- a/src/PickerInput/SinglePicker.tsx
+++ b/src/PickerInput/SinglePicker.tsx
@@ -53,9 +53,9 @@ export interface BasePickerProps<
   /** Not support `time` or `datetime` picker */
   multiple?: boolean;
   removeIcon?: React.ReactNode;
-  /** Only work when `multiple` is in used */
+  /** Only works when `multiple` is in use */
   maxTagCount?: number | 'responsive';
-  /** Only work when `multiple` is in used */
+  /** Only works when `multiple` is in use */
   tagRender?: (props: CustomTagProps<DateType>) => React.ReactNode;
 
   // Value

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,7 +29,11 @@
 
 import type { PickerRef, SharedTimeProps } from './interface';
 import RangePicker, { type RangePickerProps } from './PickerInput/RangePicker';
-import Picker, { type BasePickerProps, type PickerProps } from './PickerInput/SinglePicker';
+import Picker, {
+  type BasePickerProps,
+  type CustomTagProps,
+  type PickerProps,
+} from './PickerInput/SinglePicker';
 import PickerPanel, { type BasePickerPanelProps, type PickerPanelProps } from './PickerPanel';
 
 export { Picker, RangePicker, PickerPanel };
@@ -40,6 +44,7 @@ export type {
   PickerRef,
   BasePickerProps,
   BasePickerPanelProps,
+  CustomTagProps,
   SharedTimeProps,
 };
 export default Picker;

--- a/tests/multiple.spec.tsx
+++ b/tests/multiple.spec.tsx
@@ -140,6 +140,33 @@ describe('Picker.Multiple', () => {
     expect(container.querySelector('.custom-remove')).toBeTruthy();
   });
 
+  it('tagRender', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <DayPicker
+        multiple
+        onChange={onChange}
+        defaultValue={[getDay('2000-01-01'), getDay('2000-01-02')]}
+        tagRender={({ label, value, onClose }) => (
+          <span className="custom-tag">
+            <span className="custom-tag-label">{label}</span>
+            {value.date() !== 1 && (
+              <button type="button" className="custom-tag-close" onClick={onClose}>
+                x
+              </button>
+            )}
+          </span>
+        )}
+      />,
+    );
+
+    expect(container.querySelectorAll('.custom-tag')).toHaveLength(2);
+    expect(container.querySelectorAll('.custom-tag-close')).toHaveLength(1);
+
+    fireEvent.click(container.querySelector('.custom-tag-close'));
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), ['2000-01-01']);
+  });
+
   describe('placeholder', () => {
     it('show placeholder', () => {
       const { container } = render(<DayPicker multiple placeholder="bamboo" />);

--- a/tests/multiple.spec.tsx
+++ b/tests/multiple.spec.tsx
@@ -167,6 +167,36 @@ describe('Picker.Multiple', () => {
     expect(onChange).toHaveBeenCalledWith(expect.anything(), ['2000-01-01']);
   });
 
+  it('tagRender should not remove when disabled', () => {
+    const onChange = jest.fn();
+    const tagRender = jest.fn(({ label, onClose }) => (
+      <button type="button" className="custom-tag-close" onClick={onClose}>
+        {label}
+      </button>
+    ));
+
+    const { container } = render(
+      <DayPicker
+        multiple
+        disabled
+        onChange={onChange}
+        defaultValue={[getDay('2000-01-01')]}
+        tagRender={tagRender}
+      />,
+    );
+
+    expect(tagRender).toHaveBeenCalledWith(
+      expect.objectContaining({
+        disabled: true,
+        closable: false,
+      }),
+    );
+
+    fireEvent.click(container.querySelector('.custom-tag-close'));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(container.querySelectorAll('.custom-tag-close')).toHaveLength(1);
+  });
+
   describe('placeholder', () => {
     it('show placeholder', () => {
       const { container } = render(<DayPicker multiple placeholder="bamboo" />);


### PR DESCRIPTION
## Summary
- add `tagRender` support for single picker `multiple` mode
- export the tag render props and keep the default multiple tag rendering unchanged
- add tests and a demo for custom multiple tag rendering

## Testing
- bun run lint
- bunx tsc --noEmit
- bun run compile
- bun run test -- --coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在多选模式中新增自定义标签渲染功能，支持通过 `tagRender` 回调自定义标签外观和交互。
  * 新增公开接口支持自定义标签属性的类型定义。

* **文档**
  * 更新示例代码展示自定义标签渲染的用法。

* **测试**
  * 添加测试覆盖自定义标签渲染功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->