### PR TITLE
Support onClear callback in picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ render(<Picker />, mountNode);
 | locale | Object | import from '@rc-component/picker/locale/en_US' | @rc-component/picker locale |
 | inputReadOnly | boolean | false | set input to read only |
 | allowClear | boolean \| { clearIcon?: ReactNode } | false | whether show clear button or customize clear button |
+| onClear | () => void |  | a callback function, can be executed when the clear button is clicked |
 | autoFocus | boolean | false | whether auto focus |
 | showTime | boolean \| Object | [showTime options](#showTime-options) | to provide an additional time selection |
 | picker | time \| date \| week \| month \| year |  | control which kind of panel should be shown |
@@ -126,6 +127,7 @@ render(<Picker />, mountNode);
 | disabled | boolean | false | whether the range picker is disabled |
 | onChange | Function(value:[moment], formatString: [string, string]) |  | a callback function, can be executed when the selected time is changing |
 | onCalendarChange | Function(value:[moment], formatString: [string, string], info: { range:'start'\|'end' }) |  | a callback function, can be executed when the start time or the end time of the range is changing |
+| onClear | () => void |  | a callback function, can be executed when the clear button is clicked |
 | direction | String: ltr or rtl |  | Layout direction of picker component, it supports RTL direction too. |
 | order | boolean | true | (TimeRangePicker only) `false` to disable auto order |
 

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -175,6 +175,7 @@ function RangePicker<DateType extends object = any>(
     defaultValue,
     value,
     needConfirm,
+    onClear,
     onKeyDown,
 
     // Disabled
@@ -461,6 +462,7 @@ function RangePicker<DateType extends object = any>(
   const onSelectorClear = () => {
     triggerSubmitChange(null);
     triggerOpen(false, { force: true });
+    onClear?.();
   };
 
   // ======================== Hover =========================
@@ -576,6 +578,7 @@ function RangePicker<DateType extends object = any>(
       ...(Object.keys(domProps) as (keyof SharedHTMLAttrs)[]),
       'onChange',
       'onCalendarChange',
+      'onClear',
       'style',
       'className',
       'onPanelChange',

--- a/src/PickerInput/SinglePicker.tsx
+++ b/src/PickerInput/SinglePicker.tsx
@@ -143,6 +143,7 @@ function Picker<DateType extends object = any>(
     value,
     needConfirm,
     onChange,
+    onClear,
     onKeyDown,
 
     // Disabled
@@ -386,6 +387,7 @@ function Picker<DateType extends object = any>(
     triggerSubmitChange(null);
     triggerOpen(false, { force: true });
     selectorRef.current.focus();
+    onClear?.();
   };
 
   // ======================== Hover =========================
@@ -496,6 +498,7 @@ function Picker<DateType extends object = any>(
       ...(Object.keys(domProps) as (keyof SharedHTMLAttrs)[]),
       'onChange',
       'onCalendarChange',
+      'onClear',
       'style',
       'className',
       'onPanelChange',

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -325,7 +325,8 @@ export type PanelSemanticName =
   | 'container';
 
 export interface SharedPickerProps<DateType extends object = any>
-  extends SharedHTMLAttrs,
+  extends
+    SharedHTMLAttrs,
     Pick<
       SharedPanelProps<DateType>,
       // Icon
@@ -379,6 +380,7 @@ export interface SharedPickerProps<DateType extends object = any>
     | {
         clearIcon?: React.ReactNode;
       };
+  onClear?: VoidFunction;
 
   /** @deprecated Please use `allowClear.clearIcon` instead */
   clearIcon?: React.ReactNode;

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -945,6 +945,16 @@ describe('Picker.Basic', () => {
     expect(document.querySelector('input').value).toEqual('');
   });
 
+  it('trigger onClear when clear value', () => {
+    const onClear = jest.fn();
+
+    render(<DayPicker allowClear defaultValue={getDay('2020-09-17')} onClear={onClear} />);
+
+    clearValue();
+    expect(onClear).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('input').value).toEqual('');
+  });
+
   it('panelRender', () => {
     render(<DayPicker open panelRender={() => <h1>Light</h1>} />);
     expect(document.querySelector('.rc-picker')).toMatchSnapshot();

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -1953,6 +1953,22 @@ describe('Picker.Range', () => {
     expect(document.querySelector('input').value).toEqual('');
   });
 
+  it('trigger onClear when clear value', () => {
+    const onClear = jest.fn();
+
+    render(
+      <DayRangePicker
+        allowClear
+        defaultValue={[getDay('2000-09-03'), getDay('2000-09-03')]}
+        onClear={onClear}
+      />,
+    );
+
+    clearValue();
+    expect(onClear).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('input').value).toEqual('');
+  });
+
   it('selected date when open is true should switch panel', () => {
     const { container } = render(<DayRangePicker open />);
 


### PR DESCRIPTION
## 变更内容

- 为 Picker 和 RangePicker 增加公开的 `onClear` 回调类型。
- 在点击清空按钮时触发 `onClear`，并保持现有清空与关闭弹层逻辑不变。
- 补充单选和范围选择器的回归测试。
- 更新 README API 表格说明。

## 背景

Ant Design 反馈 DatePicker / TimePicker 等支持清空的输入组件缺少清空回调。rc-picker 已有内部清空链路，但没有向外暴露对应 API。本次实现对齐 rc-input、rc-select 等组件的无参 `onClear` 设计。

关联 ant-design/ant-design#58349。

## 验证

- `npm run lint:tsc`
- `npm test -- --runTestsByPath tests/range.spec.tsx`
- `npm test -- --runTestsByPath tests/picker.spec.tsx`
- `npm run lint` 无 error，仅有项目既有 warning
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 选择器组件现已支持 `onClear` 回调属性，在清除已选值时自动触发执行。

* **文档**
  * 补充了选择器 API 文档中关于 `onClear` 属性的详细说明。

* **测试**
  * 新增了对 `onClear` 回调功能的测试用例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->