### PR TITLE
Fix disabled existing values blocking picker changes

### DIFF
--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -343,6 +343,7 @@ function RangePicker<DateType extends object = any>(
     setInnerValue,
     getCalendarValue,
     triggerCalendarChange,
+    true, // rangeValue
     disabled,
     formatList,
     focused,

--- a/src/PickerInput/SinglePicker.tsx
+++ b/src/PickerInput/SinglePicker.tsx
@@ -30,6 +30,7 @@ import useShowNow from './hooks/useShowNow';
 import Popup from './Popup';
 import SingleSelector from './Selector/SingleSelector';
 import useSemantic from '../hooks/useSemantic';
+import { isSameTimestamp } from '../utils/dateUtil';
 
 // TODO: isInvalidateDate with showTime.disabledTime should not provide `range` prop
 
@@ -451,6 +452,17 @@ function Picker<DateType extends object = any>(
     onSetHover(date, 'cell');
   };
 
+  const isPopupInvalidateDate = useEvent((date: DateType) => {
+    if (
+      multiple &&
+      mergedValue.some((valueDate) => isSameTimestamp(generateConfig, valueDate, date))
+    ) {
+      return false;
+    }
+
+    return isInvalidateDate(date, { activeIndex: 0 });
+  });
+
   // >>> Focus
   const onPanelFocus: React.FocusEventHandler<HTMLElement> = (event) => {
     triggerOpen(true);
@@ -527,7 +539,7 @@ function Picker<DateType extends object = any>(
       // Value
       format={maskFormat}
       value={calendarValue}
-      isInvalid={isInvalidateDate}
+      isInvalid={isPopupInvalidateDate}
       onChange={null}
       onSelect={onPanelSelect}
       // PickerValue

--- a/src/PickerInput/SinglePicker.tsx
+++ b/src/PickerInput/SinglePicker.tsx
@@ -298,7 +298,8 @@ function Picker<DateType extends object = any>(
     setInnerValue,
     getCalendarValue,
     triggerCalendarChange,
-    [], //disabled,
+    false, // rangeValue
+    [], // disabled
     formatList,
     focused,
     mergedOpen,
@@ -455,6 +456,7 @@ function Picker<DateType extends object = any>(
   const isPopupInvalidateDate = useEvent((date: DateType) => {
     if (
       multiple &&
+      Array.isArray(mergedValue) &&
       mergedValue.some((valueDate) => isSameTimestamp(generateConfig, valueDate, date))
     ) {
       return false;

--- a/src/PickerInput/hooks/useRangeValue.ts
+++ b/src/PickerInput/hooks/useRangeValue.ts
@@ -72,6 +72,14 @@ function orderDates<DateType extends object, DatesType extends DateType[]>(
   return [...dates].sort((a, b) => (generateConfig.isAfter(a, b) ? 1 : -1)) as DatesType;
 }
 
+function includesTimestamp<DateType extends object>(
+  generateConfig: GenerateConfig<DateType>,
+  dates: DateType[],
+  date: DateType,
+) {
+  return dates.some((prevDate) => isSameTimestamp(generateConfig, prevDate, date));
+}
+
 /**
  * Used for internal value management.
  * It should always use `mergedValue` in render logic
@@ -197,6 +205,7 @@ export default function useRangeValue<ValueType extends DateType[], DateType ext
   } = info;
 
   const orderOnChange = disabled.some((d) => d) ? false : order;
+  const isRangeValue = disabled.length > 0;
 
   // ============================= Util =============================
   const [getDateTexts, isSameDates] = useUtil<ValueType>(generateConfig, locale, formatList);
@@ -263,11 +272,52 @@ export default function useRangeValue<ValueType extends DateType[], DateType ext
       generateConfig.isAfter(end, start);
 
     // >>> Invalid
-    const validateDates =
-      // Validate start
-      (disabled[0] || !start || !isInvalidateDate(start, { activeIndex: 0 })) &&
-      // Validate end
-      (disabled[1] || !end || !isInvalidateDate(end, { from: start, activeIndex: 1 }));
+    const prevStart = mergedValue[0] || null;
+    const prevEnd = mergedValue[1] || null;
+
+    const startChanged = !isSameTimestamp(generateConfig, prevStart, start || null);
+    const endChanged = !isSameTimestamp(generateConfig, prevEnd, end || null);
+
+    const isInvalidateChangedDate = (
+      date: DateType,
+      prevDate: DateType,
+      changed: boolean,
+      prevInfo: { from?: DateType; activeIndex: number },
+      nextInfo: { from?: DateType; activeIndex: number },
+    ) => {
+      const nextInvalidate = isInvalidateDate(date, nextInfo);
+
+      return nextInvalidate && (changed || !prevDate || !isInvalidateDate(prevDate, prevInfo));
+    };
+
+    const validateDates = isRangeValue
+      ? // Validate range dates. Existing invalid values should not block other updates.
+        (disabled[0] ||
+          !start ||
+          !isInvalidateChangedDate(
+            start,
+            prevStart,
+            startChanged,
+            { activeIndex: 0 },
+            { activeIndex: 0 },
+          )) &&
+        (disabled[1] ||
+          !end ||
+          !isInvalidateChangedDate(
+            end,
+            prevEnd,
+            endChanged,
+            { from: prevStart, activeIndex: 1 },
+            { from: start, activeIndex: 1 },
+          ))
+      : // Validate single or multiple dates. Existing values may be disabled by updated `disabledDate`.
+        clone.every(
+          (date) =>
+            !date ||
+            includesTimestamp(generateConfig, mergedValue, date) ||
+            !isInvalidateDate(date, { activeIndex: 0 }),
+        );
+
     // >>> Result
     const allPassed =
       // Null value is from clear button

--- a/src/PickerInput/hooks/useRangeValue.ts
+++ b/src/PickerInput/hooks/useRangeValue.ts
@@ -77,7 +77,10 @@ function includesTimestamp<DateType extends object>(
   dates: DateType[],
   date: DateType,
 ) {
-  return dates.some((prevDate) => isSameTimestamp(generateConfig, prevDate, date));
+  return (
+    Array.isArray(dates) &&
+    dates.some((prevDate) => isSameTimestamp(generateConfig, prevDate, date))
+  );
 }
 
 /**
@@ -179,6 +182,7 @@ export default function useRangeValue<ValueType extends DateType[], DateType ext
   setInnerValue: (nextValue: ValueType) => void,
   getCalendarValue: () => ValueType,
   triggerCalendarChange: TriggerCalendarChange<ValueType>,
+  rangeValue: boolean,
   disabled: ReplaceListType<Required<ValueType>, boolean>,
   formatList: FormatType[],
   focused: boolean,
@@ -205,7 +209,6 @@ export default function useRangeValue<ValueType extends DateType[], DateType ext
   } = info;
 
   const orderOnChange = disabled.some((d) => d) ? false : order;
-  const isRangeValue = disabled.length > 0;
 
   // ============================= Util =============================
   const [getDateTexts, isSameDates] = useUtil<ValueType>(generateConfig, locale, formatList);
@@ -278,6 +281,9 @@ export default function useRangeValue<ValueType extends DateType[], DateType ext
     const startChanged = !isSameTimestamp(generateConfig, prevStart, start || null);
     const endChanged = !isSameTimestamp(generateConfig, prevEnd, end || null);
 
+    // `validateDates` negates this helper: only a changed/new invalid date
+    // should block submission, while an unchanged value that was already
+    // invalid can remain without blocking another field update.
     const isInvalidateChangedDate = (
       date: DateType,
       prevDate: DateType,
@@ -290,7 +296,7 @@ export default function useRangeValue<ValueType extends DateType[], DateType ext
       return nextInvalidate && (changed || !prevDate || !isInvalidateDate(prevDate, prevInfo));
     };
 
-    const validateDates = isRangeValue
+    const validateDates = rangeValue
       ? // Validate range dates. Existing invalid values should not block other updates.
         (disabled[0] ||
           !start ||

--- a/tests/multiple.spec.tsx
+++ b/tests/multiple.spec.tsx
@@ -76,6 +76,25 @@ describe('Picker.Multiple', () => {
     expect(onChange).toHaveBeenCalledWith(expect.anything(), ['1990-09-01', '1990-09-05']);
   });
 
+  it('does not block change when existing value is disabled by disabledDate', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <DayPicker
+        multiple
+        needConfirm
+        defaultValue={[getDay('1990-09-03')]}
+        disabledDate={(date) => date < getDay('1990-09-03').endOf('day')}
+        onChange={onChange}
+      />,
+    );
+
+    openPicker(container);
+    selectCell(5);
+    fireEvent.click(document.querySelector('.rc-picker-ok button'));
+
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), ['1990-09-03', '1990-09-05']);
+  });
+
   it('selector remove', () => {
     const onChange = jest.fn();
     const { container } = render(

--- a/tests/multiple.spec.tsx
+++ b/tests/multiple.spec.tsx
@@ -95,6 +95,25 @@ describe('Picker.Multiple', () => {
     expect(onChange).toHaveBeenCalledWith(expect.anything(), ['1990-09-03', '1990-09-05']);
   });
 
+  it('blocks adding a preset value disabled by disabledDate', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <DayPicker
+        multiple
+        needConfirm
+        defaultValue={[getDay('1990-09-03')]}
+        disabledDate={(date) => date.isSame(getDay('1990-09-05'), 'date')}
+        presets={[{ label: 'Disabled', value: getDay('1990-09-05') }]}
+        onChange={onChange}
+      />,
+    );
+
+    openPicker(container);
+    fireEvent.click(document.querySelector('.rc-picker-presets li'));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('selector remove', () => {
     const onChange = jest.fn();
     const { container } = render(

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -275,6 +275,63 @@ describe('Picker.Range', () => {
       );
     });
 
+    it('does not block change when existing value is disabled by disabledDate', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <DayRangePicker
+          defaultValue={[getDay('1990-09-03'), getDay('1990-09-05')]}
+          disabledDate={(date) => date < getDay('1990-09-03').endOf('day')}
+          onChange={onChange}
+        />,
+      );
+
+      openPicker(container, 1);
+      selectCell(6);
+      closePicker(container, 1);
+
+      expect(onChange).toHaveBeenCalledWith(
+        [expect.anything(), expect.anything()],
+        ['1990-09-03', '1990-09-06'],
+      );
+    });
+
+    it('does not block start change when existing end value is disabled by disabledDate', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <DayRangePicker
+          defaultValue={[getDay('1990-09-01'), getDay('1990-09-03')]}
+          disabledDate={(date) => date.isSame(getDay('1990-09-03'), 'date')}
+          onChange={onChange}
+        />,
+      );
+
+      openPicker(container, 0);
+      selectCell(2);
+      closePicker(container, 1);
+
+      expect(onChange).toHaveBeenCalledWith(
+        [expect.anything(), expect.anything()],
+        ['1990-09-02', '1990-09-03'],
+      );
+    });
+
+    it('blocks change when existing end value becomes disabled by new start value', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <DayRangePicker
+          defaultValue={[getDay('1990-09-03'), getDay('1990-09-04')]}
+          disabledDate={(date: Dayjs, { from }) => !!from && date.isAfter(from.add(1, 'day'))}
+          onChange={onChange}
+        />,
+      );
+
+      openPicker(container, 0);
+      selectCell(2);
+      closePicker(container, 1);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
     it('should close panel when finish first choose with showTime = true and disabled = [false, true]', () => {
       const { baseElement } = render(<DayRangePicker showTime disabled={[false, true]} />);
       expect(baseElement.querySelectorAll('.rc-picker-input')).toHaveLength(2);

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -315,6 +315,42 @@ describe('Picker.Range', () => {
       );
     });
 
+    it('blocks start change from disabled date to another disabled date', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <DayRangePicker
+          defaultValue={[getDay('1990-09-01'), getDay('1990-09-05')]}
+          disabledDate={(date) => date.isBefore(getDay('1990-09-03'), 'date')}
+          onChange={onChange}
+        />,
+      );
+
+      openPicker(container, 0);
+      inputValue('1990-09-02', 0);
+      keyDown(container, 0, KeyCode.ENTER);
+      closePicker(container, 0);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('blocks end change from disabled date to another disabled date', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <DayRangePicker
+          defaultValue={[getDay('1990-09-01'), getDay('1990-09-03')]}
+          disabledDate={(date: Dayjs, { from }) => !!from && date.isAfter(from.add(1, 'day'))}
+          onChange={onChange}
+        />,
+      );
+
+      openPicker(container, 1);
+      inputValue('1990-09-04', 1);
+      keyDown(container, 1, KeyCode.ENTER);
+      closePicker(container, 1);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
     it('blocks change when existing end value becomes disabled by new start value', () => {
       const onChange = jest.fn();
       const { container } = render(


### PR DESCRIPTION
## 背景

当 DatePicker/RangePicker 已有选中值后来被 disabledDate 判定为 disabled 时，当前提交逻辑会全量校验已有值，导致用户修改其他合法日期时 onChange 不触发。

antd issue: https://github.com/ant-design/ant-design/issues/58330

## 修改内容

- RangePicker 提交校验改为只拦截本次新增或本次变化后才变 invalid 的日期。
- 已经存在且本来就是 invalid 的值不再阻塞用户修改其他合法日期。
- multiple 模式下，OK 按钮的 invalid 判断同样忽略已存在的旧值，避免被默认值卡住。
- 补充 RangePicker 与 multiple 的回归测试，覆盖已有 start/end disabled、以及 from 变化导致另一端新变 invalid 的负例。

## 验证

- npx rc-test tests/range.spec.tsx tests/multiple.spec.tsx --runInBand
- npx rc-test tests/range.spec.tsx --runInBand
- npm run lint:tsc
- npm test -- --runInBand
- npm run lint（通过，保留仓库既有 warnings）
- prettier --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进弹窗面板的失效日期判断：在多选场景下，时间戳相同的候选日期不再被误判为无效，避免阻断选择/确认流程。
  * 优化单/多选与区间选择的校验逻辑，减少因时间戳变更导致的无谓提交阻断。

* **Tests**
  * 新增多项测试，覆盖禁用日期与现有值、预设值交互以及范围选择下的失效日期行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->