### PR TITLE
fix: add A → a replacement in dateFns localeParse for use12Hours

### DIFF
--- a/src/generate/dateFns.ts
+++ b/src/generate/dateFns.ts
@@ -41,7 +41,8 @@ const localeParse = (format: string) => {
     .replace(/D/g, 'd')
     .replace(/gggg/, 'yyyy')
     .replace(/g/g, 'G')
-    .replace(/([Ww])o/g, 'wo');
+    .replace(/([Ww])o/g, 'wo')
+    .replace(/A/g, 'a');
 };
 
 const parse = (text: string, format: string, locale: string) => {

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -339,7 +339,7 @@ describe('Generate:date-fns', () => {
   it('format and parse with AM/PM (uppercase A)', () => {
     const date = new Date(2000, 0, 1, 14, 30, 0);
 
-    // Format with uppercase A (moment-style) should produce lowercase am/pm output
+    // Format with uppercase A (moment-style) should be normalized to date-fns `a`
     const formatted = dateFnsGenerateConfig.locale.format('en_US', date, 'YYYY-MM-DD hh:mm:ss A');
     expect(formatted).toEqual('2000-01-01 02:30:00 PM');
 

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -335,4 +335,19 @@ describe('Generate:date-fns', () => {
     expect(dateFnsGenerateConfig.locale.getWeekFirstDay('it_IT')).toEqual(1);
     expect(dateFnsGenerateConfig.locale.getWeekFirstDay('fr_FR')).toEqual(1);
   });
+
+  it('format and parse with AM/PM (uppercase A)', () => {
+    const date = new Date(2000, 0, 1, 14, 30, 0);
+
+    // Format with uppercase A (moment-style) should produce lowercase am/pm output
+    const formatted = dateFnsGenerateConfig.locale.format('en_US', date, 'YYYY-MM-DD hh:mm:ss A');
+    expect(formatted).toEqual('2000-01-01 02:30:00 PM');
+
+    // Parse with uppercase A should also work without throwing
+    const parsed = dateFnsGenerateConfig.locale.parse('en_US', '2000-01-01 02:30:00 PM', [
+      'YYYY-MM-DD hh:mm:ss A',
+    ]);
+    expect(dateFnsGenerateConfig.getHour(parsed)).toEqual(14);
+    expect(dateFnsGenerateConfig.getMinute(parsed)).toEqual(30);
+  });
 });


### PR DESCRIPTION
## Summary

- Add missing `.replace(/A/g, 'a')` to `localeParse` in the date-fns generate config
- Fixes `use12Hours` crashing with `RangeError: Format string contains an unescaped latin alphabet character A`

`localeParse` already converts moment.js format tokens to date-fns equivalents (`Y→y`, `D→d`, etc.) but was missing `A→a` (AM/PM). When `use12Hours` is enabled, rc-picker injects uppercase `A` into the format string internally, which date-fns rejects.

Fixes #964

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了日期格式规范化，兼容将 AM/PM 标记大写 A 视为小写 a 进行处理，提升日期解析与格式化的一致性与稳定性。

* **Tests**
  * 新增针对 date-fns 的单元测试，覆盖大写 A 在格式化与解析中的行为，验证输出与解析结果正确且一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->