### PR TITLE
fix: refactor clear icon to button element to make it accessible

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -411,7 +411,7 @@
   &-clear {
     position: absolute;
     top: 0;
-    inset-inline-end: 4px;
+    inset-inline-end: 0;
     cursor: pointer;
 
     &-btn::after {

--- a/src/PickerInput/Selector/ClearIcon.tsx
+++ b/src/PickerInput/Selector/ClearIcon.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import PickerContext from '../context';
+import { clsx } from 'clsx';
+
+export interface ClearIconProps extends React.HtmlHTMLAttributes<HTMLElement> {
+  icon?: React.ReactNode;
+  onClear: VoidFunction;
+}
+
+export default function ClearIcon({ icon, onClear, ...restProps }: ClearIconProps) {
+  const { prefixCls, classNames, styles, locale } = React.useContext(PickerContext);
+
+  return (
+    <button
+      {...restProps}
+      type="button"
+      aria-label={locale.clear}
+      className={clsx(`${prefixCls}-clear`, classNames.suffix)}
+      style={styles.suffix}
+      onMouseDown={(e) => {
+        e.preventDefault();
+      }}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClear();
+      }}
+    >
+      {icon}
+    </button>
+  );
+}

--- a/src/PickerInput/Selector/Icon.tsx
+++ b/src/PickerInput/Selector/Icon.tsx
@@ -4,41 +4,18 @@ import { clsx } from 'clsx';
 
 export interface IconProps extends React.HtmlHTMLAttributes<HTMLElement> {
   icon?: React.ReactNode;
-  type: 'suffix' | 'clear';
 }
 
-export default function Icon(props: IconProps) {
-  const { icon, type, ...restProps } = props;
+export default function Icon({ icon, ...restProps }: IconProps) {
   const { prefixCls, classNames, styles } = React.useContext(PickerContext);
 
   return icon ? (
     <span
-      className={clsx(`${prefixCls}-${type}`, classNames.suffix)}
+      className={clsx(`${prefixCls}-suffix`, classNames.suffix)}
       style={styles.suffix}
       {...restProps}
     >
       {icon}
     </span>
   ) : null;
-}
-
-export interface ClearIconProps extends Omit<IconProps, 'type'> {
-  onClear: VoidFunction;
-}
-
-export function ClearIcon({ onClear, ...restProps }: ClearIconProps) {
-  return (
-    <Icon
-      {...restProps}
-      type="clear"
-      role="button"
-      onMouseDown={(e) => {
-        e.preventDefault();
-      }}
-      onClick={(e) => {
-        e.stopPropagation();
-        onClear();
-      }}
-    />
-  );
 }

--- a/src/PickerInput/Selector/Input.tsx
+++ b/src/PickerInput/Selector/Input.tsx
@@ -419,7 +419,7 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
         className={classNames.input}
         style={styles.input}
       />
-      <Icon type="suffix" icon={suffixIcon} />
+      <Icon icon={suffixIcon} />
       {clearIcon}
     </div>
   );

--- a/src/PickerInput/Selector/RangeSelector.tsx
+++ b/src/PickerInput/Selector/RangeSelector.tsx
@@ -6,7 +6,8 @@ import type { RangePickerRef, SelectorProps } from '../../interface';
 import PickerContext from '../context';
 import useInputProps from './hooks/useInputProps';
 import useRootProps from './hooks/useRootProps';
-import Icon, { ClearIcon } from './Icon';
+import Icon from './Icon';
+import ClearIcon from './ClearIcon';
 import Input, { type InputRef } from './Input';
 
 export type SelectorIdType =
@@ -261,7 +262,7 @@ function RangeSelector<DateType extends object = any>(
           date-range="end"
         />
         <div className={`${prefixCls}-active-bar`} style={activeBarStyle} />
-        <Icon type="suffix" icon={suffixIcon} />
+        <Icon icon={suffixIcon} />
         {showClear && <ClearIcon icon={clearIcon} onClear={onClear} />}
       </div>
     </ResizeObserver>

--- a/src/PickerInput/Selector/SingleSelector/index.tsx
+++ b/src/PickerInput/Selector/SingleSelector/index.tsx
@@ -4,7 +4,8 @@ import type { InternalMode, PickerRef, SelectorProps } from '../../../interface'
 import { isSame } from '../../../utils/dateUtil';
 import type { PickerProps } from '../../SinglePicker';
 import PickerContext from '../../context';
-import Icon, { ClearIcon } from '../Icon';
+import Icon from '../Icon';
+import ClearIcon from '../ClearIcon';
 import Input, { type InputRef } from '../Input';
 import useInputProps from '../hooks/useInputProps';
 import useRootProps from '../hooks/useRootProps';
@@ -183,7 +184,7 @@ function SingleSelector<DateType extends object = any>(
         autoFocus={autoFocus}
         tabIndex={tabIndex}
       />
-      <Icon type="suffix" icon={suffixIcon} />
+      <Icon icon={suffixIcon} />
       {showClear && <ClearIcon icon={clearIcon} onClear={onClear} />}
     </>
   ) : (

--- a/src/PickerInput/SinglePicker.tsx
+++ b/src/PickerInput/SinglePicker.tsx
@@ -388,6 +388,7 @@ function Picker<DateType extends object = any>(
   const onSelectorClear = () => {
     triggerSubmitChange(null);
     triggerOpen(false, { force: true });
+    selectorRef.current.focus();
   };
 
   // ======================== Hover =========================

--- a/tests/__snapshots__/picker.spec.tsx.snap
+++ b/tests/__snapshots__/picker.spec.tsx.snap
@@ -17,14 +17,15 @@ exports[`Picker.Basic icon 1`] = `
       class="suffix-icon"
     />
   </span>
-  <span
+  <button
+    aria-label="Clear"
     class="rc-picker-clear"
-    role="button"
+    type="button"
   >
     <span
       class="suffix-icon"
     />
-  </span>
+  </button>
 </div>
 `;
 

--- a/tests/__snapshots__/range.spec.tsx.snap
+++ b/tests/__snapshots__/range.spec.tsx.snap
@@ -43,14 +43,15 @@ exports[`Picker.Range icon 1`] = `
         class="suffix-icon"
       />
     </span>
-    <span
+    <button
+      aria-label="清除"
       class="rc-picker-clear"
-      role="button"
+      type="button"
     >
       <span
         class="suffix-icon"
       />
-    </span>
+    </button>
   </div>
 </div>
 `;


### PR DESCRIPTION
This PR improves clear button functionality by:
- changing custom span to navite button element
- using `aria-label` attribute with the locale value
- focusing input element after clearing

Fixes https://github.com/ant-design/ant-design/issues/57933.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 清除选择值后，输入控件现自动获得焦点，改善交互体验。

* **Style**
  * 调整清除按钮的位置对齐方式，使其贴紧边缘显示。

* **Refactor**
  * 优化内部组件结构和样式管理逻辑，提升代码可维护性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/picker/pull/971?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->