### PR TITLE
fix: align meridiem labels with 12-hour periods

### DIFF
--- a/src/PickerPanel/TimePanel/TimePanelBody/index.tsx
+++ b/src/PickerPanel/TimePanel/TimePanelBody/index.tsx
@@ -114,8 +114,8 @@ export default function TimePanelBody<DateType extends object = any>(
     }
 
     const base = generateConfig.getNow();
-    const amDate = generateConfig.setHour(base, 6);
-    const pmDate = generateConfig.setHour(base, 18);
+    const amDate = generateConfig.setHour(base, 9);
+    const pmDate = generateConfig.setHour(base, 15);
 
     const formatMeridiem = (date: DateType, defaultLabel: string) => {
       const { cellMeridiemFormat } = locale;

--- a/tests/new-range.spec.tsx
+++ b/tests/new-range.spec.tsx
@@ -333,11 +333,11 @@ describe('NewPicker.Range', () => {
       expect(
         document.querySelectorAll('[data-type="meridiem"] .rc-picker-time-panel-cell')[0]
           .textContent,
-      ).toEqual('早上');
+      ).toEqual('上午');
       expect(
         document.querySelectorAll('[data-type="meridiem"] .rc-picker-time-panel-cell')[1]
           .textContent,
-      ).toEqual('晚上');
+      ).toEqual('下午');
     });
   });
 


### PR DESCRIPTION
## Summary

- format the 12-hour meridiem column with 9:00 and 15:00 sample times
- make Chinese `cellMeridiemFormat: A` render generic `上午` / `下午` labels instead of `早上` / `晚上`
- update the meridiem locale expectation

## Root Cause

The time panel used 6:00 and 18:00 as sample dates for formatting AM/PM labels. In Chinese locales those hours map to `早上` and `晚上`, while selected values such as 13:00 format as `下午`, causing the panel label and input value to diverge.

## Testing

- `npm test -- tests/new-range.spec.tsx --runInBand`
- `npm run lint:tsc`
- `git diff --check`

Ref: ant-design/ant-design#58286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 修复时间选择器中上午/下午显示文本的准确性和一致性，提升用户体验的清晰度。

* **测试**
  * 更新相关的测试用例，确保其与新的文本显示相适应。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->