### PR TITLE
fix: avoid submitting unconfirmed range values on blur

### DIFF
--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -669,9 +669,7 @@ function RangePicker<DateType extends object = any>(
       return;
     }
 
-    if (!needConfirm) {
-      lastOperation('input');
-    }
+    lastOperation('input');
 
     triggerOpen(true, {
       inherit: true,

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -226,6 +226,7 @@ function RangePicker<DateType extends object = any>(
 
     // Native
     onClick,
+    onMouseDown,
   } = filledProps;
 
   // ========================= Refs =========================
@@ -272,6 +273,8 @@ function RangePicker<DateType extends object = any>(
     updateSubmitIndex,
     hasActiveSubmitValue,
   ] = useRangeActive(disabled, allowEmpty, mergedOpen);
+  const pendingKeyboardSwitchRef = React.useRef(false);
+  const keyboardSwitchInputRef = React.useRef(false);
 
   const onSharedFocus = (event: React.FocusEvent<HTMLElement>, index?: number) => {
     triggerFocus(true);
@@ -669,6 +672,9 @@ function RangePicker<DateType extends object = any>(
       return;
     }
 
+    keyboardSwitchInputRef.current = pendingKeyboardSwitchRef.current;
+    pendingKeyboardSwitchRef.current = false;
+
     lastOperation('input');
 
     triggerOpen(true, {
@@ -688,6 +694,14 @@ function RangePicker<DateType extends object = any>(
   };
 
   const onSelectorBlur: SelectorProps['onBlur'] = (event, index) => {
+    const relatedTarget = event.relatedTarget as Node | null;
+    if (
+      pendingKeyboardSwitchRef.current &&
+      !selectorRef.current.nativeElement.contains(relatedTarget)
+    ) {
+      pendingKeyboardSwitchRef.current = false;
+    }
+
     triggerOpen(false);
     if (!needConfirm && lastOperation() === 'input') {
       const nextIndex = nextActiveIndex(calendarValue);
@@ -697,8 +711,23 @@ function RangePicker<DateType extends object = any>(
     onSharedBlur(event, index);
   };
 
+  const onSelectorMouseDown: React.MouseEventHandler<HTMLDivElement> = (event) => {
+    const target = event.target as HTMLElement;
+    const rootNode = target.getRootNode();
+    const activeElement =
+      (rootNode as Document | ShadowRoot).activeElement ?? document.activeElement;
+
+    if (target.tagName === 'INPUT' && target !== activeElement) {
+      pendingKeyboardSwitchRef.current = false;
+      keyboardSwitchInputRef.current = false;
+    }
+
+    onMouseDown?.(event);
+  };
+
   const onSelectorKeyDown: SelectorProps['onKeyDown'] = (event, preventDefault) => {
     if (event.key === 'Tab') {
+      pendingKeyboardSwitchRef.current = true;
       triggerPartConfirm(null, true);
     }
 
@@ -742,7 +771,8 @@ function RangePicker<DateType extends object = any>(
     const lastOp = lastOperation();
 
     // Trade as confirm on field leave
-    if (!mergedOpen && !needConfirm && lastOp === 'input') {
+    if (!mergedOpen && lastOp === 'input' && (!needConfirm || keyboardSwitchInputRef.current)) {
+      keyboardSwitchInputRef.current = false;
       triggerOpen(false);
       triggerPartConfirm(null, true);
     }
@@ -825,6 +855,7 @@ function RangePicker<DateType extends object = any>(
           onOpenChange={triggerOpen}
           // Click
           onClick={onSelectorClick}
+          onMouseDown={onSelectorMouseDown}
           onClear={onSelectorClear}
           // Invalid
           invalid={submitInvalidates}

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -744,7 +744,7 @@ function RangePicker<DateType extends object = any>(
     const lastOp = lastOperation();
 
     // Trade as confirm on field leave
-    if (!mergedOpen && lastOp === 'input') {
+    if (!mergedOpen && !needConfirm && lastOp === 'input') {
       triggerOpen(false);
       triggerPartConfirm(null, true);
     }

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -56,8 +56,10 @@ export type RangeValueType<DateType> = [
 /** Used for change event, it should always be not undefined */
 export type NoUndefinedRangeValueType<DateType> = [start: DateType | null, end: DateType | null];
 
-export interface BaseRangePickerProps<DateType extends object>
-  extends Omit<SharedPickerProps<DateType>, 'showTime' | 'id'> {
+export interface BaseRangePickerProps<DateType extends object> extends Omit<
+  SharedPickerProps<DateType>,
+  'showTime' | 'id'
+> {
   // Structure
   id?: SelectorIdType;
 
@@ -132,7 +134,8 @@ export interface BaseRangePickerProps<DateType extends object>
 }
 
 export interface RangePickerProps<DateType extends object>
-  extends BaseRangePickerProps<DateType>,
+  extends
+    BaseRangePickerProps<DateType>,
     Omit<RangeTimeProps<DateType>, 'format' | 'defaultValue' | 'defaultOpenValue'> {}
 
 function getActiveRange(activeIndex: number) {
@@ -666,7 +669,9 @@ function RangePicker<DateType extends object = any>(
       return;
     }
 
-    lastOperation('input');
+    if (!needConfirm) {
+      lastOperation('input');
+    }
 
     triggerOpen(true, {
       inherit: true,

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -918,6 +918,32 @@ describe('Picker.Range', () => {
     matchValues(container, '', '');
   });
 
+  it('should not submit typed values on blur before confirm', () => {
+    const onChange = jest.fn();
+    const { container } = render(<DayRangePicker showTime allowEmpty onChange={onChange} />);
+
+    const startInput = container.querySelectorAll<HTMLInputElement>('input')[0];
+
+    startInput.focus();
+    fireEvent.change(startInput, {
+      target: {
+        value: '1990-09-11 00:00:00',
+      },
+    });
+
+    fireEvent.mouseDown(document.body);
+    startInput.blur();
+
+    for (let i = 0; i < 5; i += 1) {
+      act(() => {
+        jest.runAllTimers();
+      });
+    }
+
+    expect(onChange).not.toHaveBeenCalled();
+    matchValues(container, '', '');
+  });
+
   describe('viewDate', () => {
     function matchTitle(title: string) {
       expect(document.querySelector('.rc-picker-header-view').textContent).toEqual(title);

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -895,6 +895,29 @@ describe('Picker.Range', () => {
     expect(document.querySelector('input').value).toEqual('');
   });
 
+  it('should not submit unconfirmed values on blur when allowEmpty lets fields switch', () => {
+    const onChange = jest.fn();
+    const { container } = render(<DayRangePicker showTime allowEmpty onChange={onChange} />);
+
+    openPicker(container, 0);
+    selectCell(11);
+
+    openPicker(container, 1);
+    openPicker(container, 0);
+
+    fireEvent.mouseDown(document.body);
+    container.querySelectorAll('input')[0].blur();
+
+    for (let i = 0; i < 5; i += 1) {
+      act(() => {
+        jest.runAllTimers();
+      });
+    }
+
+    expect(onChange).not.toHaveBeenCalled();
+    matchValues(container, '', '');
+  });
+
   describe('viewDate', () => {
     function matchTitle(title: string) {
       expect(document.querySelector('.rc-picker-header-view').textContent).toEqual(title);

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -1035,6 +1035,50 @@ describe('Picker.Range', () => {
     matchValues(container, '1990-09-11 00:00:00', '');
   });
 
+  it('should clear pending keyboard switch when focus leaves picker before mouse switching', () => {
+    const onChange = jest.fn();
+    const { container } = render(<DayRangePicker showTime allowEmpty onChange={onChange} />);
+
+    const [startInput, endInput] = container.querySelectorAll<HTMLInputElement>('input');
+
+    startInput.focus();
+    fireEvent.change(startInput, {
+      target: {
+        value: '1990-09-11 00:00:00',
+      },
+    });
+    fireEvent.keyDown(startInput, {
+      key: 'Tab',
+    });
+
+    fireEvent.blur(startInput, {
+      relatedTarget: document.body,
+    });
+    fireEvent.mouseDown(endInput);
+    endInput.focus();
+    fireEvent.change(endInput, {
+      target: {
+        value: '1990-09-12 00:00:00',
+      },
+    });
+
+    fireEvent.mouseDown(document.body);
+    endInput.blur();
+
+    for (let i = 0; i < 5; i += 1) {
+      act(() => {
+        jest.runAllTimers();
+      });
+    }
+
+    expect(onChange).not.toHaveBeenCalledWith(expect.anything(), [
+      '1990-09-11 00:00:00',
+      '1990-09-12 00:00:00',
+    ]);
+    expect(onChange).toHaveBeenCalled();
+    matchValues(container, '1990-09-11 00:00:00', '');
+  });
+
   it('should keep keyboard switch allowance when clicking inside the current input', () => {
     const onChange = jest.fn();
     const { container } = render(<DayRangePicker showTime allowEmpty onChange={onChange} />);

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -955,6 +955,126 @@ describe('Picker.Range', () => {
     matchValues(container, '', '');
   });
 
+  it('should submit typed values on blur after keyboard switch to next input', () => {
+    const onChange = jest.fn();
+    const { container } = render(<DayRangePicker showTime allowEmpty onChange={onChange} />);
+
+    const [startInput, endInput] = container.querySelectorAll<HTMLInputElement>('input');
+
+    startInput.focus();
+    fireEvent.change(startInput, {
+      target: {
+        value: '1990-09-11 00:00:00',
+      },
+    });
+    fireEvent.keyDown(startInput, {
+      key: 'Tab',
+    });
+
+    endInput.focus();
+    fireEvent.change(endInput, {
+      target: {
+        value: '1990-09-12 00:00:00',
+      },
+    });
+
+    fireEvent.mouseDown(document.body);
+    endInput.blur();
+
+    for (let i = 0; i < 5; i += 1) {
+      act(() => {
+        jest.runAllTimers();
+      });
+    }
+
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), [
+      '1990-09-11 00:00:00',
+      '1990-09-12 00:00:00',
+    ]);
+    matchValues(container, '1990-09-11 00:00:00', '1990-09-12 00:00:00');
+  });
+
+  it('should not confirm typed end value on blur after mouse switching to next input', () => {
+    const onChange = jest.fn();
+    const { container } = render(<DayRangePicker showTime allowEmpty onChange={onChange} />);
+
+    const [startInput, endInput] = container.querySelectorAll<HTMLInputElement>('input');
+
+    startInput.focus();
+    fireEvent.change(startInput, {
+      target: {
+        value: '1990-09-11 00:00:00',
+      },
+    });
+    fireEvent.keyDown(startInput, {
+      key: 'Tab',
+    });
+
+    fireEvent.mouseDown(endInput);
+    endInput.focus();
+    fireEvent.change(endInput, {
+      target: {
+        value: '1990-09-12 00:00:00',
+      },
+    });
+
+    fireEvent.mouseDown(document.body);
+    endInput.blur();
+
+    for (let i = 0; i < 5; i += 1) {
+      act(() => {
+        jest.runAllTimers();
+      });
+    }
+
+    expect(onChange).not.toHaveBeenCalledWith(expect.anything(), [
+      '1990-09-11 00:00:00',
+      '1990-09-12 00:00:00',
+    ]);
+    expect(onChange).toHaveBeenCalled();
+    matchValues(container, '1990-09-11 00:00:00', '');
+  });
+
+  it('should keep keyboard switch allowance when clicking inside the current input', () => {
+    const onChange = jest.fn();
+    const { container } = render(<DayRangePicker showTime allowEmpty onChange={onChange} />);
+
+    const [startInput, endInput] = container.querySelectorAll<HTMLInputElement>('input');
+
+    startInput.focus();
+    fireEvent.change(startInput, {
+      target: {
+        value: '1990-09-11 00:00:00',
+      },
+    });
+    fireEvent.keyDown(startInput, {
+      key: 'Tab',
+    });
+
+    endInput.focus();
+    fireEvent.change(endInput, {
+      target: {
+        value: '1990-09-12 00:00:00',
+      },
+    });
+
+    fireEvent.mouseDown(endInput);
+    fireEvent.mouseDown(document.body);
+    endInput.blur();
+
+    for (let i = 0; i < 5; i += 1) {
+      act(() => {
+        jest.runAllTimers();
+      });
+    }
+
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), [
+      '1990-09-11 00:00:00',
+      '1990-09-12 00:00:00',
+    ]);
+    matchValues(container, '1990-09-11 00:00:00', '1990-09-12 00:00:00');
+  });
+
   describe('viewDate', () => {
     function matchTitle(title: string) {
       expect(document.querySelector('.rc-picker-header-view').textContent).toEqual(title);

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -897,10 +897,21 @@ describe('Picker.Range', () => {
 
   it('should not submit unconfirmed values on blur when allowEmpty lets fields switch', () => {
     const onChange = jest.fn();
-    const { container } = render(<DayRangePicker showTime allowEmpty onChange={onChange} />);
+    const onCalendarChange = jest.fn();
+    const { container } = render(
+      <DayRangePicker
+        showTime
+        allowEmpty
+        onChange={onChange}
+        onCalendarChange={onCalendarChange}
+      />,
+    );
 
     openPicker(container, 0);
     selectCell(11);
+    expect(onCalendarChange).toHaveBeenCalledWith(expect.anything(), ['1990-09-11 00:00:00', ''], {
+      range: 'start',
+    });
 
     openPicker(container, 1);
     openPicker(container, 0);


### PR DESCRIPTION
## Summary
- avoid marking plain range input focus switches as input operations when `needConfirm` is enabled
- keep the existing blur-submit behavior for `!needConfirm` flows
- add a regression test for `showTime + allowEmpty` without pressing `OK`

## Testing
- npm test -- --runInBand tests/range.spec.tsx tests/new-range.spec.tsx
- npm test -- --runInBand

Fixes ant-design/ant-design#57728

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 增加键盘/鼠标切换识别与跟踪（区分 Tab 键的切换），并在切换时转移/清除待确认状态。
  * 在选择器交互中转发鼠标按下事件以改善行为一致性。

* **Bug Fixes**
  * 修复切换/失焦场景下错误触发部分或完整确认的问题，确保未确认输入不会意外提交。
  * 确保在离开选择器时清除待定键盘切换状态，避免残留影响确认逻辑。

* **Tests**
  * 增补用例，覆盖显示时间与允许为空场景下的切换、失焦与提交差异。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->