### PR TITLE
feat: support Temporal generateConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,8 +118,9 @@
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
     "@eslint/compat": "^2.1.0",
+    "@eslint/js": "^10.0.1",
+    "@js-temporal/polyfill": "^0.5.1",
     "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.4",
     "@testing-library/dom": "^10.4.1",
@@ -158,6 +159,7 @@
     "typescript-eslint": "^8.62.1"
   },
   "peerDependencies": {
+    "@js-temporal/polyfill": ">= 0.5.1",
     "date-fns": ">= 2.x",
     "dayjs": ">= 1.x",
     "luxon": ">= 3.x",
@@ -166,6 +168,9 @@
     "react-dom": ">=16.9.0"
   },
   "peerDependenciesMeta": {
+    "@js-temporal/polyfill": {
+      "optional": true
+    },
     "date-fns": {
       "optional": true
     },
@@ -193,6 +198,8 @@
     "./generate/luxon.js": "./es/generate/luxon.js",
     "./generate/moment": "./es/generate/moment.js",
     "./generate/moment.js": "./es/generate/moment.js",
+    "./generate/temporal": "./es/generate/temporal.js",
+    "./generate/temporal.js": "./es/generate/temporal.js",
     "./lib/index.js": "./es/index.js",
     "./locale/am_ET": "./es/locale/am_ET.js",
     "./locale/am_ET.js": "./es/locale/am_ET.js",

--- a/src/generate/temporal.ts
+++ b/src/generate/temporal.ts
@@ -47,14 +47,14 @@ type LocaleWeekInfoSource = {
   minimalDays: number;
 };
 
-const fullWidthFormatLocaleMap: Record<string, string> = {
-  zh_CN: 'narrow',
-  zh_TW: 'narrow',
+const weekDayFormatLocaleMap: Record<string, 'narrow' | 'short'> = {
+  'zh-CN': 'narrow',
+  'zh-TW': 'narrow',
 };
 
-const shortWeekDayLengthMap: Record<string, number> = {
-  en_US: 2,
-  en_GB: 2,
+const weekDayTruncateLengthMap: Record<string, number> = {
+  'en-US': 2,
+  'en-GB': 2,
 };
 
 const TEMPORAL_MISSING_ERROR =
@@ -63,6 +63,39 @@ const TEMPORAL_MISSING_ERROR =
 const padStart = (value: number, length = 2) => String(value).padStart(length, '0');
 
 const normalizeLocale = (locale: string) => locale.replace(/_/g, '-');
+
+const getLocaleLanguage = (locale: string) => normalizeLocale(locale).split('-')[0];
+
+const getEnglishOrdinalSuffix = (value: number) => {
+  const mod10 = value % 10;
+  const mod100 = value % 100;
+
+  if (mod10 === 1 && mod100 !== 11) {
+    return 'st';
+  }
+  if (mod10 === 2 && mod100 !== 12) {
+    return 'nd';
+  }
+  if (mod10 === 3 && mod100 !== 13) {
+    return 'rd';
+  }
+
+  return 'th';
+};
+
+const getOrdinalValue = (locale: string, value: number, unit: 'day' | 'week') => {
+  const language = getLocaleLanguage(locale);
+
+  if (language === 'zh') {
+    return `${value}${unit === 'week' ? '周' : '日'}`;
+  }
+
+  if (language === 'en') {
+    return `${value}${getEnglishOrdinalSuffix(value)}`;
+  }
+
+  return String(value);
+};
 
 const isLocaleWeekInfoSource = (value: unknown): value is LocaleWeekInfoSource =>
   !!value &&
@@ -114,7 +147,10 @@ const isTemporalDateTime = (value: unknown): value is TemporalDateTime => {
     typeof (value as TemporalDateTime).hour === 'number' &&
     typeof (value as TemporalDateTime).minute === 'number' &&
     typeof (value as TemporalDateTime).second === 'number' &&
-    typeof (value as TemporalDateTime).millisecond === 'number'
+    typeof (value as TemporalDateTime).millisecond === 'number' &&
+    typeof (value as TemporalDateTime).with === 'function' &&
+    typeof (value as TemporalDateTime).add === 'function' &&
+    typeof (value as TemporalDateTime).toPlainDate === 'function'
   );
 };
 
@@ -122,18 +158,22 @@ const getWeekInfo = (locale: string): LocaleWeekInfo => {
   const normalized = normalizeLocale(locale);
 
   if (typeof Intl?.Locale === 'function') {
-    const localeInfo = new Intl.Locale(normalized) as Intl.Locale & {
-      getWeekInfo?: () => unknown;
-      weekInfo?: unknown;
-    };
-
-    const weekInfo = localeInfo.weekInfo || localeInfo.getWeekInfo?.();
-
-    if (isLocaleWeekInfoSource(weekInfo)) {
-      return {
-        firstDay: weekInfo.firstDay % 7,
-        minimalDays: weekInfo.minimalDays,
+    try {
+      const localeInfo = new Intl.Locale(normalized) as Intl.Locale & {
+        getWeekInfo?: () => unknown;
+        weekInfo?: unknown;
       };
+
+      const weekInfo = localeInfo.weekInfo || localeInfo.getWeekInfo?.();
+
+      if (isLocaleWeekInfoSource(weekInfo)) {
+        return {
+          firstDay: weekInfo.firstDay % 7,
+          minimalDays: weekInfo.minimalDays,
+        };
+      }
+    } catch {
+      // Fallback below.
     }
   }
 
@@ -156,6 +196,14 @@ const getLocaleMonthNames = (locale: string, width: 'short' | 'long') =>
       month: width,
       timeZone: 'UTC',
     }).format(new Date(Date.UTC(2020, index, 1))),
+  );
+
+const getLocaleWeekDays = (locale: string, width: 'long' | 'short') =>
+  Array.from({ length: 7 }, (_, index) =>
+    new Intl.DateTimeFormat(normalizeLocale(locale), {
+      weekday: width,
+      timeZone: 'UTC',
+    }).format(new Date(Date.UTC(2024, 0, 7 + index))),
   );
 
 const getLocaleDayPeriods = (locale: string) => {
@@ -181,8 +229,8 @@ const getLocaleDayPeriods = (locale: string) => {
 
 const getShortWeekDays = (locale: string) => {
   const normalized = normalizeLocale(locale);
-  const format = (fullWidthFormatLocaleMap[locale] || 'short') as 'narrow' | 'short';
-  const sliceLength = shortWeekDayLengthMap[locale];
+  const format = weekDayFormatLocaleMap[normalized] || 'short';
+  const sliceLength = weekDayTruncateLengthMap[normalized];
 
   return Array.from({ length: 7 }, (_, index) => {
     const weekday = new Intl.DateTimeFormat(normalized, {
@@ -192,6 +240,24 @@ const getShortWeekDays = (locale: string) => {
 
     return sliceLength ? weekday.slice(0, sliceLength) : weekday;
   });
+};
+
+const getDayOfWeekName = (
+  locale: string,
+  date: TemporalDateTime,
+  format: 'dddd' | 'ddd' | 'dd',
+) => {
+  const weekDayIndex = getWeekDayIndex(date);
+
+  if (format === 'dddd') {
+    return getLocaleWeekDays(locale, 'long')[weekDayIndex];
+  }
+
+  if (format === 'ddd') {
+    return getLocaleWeekDays(locale, 'short')[weekDayIndex];
+  }
+
+  return getShortWeekDays(locale)[weekDayIndex];
 };
 
 const getWeekDayIndex = (date: TemporalDateTime) => date.dayOfWeek % 7;
@@ -244,45 +310,26 @@ const getWeekInfoForDate = (locale: string, date: TemporalDateTime): ParsedWeek 
 
 const getQuarter = (date: TemporalDateTime) => Math.floor((date.month - 1) / 3) + 1;
 
-const getWeekOrdinal = (locale: string, week: number) => {
-  if (locale.startsWith('zh_')) {
-    return `${week}周`;
-  }
-
-  if (locale.startsWith('en_')) {
-    const mod10 = week % 10;
-    const mod100 = week % 100;
-
-    if (mod10 === 1 && mod100 !== 11) {
-      return `${week}st`;
-    }
-    if (mod10 === 2 && mod100 !== 12) {
-      return `${week}nd`;
-    }
-    if (mod10 === 3 && mod100 !== 13) {
-      return `${week}rd`;
-    }
-
-    return `${week}th`;
-  }
-
-  return String(week);
-};
+const getWeekOrdinal = (locale: string, week: number) => getOrdinalValue(locale, week, 'week');
 
 const tokenList = [
   'YYYY',
   'GGGG',
   'gggg',
+  'dddd',
+  'ddd',
   'MMMM',
   'MMM',
   'SSS',
   'Wo',
+  'Do',
   'wo',
   'ww',
   'WW',
   'YY',
   'MM',
   'DD',
+  'dd',
   'HH',
   'hh',
   'mm',
@@ -363,6 +410,10 @@ const formatToken = (locale: string, date: TemporalDateTime, token: Token) => {
     case 'GGGG':
     case 'gggg':
       return padStart(weekData.weekYear, 4);
+    case 'dddd':
+    case 'ddd':
+    case 'dd':
+      return getDayOfWeekName(locale, date, token);
     case 'MMMM':
       return getLocaleMonthNames(locale, 'long')[date.month - 1];
     case 'MMM':
@@ -375,6 +426,8 @@ const formatToken = (locale: string, date: TemporalDateTime, token: Token) => {
       return padStart(date.day);
     case 'D':
       return String(date.day);
+    case 'Do':
+      return getOrdinalValue(locale, date.day, 'day');
     case 'HH':
       return padStart(date.hour);
     case 'H':
@@ -431,6 +484,19 @@ const getMonthNameMatcher = (locale: string, width: 'short' | 'long') => {
   };
 };
 
+const getWeekDayMatcher = (locale: string, width: 'long' | 'short' | 'min') => {
+  const weekDays = width === 'min' ? getShortWeekDays(locale) : getLocaleWeekDays(locale, width);
+  const matcher = Array.from(new Set(weekDays))
+    .sort((left, right) => right.length - left.length)
+    .map(escapeRegExp)
+    .join('|');
+
+  return {
+    matcher,
+    weekDays,
+  };
+};
+
 const getDayPeriodMatcher = (locale: string) => {
   const periods = getLocaleDayPeriods(locale);
 
@@ -456,6 +522,9 @@ const getDayPeriodMatcher = (locale: string) => {
 const buildParseMatcher = (locale: string, parts: FormatPart[]) => {
   const monthShort = getMonthNameMatcher(locale, 'short');
   const monthLong = getMonthNameMatcher(locale, 'long');
+  const weekDayLong = getWeekDayMatcher(locale, 'long');
+  const weekDayShort = getWeekDayMatcher(locale, 'short');
+  const weekDayMin = getWeekDayMatcher(locale, 'min');
   const meridiemMatcher = getDayPeriodMatcher(locale);
 
   const regexParts = parts.map((part, index) => {
@@ -472,6 +541,10 @@ const buildParseMatcher = (locale: string, parts: FormatPart[]) => {
         return `(?<${key}>\\d{4})`;
       case 'YY':
         return `(?<${key}>\\d{2})`;
+      case 'dddd':
+        return `(?<${key}>${weekDayLong.matcher})`;
+      case 'ddd':
+        return `(?<${key}>${weekDayShort.matcher})`;
       case 'MMMM':
         return `(?<${key}>${monthLong.matcher})`;
       case 'MMM':
@@ -497,7 +570,10 @@ const buildParseMatcher = (locale: string, parts: FormatPart[]) => {
         return `(?<${key}>\\d{1,2})`;
       case 'SSS':
         return `(?<${key}>\\d{1,3})`;
+      case 'dd':
+        return `(?<${key}>${weekDayMin.matcher})`;
       case 'Wo':
+      case 'Do':
       case 'wo':
         return `(?<${key}>\\d{1,2}(?:[^\\d\\s]+)?)`;
       case 'A':
@@ -521,9 +597,42 @@ const parseWeekOrdinal = (value: string) => {
 };
 
 const parseDateByWeek = (locale: string, weekYear: number, week: number) => {
+  if (week < 1 || week > 53) {
+    return null;
+  }
+
   const weekInfo = getWeekInfo(locale);
   const weekYearStart = getWeekYearStart(weekYear, weekInfo);
-  return weekYearStart.add({ days: (week - 1) * 7 });
+  const result = weekYearStart.add({ days: (week - 1) * 7 });
+  const parsedWeekInfo = getWeekInfoForDate(locale, result);
+
+  if (parsedWeekInfo.weekYear !== weekYear || parsedWeekInfo.week !== week) {
+    return null;
+  }
+
+  return result;
+};
+
+const parseTwoDigitYear = (value: string) => {
+  const year = Number(value);
+
+  return year <= 68 ? 2000 + year : 1900 + year;
+};
+
+const isMeridiemValue = (value: string, candidate: string) =>
+  value.localeCompare(candidate, undefined, { sensitivity: 'accent' }) === 0 ||
+  value.localeCompare(candidate, undefined, { sensitivity: 'base' }) === 0;
+
+const isPmMeridiem = (locale: string, meridiem: string) => {
+  const periods = getLocaleDayPeriods(locale);
+
+  return [periods.pm, 'PM', 'pm'].some((candidate) => isMeridiemValue(meridiem, candidate));
+};
+
+const isAmMeridiem = (locale: string, meridiem: string) => {
+  const periods = getLocaleDayPeriods(locale);
+
+  return [periods.am, 'AM', 'am'].some((candidate) => isMeridiemValue(meridiem, candidate));
 };
 
 const parseFromFormat = (locale: string, text: string, format: string): TemporalDateTime | null => {
@@ -548,6 +657,8 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
   let meridiem: string | undefined;
   let parsedWeek: number | undefined;
   let parsedWeekYear: number | undefined;
+  let parsedWeekType: 'locale' | 'iso' | undefined;
+  let parsedWeekYearType: 'locale' | 'iso' | undefined;
   let usedTimeToken = false;
   let usedDateToken = false;
 
@@ -567,22 +678,31 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
         usedDateToken = true;
         break;
       case 'YY':
-        year = 2000 + Number(value);
+        year = parseTwoDigitYear(value);
         usedDateToken = true;
         break;
       case 'GGGG':
+        parsedWeekYear = Number(value);
+        parsedWeekYearType = 'iso';
+        usedDateToken = true;
+        break;
       case 'gggg':
         parsedWeekYear = Number(value);
+        parsedWeekYearType = 'locale';
         usedDateToken = true;
         break;
       case 'MMMM':
-        month =
-          monthLong.monthNames.findIndex((name) => name.toLowerCase() === value.toLowerCase()) + 1;
+        month = monthLong.monthNames.findIndex(
+          (name) => name.toLowerCase() === value.toLowerCase(),
+        );
+        month = month === -1 ? Number.NaN : month + 1;
         usedDateToken = true;
         break;
       case 'MMM':
-        month =
-          monthShort.monthNames.findIndex((name) => name.toLowerCase() === value.toLowerCase()) + 1;
+        month = monthShort.monthNames.findIndex(
+          (name) => name.toLowerCase() === value.toLowerCase(),
+        );
+        month = month === -1 ? Number.NaN : month + 1;
         usedDateToken = true;
         break;
       case 'MM':
@@ -593,6 +713,10 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
       case 'DD':
       case 'D':
         day = Number(value);
+        usedDateToken = true;
+        break;
+      case 'Do':
+        day = parseWeekOrdinal(value) ?? undefined;
         usedDateToken = true;
         break;
       case 'HH':
@@ -624,15 +748,21 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
         usedDateToken = true;
         break;
       case 'ww':
-      case 'WW':
       case 'w':
+        parsedWeek = Number(value);
+        parsedWeekType = 'locale';
+        usedDateToken = true;
+        break;
+      case 'WW':
       case 'W':
         parsedWeek = Number(value);
+        parsedWeekType = 'iso';
         usedDateToken = true;
         break;
       case 'Wo':
       case 'wo':
         parsedWeek = parseWeekOrdinal(value) ?? undefined;
+        parsedWeekType = 'locale';
         usedDateToken = true;
         break;
       case 'A':
@@ -646,9 +776,18 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
   });
 
   if (
-    [month, day, hour, minute, second, millisecond, quarter, parsedWeek, parsedWeekYear].some(
-      (value) => Number.isNaN(value),
-    )
+    [year, month, day, hour, minute, second, millisecond, quarter, parsedWeek, parsedWeekYear]
+      .filter((value) => value !== undefined)
+      .some((value) => Number.isNaN(value))
+  ) {
+    return null;
+  }
+
+  if (
+    parsedWeek !== undefined &&
+    parsedWeekType &&
+    parsedWeekYearType &&
+    parsedWeekType !== parsedWeekYearType
   ) {
     return null;
   }
@@ -681,12 +820,11 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
       second !== undefined ||
       millisecond !== undefined
     ) {
-      const upperMeridiem = meridiem?.toUpperCase();
       let parsedHour = hour ?? 0;
 
-      if (upperMeridiem === 'PM' && parsedHour < 12) {
+      if (meridiem && isPmMeridiem(locale, meridiem) && parsedHour < 12) {
         parsedHour += 12;
-      } else if (upperMeridiem === 'AM' && parsedHour === 12) {
+      } else if (meridiem && isAmMeridiem(locale, meridiem) && parsedHour === 12) {
         parsedHour = 0;
       }
 
@@ -720,7 +858,7 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
 const generateConfig: GenerateConfig<TemporalDateTime> = {
   getNow: () => getTemporal().Now.plainDateTimeISO(),
   getFixedDate: (value) => {
-    const matched = value.match(/^(\d{4})-(\d{1,2})-(\d{2})$/);
+    const matched = value.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
 
     if (!matched) {
       throw new Error(`Invalid fixed date value: ${value}`);

--- a/src/generate/temporal.ts
+++ b/src/generate/temporal.ts
@@ -1,0 +1,797 @@
+import type { Temporal as TemporalPolyfill } from '@js-temporal/polyfill';
+
+import type { GenerateConfig } from '.';
+
+type TemporalDateTime = TemporalPolyfill.PlainDateTime;
+
+type TemporalDateTimeInput =
+  | TemporalDateTime
+  | string
+  | {
+      year: number;
+      month: number;
+      day: number;
+      hour?: number;
+      minute?: number;
+      second?: number;
+      millisecond?: number;
+    };
+
+type TemporalGlobal = {
+  PlainDateTime: {
+    from: (
+      value: TemporalDateTimeInput,
+      options?: {
+        overflow?: 'constrain' | 'reject';
+      },
+    ) => TemporalDateTime;
+    compare: (date1: TemporalDateTime, date2: TemporalDateTime) => number;
+  };
+  Now: {
+    plainDateTimeISO: () => TemporalDateTime;
+  };
+};
+
+type ParsedWeek = {
+  week: number;
+  weekYear: number;
+};
+
+type LocaleWeekInfo = {
+  firstDay: number;
+  minimalDays: number;
+};
+
+type LocaleWeekInfoSource = {
+  firstDay: number;
+  minimalDays: number;
+};
+
+const fullWidthFormatLocaleMap: Record<string, string> = {
+  zh_CN: 'narrow',
+  zh_TW: 'narrow',
+};
+
+const shortWeekDayLengthMap: Record<string, number> = {
+  en_US: 2,
+  en_GB: 2,
+};
+
+const TEMPORAL_MISSING_ERROR =
+  'Temporal API is not available. Please use a runtime with native Temporal support or attach @js-temporal/polyfill to globalThis.Temporal before using @rc-component/picker/generate/temporal.';
+
+const padStart = (value: number, length = 2) => String(value).padStart(length, '0');
+
+const normalizeLocale = (locale: string) => locale.replace(/_/g, '-');
+
+const isLocaleWeekInfoSource = (value: unknown): value is LocaleWeekInfoSource =>
+  !!value &&
+  typeof value === 'object' &&
+  typeof (value as LocaleWeekInfoSource).firstDay === 'number' &&
+  typeof (value as LocaleWeekInfoSource).minimalDays === 'number';
+
+const getTemporal = (): TemporalGlobal => {
+  const temporal = globalThis.Temporal;
+
+  if (!temporal?.PlainDateTime || !temporal?.Now) {
+    throw new Error(TEMPORAL_MISSING_ERROR);
+  }
+
+  return temporal as unknown as TemporalGlobal;
+};
+
+const createDateTime = (
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0,
+  second = 0,
+  millisecond = 0,
+) =>
+  getTemporal().PlainDateTime.from(
+    {
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+    },
+    { overflow: 'constrain' },
+  );
+
+const isTemporalDateTime = (value: unknown): value is TemporalDateTime => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  return (
+    typeof (value as TemporalDateTime).year === 'number' &&
+    typeof (value as TemporalDateTime).month === 'number' &&
+    typeof (value as TemporalDateTime).day === 'number' &&
+    typeof (value as TemporalDateTime).hour === 'number' &&
+    typeof (value as TemporalDateTime).minute === 'number' &&
+    typeof (value as TemporalDateTime).second === 'number' &&
+    typeof (value as TemporalDateTime).millisecond === 'number'
+  );
+};
+
+const getWeekInfo = (locale: string): LocaleWeekInfo => {
+  const normalized = normalizeLocale(locale);
+
+  if (typeof Intl?.Locale === 'function') {
+    const localeInfo = new Intl.Locale(normalized) as Intl.Locale & {
+      getWeekInfo?: () => unknown;
+      weekInfo?: unknown;
+    };
+
+    const weekInfo = localeInfo.weekInfo || localeInfo.getWeekInfo?.();
+
+    if (isLocaleWeekInfoSource(weekInfo)) {
+      return {
+        firstDay: weekInfo.firstDay % 7,
+        minimalDays: weekInfo.minimalDays,
+      };
+    }
+  }
+
+  if (normalized === 'en-US') {
+    return {
+      firstDay: 0,
+      minimalDays: 1,
+    };
+  }
+
+  return {
+    firstDay: 1,
+    minimalDays: 4,
+  };
+};
+
+const getLocaleMonthNames = (locale: string, width: 'short' | 'long') =>
+  Array.from({ length: 12 }, (_, index) =>
+    new Intl.DateTimeFormat(normalizeLocale(locale), {
+      month: width,
+      timeZone: 'UTC',
+    }).format(new Date(Date.UTC(2020, index, 1))),
+  );
+
+const getLocaleDayPeriods = (locale: string) => {
+  const formatter = new Intl.DateTimeFormat(normalizeLocale(locale), {
+    hour: 'numeric',
+    hour12: true,
+    timeZone: 'UTC',
+  });
+
+  const getPeriod = (hour: number) => {
+    const parts = formatter.formatToParts(new Date(Date.UTC(2020, 0, 1, hour)));
+    return parts.find((part) => part.type === 'dayPeriod')?.value;
+  };
+
+  const am = getPeriod(1) || 'AM';
+  const pm = getPeriod(13) || 'PM';
+
+  return {
+    am,
+    pm,
+  };
+};
+
+const getShortWeekDays = (locale: string) => {
+  const normalized = normalizeLocale(locale);
+  const format = (fullWidthFormatLocaleMap[locale] || 'short') as 'narrow' | 'short';
+  const sliceLength = shortWeekDayLengthMap[locale];
+
+  return Array.from({ length: 7 }, (_, index) => {
+    const weekday = new Intl.DateTimeFormat(normalized, {
+      weekday: format,
+      timeZone: 'UTC',
+    }).format(new Date(Date.UTC(2024, 0, 7 + index)));
+
+    return sliceLength ? weekday.slice(0, sliceLength) : weekday;
+  });
+};
+
+const getWeekDayIndex = (date: TemporalDateTime) => date.dayOfWeek % 7;
+
+const getWeekStart = (date: TemporalDateTime, firstDay: number) => {
+  const currentDay = getWeekDayIndex(date);
+  let diff = firstDay - currentDay;
+
+  if (currentDay < firstDay) {
+    diff -= 7;
+  }
+
+  return date.add({ days: diff });
+};
+
+const getWeekYearStart = (year: number, weekInfo: LocaleWeekInfo) => {
+  const firstDate = createDateTime(year, 1, 1);
+  const weekStart = getWeekStart(firstDate, weekInfo.firstDay);
+  const weekDayOffset = (getWeekDayIndex(firstDate) - weekInfo.firstDay + 7) % 7;
+  const firstWeekDays = 7 - weekDayOffset;
+
+  return firstWeekDays >= weekInfo.minimalDays ? weekStart : weekStart.add({ days: 7 });
+};
+
+const getWeekInfoForDate = (locale: string, date: TemporalDateTime): ParsedWeek => {
+  const weekInfo = getWeekInfo(locale);
+  const currentWeekStart = getWeekStart(date, weekInfo.firstDay);
+
+  let weekYear = date.year;
+  let weekYearStart = getWeekYearStart(weekYear, weekInfo);
+
+  if (getTemporal().PlainDateTime.compare(currentWeekStart, weekYearStart) < 0) {
+    weekYear -= 1;
+    weekYearStart = getWeekYearStart(weekYear, weekInfo);
+  } else {
+    const nextWeekYearStart = getWeekYearStart(weekYear + 1, weekInfo);
+    if (getTemporal().PlainDateTime.compare(currentWeekStart, nextWeekYearStart) >= 0) {
+      weekYear += 1;
+      weekYearStart = nextWeekYearStart;
+    }
+  }
+
+  const diffDays = currentWeekStart.toPlainDate().since(weekYearStart.toPlainDate()).days;
+
+  return {
+    week: Math.floor(diffDays / 7) + 1,
+    weekYear,
+  };
+};
+
+const getQuarter = (date: TemporalDateTime) => Math.floor((date.month - 1) / 3) + 1;
+
+const getWeekOrdinal = (locale: string, week: number) => {
+  if (locale.startsWith('zh_')) {
+    return `${week}周`;
+  }
+
+  if (locale.startsWith('en_')) {
+    const mod10 = week % 10;
+    const mod100 = week % 100;
+
+    if (mod10 === 1 && mod100 !== 11) {
+      return `${week}st`;
+    }
+    if (mod10 === 2 && mod100 !== 12) {
+      return `${week}nd`;
+    }
+    if (mod10 === 3 && mod100 !== 13) {
+      return `${week}rd`;
+    }
+
+    return `${week}th`;
+  }
+
+  return String(week);
+};
+
+const tokenList = [
+  'YYYY',
+  'GGGG',
+  'gggg',
+  'MMMM',
+  'MMM',
+  'SSS',
+  'Wo',
+  'wo',
+  'ww',
+  'WW',
+  'YY',
+  'MM',
+  'DD',
+  'HH',
+  'hh',
+  'mm',
+  'ss',
+  'Q',
+  'W',
+  'w',
+  'M',
+  'D',
+  'H',
+  'h',
+  'm',
+  's',
+  'A',
+  'a',
+] as const;
+
+type Token = (typeof tokenList)[number];
+
+type FormatPart =
+  | {
+      type: 'literal';
+      value: string;
+    }
+  | {
+      type: 'token';
+      value: Token;
+    };
+
+const parseFormatParts = (format: string): FormatPart[] => {
+  const parts: FormatPart[] = [];
+  let index = 0;
+
+  while (index < format.length) {
+    if (format[index] === '[') {
+      const closeIndex = format.indexOf(']', index + 1);
+      const literal =
+        closeIndex === -1 ? format.slice(index + 1) : format.slice(index + 1, closeIndex);
+
+      parts.push({
+        type: 'literal',
+        value: literal,
+      });
+
+      index = closeIndex === -1 ? format.length : closeIndex + 1;
+      continue;
+    }
+
+    const token = tokenList.find((currentToken) => format.startsWith(currentToken, index));
+    if (token) {
+      parts.push({
+        type: 'token',
+        value: token,
+      });
+      index += token.length;
+      continue;
+    }
+
+    parts.push({
+      type: 'literal',
+      value: format[index],
+    });
+    index += 1;
+  }
+
+  return parts;
+};
+
+const formatToken = (locale: string, date: TemporalDateTime, token: Token) => {
+  const weekData = getWeekInfoForDate(locale, date);
+  const dayPeriods = getLocaleDayPeriods(locale);
+
+  switch (token) {
+    case 'YYYY':
+      return padStart(date.year, 4);
+    case 'YY':
+      return padStart(date.year % 100, 2);
+    case 'GGGG':
+    case 'gggg':
+      return padStart(weekData.weekYear, 4);
+    case 'MMMM':
+      return getLocaleMonthNames(locale, 'long')[date.month - 1];
+    case 'MMM':
+      return getLocaleMonthNames(locale, 'short')[date.month - 1];
+    case 'MM':
+      return padStart(date.month);
+    case 'M':
+      return String(date.month);
+    case 'DD':
+      return padStart(date.day);
+    case 'D':
+      return String(date.day);
+    case 'HH':
+      return padStart(date.hour);
+    case 'H':
+      return String(date.hour);
+    case 'hh': {
+      const hour = date.hour % 12 || 12;
+      return padStart(hour);
+    }
+    case 'h':
+      return String(date.hour % 12 || 12);
+    case 'mm':
+      return padStart(date.minute);
+    case 'm':
+      return String(date.minute);
+    case 'ss':
+      return padStart(date.second);
+    case 's':
+      return String(date.second);
+    case 'SSS':
+      return padStart(date.millisecond, 3);
+    case 'Q':
+      return String(getQuarter(date));
+    case 'ww':
+    case 'WW':
+      return padStart(weekData.week);
+    case 'w':
+    case 'W':
+      return String(weekData.week);
+    case 'Wo':
+    case 'wo':
+      return getWeekOrdinal(locale, weekData.week);
+    case 'A':
+      return date.hour < 12 ? dayPeriods.am : dayPeriods.pm;
+    case 'a':
+      return (date.hour < 12 ? dayPeriods.am : dayPeriods.pm).toLowerCase();
+    default:
+      return token;
+  }
+};
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const getMonthNameMatcher = (locale: string, width: 'short' | 'long') => {
+  const monthNames = getLocaleMonthNames(locale, width);
+  const matcher = monthNames
+    .slice()
+    .sort((left, right) => right.length - left.length)
+    .map(escapeRegExp)
+    .join('|');
+
+  return {
+    matcher,
+    monthNames,
+  };
+};
+
+const getDayPeriodMatcher = (locale: string) => {
+  const periods = getLocaleDayPeriods(locale);
+
+  return Array.from(
+    new Set([
+      periods.am,
+      periods.pm,
+      periods.am.toUpperCase(),
+      periods.pm.toUpperCase(),
+      periods.am.toLowerCase(),
+      periods.pm.toLowerCase(),
+      'AM',
+      'PM',
+      'am',
+      'pm',
+    ]),
+  )
+    .sort((left, right) => right.length - left.length)
+    .map(escapeRegExp)
+    .join('|');
+};
+
+const buildParseMatcher = (locale: string, parts: FormatPart[]) => {
+  const monthShort = getMonthNameMatcher(locale, 'short');
+  const monthLong = getMonthNameMatcher(locale, 'long');
+  const meridiemMatcher = getDayPeriodMatcher(locale);
+
+  const regexParts = parts.map((part, index) => {
+    if (part.type === 'literal') {
+      return escapeRegExp(part.value);
+    }
+
+    const key = `${part.value}_${index}`;
+
+    switch (part.value) {
+      case 'YYYY':
+      case 'GGGG':
+      case 'gggg':
+        return `(?<${key}>\\d{4})`;
+      case 'YY':
+        return `(?<${key}>\\d{2})`;
+      case 'MMMM':
+        return `(?<${key}>${monthLong.matcher})`;
+      case 'MMM':
+        return `(?<${key}>${monthShort.matcher})`;
+      case 'MM':
+      case 'DD':
+      case 'HH':
+      case 'hh':
+      case 'mm':
+      case 'ss':
+      case 'ww':
+      case 'WW':
+        return `(?<${key}>\\d{2})`;
+      case 'M':
+      case 'D':
+      case 'H':
+      case 'h':
+      case 'm':
+      case 's':
+      case 'Q':
+      case 'w':
+      case 'W':
+        return `(?<${key}>\\d{1,2})`;
+      case 'SSS':
+        return `(?<${key}>\\d{1,3})`;
+      case 'Wo':
+      case 'wo':
+        return `(?<${key}>\\d{1,2}(?:[^\\d\\s]+)?)`;
+      case 'A':
+      case 'a':
+        return `(?<${key}>${meridiemMatcher})`;
+      default:
+        return '';
+    }
+  });
+
+  return {
+    matcher: new RegExp(`^${regexParts.join('')}$`, 'iu'),
+    monthShort,
+    monthLong,
+  };
+};
+
+const parseWeekOrdinal = (value: string) => {
+  const matched = value.match(/\d+/);
+  return matched ? Number(matched[0]) : null;
+};
+
+const parseDateByWeek = (locale: string, weekYear: number, week: number) => {
+  const weekInfo = getWeekInfo(locale);
+  const weekYearStart = getWeekYearStart(weekYear, weekInfo);
+  return weekYearStart.add({ days: (week - 1) * 7 });
+};
+
+const parseFromFormat = (locale: string, text: string, format: string): TemporalDateTime | null => {
+  const parts = parseFormatParts(format);
+  const { matcher, monthShort, monthLong } = buildParseMatcher(locale, parts);
+  const matched = matcher.exec(text);
+
+  if (!matched?.groups) {
+    return null;
+  }
+
+  const parsedValues: Record<string, string> = matched.groups;
+
+  let year: number | undefined;
+  let month: number | undefined;
+  let day: number | undefined;
+  let hour: number | undefined;
+  let minute: number | undefined;
+  let second: number | undefined;
+  let millisecond: number | undefined;
+  let quarter: number | undefined;
+  let meridiem: string | undefined;
+  let parsedWeek: number | undefined;
+  let parsedWeekYear: number | undefined;
+  let usedTimeToken = false;
+  let usedDateToken = false;
+
+  parts.forEach((part, index) => {
+    if (part.type === 'literal') {
+      return;
+    }
+
+    const value = parsedValues[`${part.value}_${index}`];
+    if (value === undefined) {
+      return;
+    }
+
+    switch (part.value) {
+      case 'YYYY':
+        year = Number(value);
+        usedDateToken = true;
+        break;
+      case 'YY':
+        year = 2000 + Number(value);
+        usedDateToken = true;
+        break;
+      case 'GGGG':
+      case 'gggg':
+        parsedWeekYear = Number(value);
+        usedDateToken = true;
+        break;
+      case 'MMMM':
+        month =
+          monthLong.monthNames.findIndex((name) => name.toLowerCase() === value.toLowerCase()) + 1;
+        usedDateToken = true;
+        break;
+      case 'MMM':
+        month =
+          monthShort.monthNames.findIndex((name) => name.toLowerCase() === value.toLowerCase()) + 1;
+        usedDateToken = true;
+        break;
+      case 'MM':
+      case 'M':
+        month = Number(value);
+        usedDateToken = true;
+        break;
+      case 'DD':
+      case 'D':
+        day = Number(value);
+        usedDateToken = true;
+        break;
+      case 'HH':
+      case 'H':
+        hour = Number(value);
+        usedTimeToken = true;
+        break;
+      case 'hh':
+      case 'h':
+        hour = Number(value) % 12;
+        usedTimeToken = true;
+        break;
+      case 'mm':
+      case 'm':
+        minute = Number(value);
+        usedTimeToken = true;
+        break;
+      case 'ss':
+      case 's':
+        second = Number(value);
+        usedTimeToken = true;
+        break;
+      case 'SSS':
+        millisecond = Number(value);
+        usedTimeToken = true;
+        break;
+      case 'Q':
+        quarter = Number(value);
+        usedDateToken = true;
+        break;
+      case 'ww':
+      case 'WW':
+      case 'w':
+      case 'W':
+        parsedWeek = Number(value);
+        usedDateToken = true;
+        break;
+      case 'Wo':
+      case 'wo':
+        parsedWeek = parseWeekOrdinal(value) ?? undefined;
+        usedDateToken = true;
+        break;
+      case 'A':
+      case 'a':
+        meridiem = value;
+        usedTimeToken = true;
+        break;
+      default:
+        break;
+    }
+  });
+
+  if (
+    [month, day, hour, minute, second, millisecond, quarter, parsedWeek, parsedWeekYear].some(
+      (value) => Number.isNaN(value),
+    )
+  ) {
+    return null;
+  }
+
+  const now = generateConfig.getNow();
+  let result: TemporalDateTime;
+
+  try {
+    if (parsedWeek !== undefined && (parsedWeekYear !== undefined || year !== undefined)) {
+      result = parseDateByWeek(locale, parsedWeekYear ?? year!, parsedWeek);
+    } else if (
+      year !== undefined ||
+      month !== undefined ||
+      day !== undefined ||
+      quarter !== undefined
+    ) {
+      const parsedYear = year ?? now.year;
+      const parsedMonth = month ?? (quarter ? (quarter - 1) * 3 + 1 : 1);
+      const parsedDay = day ?? 1;
+      result = createDateTime(parsedYear, parsedMonth, parsedDay);
+    } else if (usedTimeToken) {
+      result = createDateTime(now.year, now.month, now.day);
+    } else {
+      return null;
+    }
+
+    if (
+      hour !== undefined ||
+      minute !== undefined ||
+      second !== undefined ||
+      millisecond !== undefined
+    ) {
+      const upperMeridiem = meridiem?.toUpperCase();
+      let parsedHour = hour ?? 0;
+
+      if (upperMeridiem === 'PM' && parsedHour < 12) {
+        parsedHour += 12;
+      } else if (upperMeridiem === 'AM' && parsedHour === 12) {
+        parsedHour = 0;
+      }
+
+      result = result.with(
+        {
+          hour: parsedHour,
+          minute: minute ?? 0,
+          second: second ?? 0,
+          millisecond: millisecond ?? 0,
+        },
+        { overflow: 'constrain' },
+      );
+    } else if (usedDateToken) {
+      result = result.with(
+        {
+          hour: 0,
+          minute: 0,
+          second: 0,
+          millisecond: 0,
+        },
+        { overflow: 'constrain' },
+      );
+    }
+  } catch {
+    return null;
+  }
+
+  return generateConfig.isValidate(result) ? result : null;
+};
+
+const generateConfig: GenerateConfig<TemporalDateTime> = {
+  getNow: () => getTemporal().Now.plainDateTimeISO(),
+  getFixedDate: (value) => {
+    const matched = value.match(/^(\d{4})-(\d{1,2})-(\d{2})$/);
+
+    if (!matched) {
+      throw new Error(`Invalid fixed date value: ${value}`);
+    }
+
+    return createDateTime(Number(matched[1]), Number(matched[2]), Number(matched[3]));
+  },
+  getEndDate: (date) => date.with({ day: date.daysInMonth }, { overflow: 'constrain' }),
+  getWeekDay: (date) => getWeekDayIndex(date),
+  getYear: (date) => date.year,
+  getMonth: (date) => date.month - 1,
+  getDate: (date) => date.day,
+  getHour: (date) => date.hour,
+  getMinute: (date) => date.minute,
+  getSecond: (date) => date.second,
+  getMillisecond: (date) => date.millisecond,
+
+  addYear: (date, diff) => date.add({ years: diff }),
+  addMonth: (date, diff) => date.add({ months: diff }),
+  addDate: (date, diff) => date.add({ days: diff }),
+  setYear: (date, year) => date.with({ year }, { overflow: 'constrain' }),
+  setMonth: (date, month) => date.with({ month: month + 1 }, { overflow: 'constrain' }),
+  setDate: (date, day) => date.with({ day }, { overflow: 'constrain' }),
+  setHour: (date, hour) => date.with({ hour }, { overflow: 'constrain' }),
+  setMinute: (date, minute) => date.with({ minute }, { overflow: 'constrain' }),
+  setSecond: (date, second) => date.with({ second }, { overflow: 'constrain' }),
+  setMillisecond: (date, millisecond) => date.with({ millisecond }, { overflow: 'constrain' }),
+
+  isAfter: (date1, date2) => getTemporal().PlainDateTime.compare(date1, date2) > 0,
+  isValidate: (date) => {
+    if (!isTemporalDateTime(date)) {
+      return false;
+    }
+
+    try {
+      getTemporal().PlainDateTime.from(date);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  locale: {
+    getWeekFirstDay: (locale) => getWeekInfo(locale).firstDay,
+    getWeekFirstDate: (locale, date) => getWeekStart(date, getWeekInfo(locale).firstDay),
+    getWeek: (locale, date) => getWeekInfoForDate(locale, date).week,
+    getShortWeekDays,
+    getShortMonths: (locale) => getLocaleMonthNames(locale, 'short'),
+    format: (locale, date, format) => {
+      if (!date || !generateConfig.isValidate(date)) {
+        return null;
+      }
+
+      return parseFormatParts(format)
+        .map((part) =>
+          part.type === 'literal' ? part.value : formatToken(locale, date, part.value),
+        )
+        .join('');
+    },
+    parse: (locale, text, formats) => {
+      for (let index = 0; index < formats.length; index += 1) {
+        const parsed = parseFromFormat(locale, text, formats[index]);
+
+        if (parsed) {
+          return parsed;
+        }
+      }
+
+      return null;
+    },
+  },
+};
+
+export default generateConfig;

--- a/src/generate/temporal.ts
+++ b/src/generate/temporal.ts
@@ -47,6 +47,8 @@ type LocaleWeekInfoSource = {
   minimalDays: number;
 };
 
+type OverflowMode = 'constrain' | 'reject';
+
 const ISO_WEEK_INFO: LocaleWeekInfo = {
   firstDay: 1,
   minimalDays: 4,
@@ -62,8 +64,29 @@ const weekDayTruncateLengthMap: Record<string, number> = {
   'en-GB': 2,
 };
 
-const TEMPORAL_MISSING_ERROR =
+export const TEMPORAL_MISSING_ERROR =
   'Temporal API is not available. Please use a runtime with native Temporal support or attach @js-temporal/polyfill to globalThis.Temporal before using @rc-component/picker/generate/temporal.';
+
+const localeWeekInfoFallbackMap: Record<string, LocaleWeekInfo> = {
+  ar: { firstDay: 6, minimalDays: 1 },
+  'ar-EG': { firstDay: 0, minimalDays: 1 },
+  'ar-MA': { firstDay: 1, minimalDays: 1 },
+  en: { firstDay: 0, minimalDays: 1 },
+  'en-US': { firstDay: 0, minimalDays: 1 },
+  fr: { firstDay: 1, minimalDays: 4 },
+  'fr-FR': { firstDay: 1, minimalDays: 4 },
+  it: { firstDay: 1, minimalDays: 4 },
+  'it-IT': { firstDay: 1, minimalDays: 4 },
+  ko: { firstDay: 0, minimalDays: 1 },
+  'ko-KR': { firstDay: 0, minimalDays: 1 },
+  zh: { firstDay: 1, minimalDays: 4 },
+  'zh-CN': { firstDay: 1, minimalDays: 4 },
+};
+
+const localeMonthNamesCache = new Map<string, string[]>();
+const localeWeekDaysCache = new Map<string, string[]>();
+const localeShortWeekDaysCache = new Map<string, string[]>();
+const localeDayPeriodsCache = new Map<string, { am: string; pm: string }>();
 
 const padStart = (value: number, length = 2) => String(value).padStart(length, '0');
 
@@ -126,6 +149,7 @@ const createDateTime = (
   minute = 0,
   second = 0,
   millisecond = 0,
+  overflow: OverflowMode = 'constrain',
 ) =>
   getTemporal().PlainDateTime.from(
     {
@@ -137,7 +161,7 @@ const createDateTime = (
       second,
       millisecond,
     },
-    { overflow: 'constrain' },
+    { overflow },
   );
 
 const isTemporalDateTime = (value: unknown): value is TemporalDateTime => {
@@ -161,6 +185,7 @@ const isTemporalDateTime = (value: unknown): value is TemporalDateTime => {
 
 const getWeekInfo = (locale: string): LocaleWeekInfo => {
   const normalized = normalizeLocale(locale);
+  const language = getLocaleLanguage(locale);
 
   if (typeof Intl?.Locale === 'function') {
     try {
@@ -182,37 +207,68 @@ const getWeekInfo = (locale: string): LocaleWeekInfo => {
     }
   }
 
-  if (normalized === 'en-US') {
-    return {
-      firstDay: 0,
-      minimalDays: 1,
-    };
+  if (localeWeekInfoFallbackMap[normalized]) {
+    return localeWeekInfoFallbackMap[normalized];
   }
 
-  return {
-    firstDay: 1,
-    minimalDays: 4,
-  };
+  if (localeWeekInfoFallbackMap[language]) {
+    return localeWeekInfoFallbackMap[language];
+  }
+
+  return ISO_WEEK_INFO;
 };
 
-const getLocaleMonthNames = (locale: string, width: 'short' | 'long') =>
-  Array.from({ length: 12 }, (_, index) =>
-    new Intl.DateTimeFormat(normalizeLocale(locale), {
-      month: width,
-      timeZone: 'UTC',
-    }).format(new Date(Date.UTC(2020, index, 1))),
+const getLocaleMonthNames = (locale: string, width: 'short' | 'long') => {
+  const normalized = normalizeLocale(locale);
+  const cacheKey = `${normalized}:${width}`;
+  const cached = localeMonthNamesCache.get(cacheKey);
+
+  if (cached) {
+    return cached;
+  }
+
+  const formatter = new Intl.DateTimeFormat(normalized, {
+    month: width,
+    timeZone: 'UTC',
+  });
+  const monthNames = Array.from({ length: 12 }, (_, index) =>
+    formatter.format(new Date(Date.UTC(2020, index, 1))),
   );
 
-const getLocaleWeekDays = (locale: string, width: 'long' | 'short') =>
-  Array.from({ length: 7 }, (_, index) =>
-    new Intl.DateTimeFormat(normalizeLocale(locale), {
-      weekday: width,
-      timeZone: 'UTC',
-    }).format(new Date(Date.UTC(2024, 0, 7 + index))),
+  localeMonthNamesCache.set(cacheKey, monthNames);
+  return monthNames;
+};
+
+const getLocaleWeekDays = (locale: string, width: 'long' | 'short') => {
+  const normalized = normalizeLocale(locale);
+  const cacheKey = `${normalized}:${width}`;
+  const cached = localeWeekDaysCache.get(cacheKey);
+
+  if (cached) {
+    return cached;
+  }
+
+  const formatter = new Intl.DateTimeFormat(normalized, {
+    weekday: width,
+    timeZone: 'UTC',
+  });
+  const weekDays = Array.from({ length: 7 }, (_, index) =>
+    formatter.format(new Date(Date.UTC(2024, 0, 7 + index))),
   );
+
+  localeWeekDaysCache.set(cacheKey, weekDays);
+  return weekDays;
+};
 
 const getLocaleDayPeriods = (locale: string) => {
-  const formatter = new Intl.DateTimeFormat(normalizeLocale(locale), {
+  const normalized = normalizeLocale(locale);
+  const cached = localeDayPeriodsCache.get(normalized);
+
+  if (cached) {
+    return cached;
+  }
+
+  const formatter = new Intl.DateTimeFormat(normalized, {
     hour: 'numeric',
     hour12: true,
     timeZone: 'UTC',
@@ -223,28 +279,37 @@ const getLocaleDayPeriods = (locale: string) => {
     return parts.find((part) => part.type === 'dayPeriod')?.value;
   };
 
-  const am = getPeriod(1) || 'AM';
-  const pm = getPeriod(13) || 'PM';
-
-  return {
-    am,
-    pm,
+  const dayPeriods = {
+    am: getPeriod(1) || 'AM',
+    pm: getPeriod(13) || 'PM',
   };
+
+  localeDayPeriodsCache.set(normalized, dayPeriods);
+  return dayPeriods;
 };
 
 const getShortWeekDays = (locale: string) => {
   const normalized = normalizeLocale(locale);
+  const cached = localeShortWeekDaysCache.get(normalized);
+
+  if (cached) {
+    return cached;
+  }
+
   const format = weekDayFormatLocaleMap[normalized] || 'short';
   const sliceLength = weekDayTruncateLengthMap[normalized];
-
-  return Array.from({ length: 7 }, (_, index) => {
-    const weekday = new Intl.DateTimeFormat(normalized, {
-      weekday: format,
-      timeZone: 'UTC',
-    }).format(new Date(Date.UTC(2024, 0, 7 + index)));
+  const formatter = new Intl.DateTimeFormat(normalized, {
+    weekday: format,
+    timeZone: 'UTC',
+  });
+  const shortWeekDays = Array.from({ length: 7 }, (_, index) => {
+    const weekday = formatter.format(new Date(Date.UTC(2024, 0, 7 + index)));
 
     return sliceLength ? weekday.slice(0, sliceLength) : weekday;
   });
+
+  localeShortWeekDaysCache.set(normalized, shortWeekDays);
+  return shortWeekDays;
 };
 
 const getDayOfWeekName = (
@@ -411,7 +476,6 @@ const parseFormatParts = (format: string): FormatPart[] => {
 };
 
 const formatToken = (locale: string, date: TemporalDateTime, token: Token) => {
-  const dayPeriods = getLocaleDayPeriods(locale);
   let localeWeekData: ParsedWeek | undefined;
   let isoWeekData: ParsedWeek | undefined;
 
@@ -486,10 +550,14 @@ const formatToken = (locale: string, date: TemporalDateTime, token: Token) => {
       return getWeekOrdinal(locale, getWeekData('iso').week);
     case 'wo':
       return getWeekOrdinal(locale, getWeekData('locale').week);
-    case 'A':
+    case 'A': {
+      const dayPeriods = getLocaleDayPeriods(locale);
       return date.hour < 12 ? dayPeriods.am : dayPeriods.pm;
-    case 'a':
+    }
+    case 'a': {
+      const dayPeriods = getLocaleDayPeriods(locale);
       return (date.hour < 12 ? dayPeriods.am : dayPeriods.pm).toLowerCase();
+    }
     default:
       return token;
   }
@@ -547,12 +615,18 @@ const getDayPeriodMatcher = (locale: string) => {
 };
 
 const buildParseMatcher = (locale: string, parts: FormatPart[]) => {
-  const monthShort = getMonthNameMatcher(locale, 'short');
-  const monthLong = getMonthNameMatcher(locale, 'long');
-  const weekDayLong = getWeekDayMatcher(locale, 'long');
-  const weekDayShort = getWeekDayMatcher(locale, 'short');
-  const weekDayMin = getWeekDayMatcher(locale, 'min');
-  const meridiemMatcher = getDayPeriodMatcher(locale);
+  const hasToken = (tokens: Token[]) =>
+    parts.some((part) => part.type === 'token' && tokens.includes(part.value));
+  const emptyMonthMatcher = {
+    matcher: '',
+    monthNames: [] as string[],
+  };
+  const monthShort = hasToken(['MMM']) ? getMonthNameMatcher(locale, 'short') : emptyMonthMatcher;
+  const monthLong = hasToken(['MMMM']) ? getMonthNameMatcher(locale, 'long') : emptyMonthMatcher;
+  const weekDayLong = hasToken(['dddd']) ? getWeekDayMatcher(locale, 'long') : null;
+  const weekDayShort = hasToken(['ddd']) ? getWeekDayMatcher(locale, 'short') : null;
+  const weekDayMin = hasToken(['dd']) ? getWeekDayMatcher(locale, 'min') : null;
+  const meridiemMatcher = hasToken(['A', 'a']) ? getDayPeriodMatcher(locale) : '';
 
   const regexParts = parts.map((part, index) => {
     if (part.type === 'literal') {
@@ -569,9 +643,9 @@ const buildParseMatcher = (locale: string, parts: FormatPart[]) => {
       case 'YY':
         return `(?<${key}>\\d{2})`;
       case 'dddd':
-        return `(?<${key}>${weekDayLong.matcher})`;
+        return `(?<${key}>${weekDayLong!.matcher})`;
       case 'ddd':
-        return `(?<${key}>${weekDayShort.matcher})`;
+        return `(?<${key}>${weekDayShort!.matcher})`;
       case 'MMMM':
         return `(?<${key}>${monthLong.matcher})`;
       case 'MMM':
@@ -598,7 +672,7 @@ const buildParseMatcher = (locale: string, parts: FormatPart[]) => {
       case 'SSS':
         return `(?<${key}>\\d{1,3})`;
       case 'dd':
-        return `(?<${key}>${weekDayMin.matcher})`;
+        return `(?<${key}>${weekDayMin!.matcher})`;
       case 'Wo':
       case 'Do':
       case 'wo':
@@ -655,6 +729,9 @@ const isMeridiemValue = (value: string, candidate: string) =>
   value.localeCompare(candidate, undefined, { sensitivity: 'accent' }) === 0 ||
   value.localeCompare(candidate, undefined, { sensitivity: 'base' }) === 0;
 
+const isWeekDayValue = (value: string, candidate: string) =>
+  value.localeCompare(candidate, undefined, { sensitivity: 'base' }) === 0;
+
 const isPmMeridiem = (locale: string, meridiem: string) => {
   const periods = getLocaleDayPeriods(locale);
 
@@ -691,7 +768,9 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
   let parsedWeekYear: number | undefined;
   let parsedWeekType: 'locale' | 'iso' | undefined;
   let parsedWeekYearType: 'locale' | 'iso' | undefined;
+  let parsedWeekDays: Array<{ token: 'dddd' | 'ddd' | 'dd'; value: string }> = [];
   let usedTimeToken = false;
+  let usedTwelveHourToken = false;
   let usedDateToken = false;
 
   parts.forEach((part, index) => {
@@ -737,6 +816,15 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
         month = month === -1 ? Number.NaN : month + 1;
         usedDateToken = true;
         break;
+      case 'dddd':
+      case 'ddd':
+      case 'dd':
+        parsedWeekDays.push({
+          token: part.value,
+          value,
+        });
+        usedDateToken = true;
+        break;
       case 'MM':
       case 'M':
         month = Number(value);
@@ -758,8 +846,9 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
         break;
       case 'hh':
       case 'h':
-        hour = Number(value) % 12;
+        hour = Number(value);
         usedTimeToken = true;
+        usedTwelveHourToken = true;
         break;
       case 'mm':
       case 'm':
@@ -819,6 +908,10 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
     return null;
   }
 
+  if (usedTwelveHourToken && hour !== undefined && (hour < 1 || hour > 12)) {
+    return null;
+  }
+
   if (
     parsedWeek !== undefined &&
     parsedWeekType &&
@@ -828,24 +921,32 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
     return null;
   }
 
-  const now = generateConfig.getNow();
+  let now: TemporalDateTime | undefined;
+  const getNow = () => {
+    now ||= generateConfig.getNow();
+    return now;
+  };
   let result: TemporalDateTime;
 
   try {
     if (parsedWeek !== undefined && (parsedWeekYear !== undefined || year !== undefined)) {
       result = parseDateByWeek(locale, parsedWeekYear ?? year!, parsedWeek, parsedWeekType);
+      if (!result) {
+        return null;
+      }
     } else if (
       year !== undefined ||
       month !== undefined ||
       day !== undefined ||
       quarter !== undefined
     ) {
-      const parsedYear = year ?? now.year;
+      const parsedYear = year ?? getNow().year;
       const parsedMonth = month ?? (quarter ? (quarter - 1) * 3 + 1 : 1);
       const parsedDay = day ?? 1;
-      result = createDateTime(parsedYear, parsedMonth, parsedDay);
+      result = createDateTime(parsedYear, parsedMonth, parsedDay, 0, 0, 0, 0, 'reject');
     } else if (usedTimeToken) {
-      result = createDateTime(now.year, now.month, now.day);
+      const current = getNow();
+      result = createDateTime(current.year, current.month, current.day, 0, 0, 0, 0, 'reject');
     } else {
       return null;
     }
@@ -858,10 +959,14 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
     ) {
       let parsedHour = hour ?? 0;
 
-      if (meridiem && isPmMeridiem(locale, meridiem) && parsedHour < 12) {
-        parsedHour += 12;
-      } else if (meridiem && isAmMeridiem(locale, meridiem) && parsedHour === 12) {
-        parsedHour = 0;
+      if (usedTwelveHourToken) {
+        if (meridiem && isPmMeridiem(locale, meridiem)) {
+          if (parsedHour < 12) {
+            parsedHour += 12;
+          }
+        } else if (meridiem && isAmMeridiem(locale, meridiem) && parsedHour === 12) {
+          parsedHour = 0;
+        }
       }
 
       result = result.with(
@@ -871,7 +976,7 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
           second: second ?? 0,
           millisecond: millisecond ?? 0,
         },
-        { overflow: 'constrain' },
+        { overflow: 'reject' },
       );
     } else if (usedDateToken) {
       result = result.with(
@@ -888,6 +993,14 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
     return null;
   }
 
+  if (
+    parsedWeekDays.some(
+      ({ token, value }) => !isWeekDayValue(value, getDayOfWeekName(locale, result, token)),
+    )
+  ) {
+    return null;
+  }
+
   return generateConfig.isValidate(result) ? result : null;
 };
 
@@ -900,7 +1013,16 @@ const generateConfig: GenerateConfig<TemporalDateTime> = {
       throw new Error(`Invalid fixed date value: ${value}`);
     }
 
-    return createDateTime(Number(matched[1]), Number(matched[2]), Number(matched[3]));
+    return createDateTime(
+      Number(matched[1]),
+      Number(matched[2]),
+      Number(matched[3]),
+      0,
+      0,
+      0,
+      0,
+      'reject',
+    );
   },
   getEndDate: (date) => date.with({ day: date.daysInMonth }, { overflow: 'constrain' }),
   getWeekDay: (date) => getWeekDayIndex(date),

--- a/src/generate/temporal.ts
+++ b/src/generate/temporal.ts
@@ -768,7 +768,7 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
   let parsedWeekYear: number | undefined;
   let parsedWeekType: 'locale' | 'iso' | undefined;
   let parsedWeekYearType: 'locale' | 'iso' | undefined;
-  let parsedWeekDays: Array<{ token: 'dddd' | 'ddd' | 'dd'; value: string }> = [];
+  const parsedWeekDays: Array<{ token: 'dddd' | 'ddd' | 'dd'; value: string }> = [];
   let usedTimeToken = false;
   let usedTwelveHourToken = false;
   let usedDateToken = false;
@@ -941,7 +941,7 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
       quarter !== undefined
     ) {
       const parsedYear = year ?? getNow().year;
-      const parsedMonth = month ?? (quarter ? (quarter - 1) * 3 + 1 : 1);
+      const parsedMonth = month ?? (quarter !== undefined ? (quarter - 1) * 3 + 1 : 1);
       const parsedDay = day ?? 1;
       result = createDateTime(parsedYear, parsedMonth, parsedDay, 0, 0, 0, 0, 'reject');
     } else if (usedTimeToken) {
@@ -1067,7 +1067,7 @@ const generateConfig: GenerateConfig<TemporalDateTime> = {
     getShortMonths: (locale) => getLocaleMonthNames(locale, 'short'),
     format: (locale, date, format) => {
       if (!date || !generateConfig.isValidate(date)) {
-        return null;
+        return '';
       }
 
       return parseFormatParts(format)

--- a/src/generate/temporal.ts
+++ b/src/generate/temporal.ts
@@ -47,6 +47,11 @@ type LocaleWeekInfoSource = {
   minimalDays: number;
 };
 
+const ISO_WEEK_INFO: LocaleWeekInfo = {
+  firstDay: 1,
+  minimalDays: 4,
+};
+
 const weekDayFormatLocaleMap: Record<string, 'narrow' | 'short'> = {
   'zh-CN': 'narrow',
   'zh-TW': 'narrow',
@@ -282,8 +287,15 @@ const getWeekYearStart = (year: number, weekInfo: LocaleWeekInfo) => {
   return firstWeekDays >= weekInfo.minimalDays ? weekStart : weekStart.add({ days: 7 });
 };
 
-const getWeekInfoForDate = (locale: string, date: TemporalDateTime): ParsedWeek => {
-  const weekInfo = getWeekInfo(locale);
+const getTokenWeekInfo = (locale: string, weekType: 'locale' | 'iso') =>
+  weekType === 'iso' ? ISO_WEEK_INFO : getWeekInfo(locale);
+
+const getWeekInfoForDate = (
+  locale: string,
+  date: TemporalDateTime,
+  weekType: 'locale' | 'iso' = 'locale',
+): ParsedWeek => {
+  const weekInfo = getTokenWeekInfo(locale, weekType);
   const currentWeekStart = getWeekStart(date, weekInfo.firstDay);
 
   let weekYear = date.year;
@@ -399,8 +411,19 @@ const parseFormatParts = (format: string): FormatPart[] => {
 };
 
 const formatToken = (locale: string, date: TemporalDateTime, token: Token) => {
-  const weekData = getWeekInfoForDate(locale, date);
   const dayPeriods = getLocaleDayPeriods(locale);
+  let localeWeekData: ParsedWeek | undefined;
+  let isoWeekData: ParsedWeek | undefined;
+
+  const getWeekData = (weekType: 'locale' | 'iso') => {
+    if (weekType === 'iso') {
+      isoWeekData ||= getWeekInfoForDate(locale, date, 'iso');
+      return isoWeekData;
+    }
+
+    localeWeekData ||= getWeekInfoForDate(locale, date, 'locale');
+    return localeWeekData;
+  };
 
   switch (token) {
     case 'YYYY':
@@ -408,8 +431,9 @@ const formatToken = (locale: string, date: TemporalDateTime, token: Token) => {
     case 'YY':
       return padStart(date.year % 100, 2);
     case 'GGGG':
+      return padStart(getWeekData('iso').weekYear, 4);
     case 'gggg':
-      return padStart(weekData.weekYear, 4);
+      return padStart(getWeekData('locale').weekYear, 4);
     case 'dddd':
     case 'ddd':
     case 'dd':
@@ -450,15 +474,18 @@ const formatToken = (locale: string, date: TemporalDateTime, token: Token) => {
       return padStart(date.millisecond, 3);
     case 'Q':
       return String(getQuarter(date));
-    case 'ww':
     case 'WW':
-      return padStart(weekData.week);
-    case 'w':
+      return padStart(getWeekData('iso').week);
+    case 'ww':
+      return padStart(getWeekData('locale').week);
     case 'W':
-      return String(weekData.week);
+      return String(getWeekData('iso').week);
+    case 'w':
+      return String(getWeekData('locale').week);
     case 'Wo':
+      return getWeekOrdinal(locale, getWeekData('iso').week);
     case 'wo':
-      return getWeekOrdinal(locale, weekData.week);
+      return getWeekOrdinal(locale, getWeekData('locale').week);
     case 'A':
       return date.hour < 12 ? dayPeriods.am : dayPeriods.pm;
     case 'a':
@@ -596,15 +623,20 @@ const parseWeekOrdinal = (value: string) => {
   return matched ? Number(matched[0]) : null;
 };
 
-const parseDateByWeek = (locale: string, weekYear: number, week: number) => {
+const parseDateByWeek = (
+  locale: string,
+  weekYear: number,
+  week: number,
+  weekType: 'locale' | 'iso' = 'locale',
+) => {
   if (week < 1 || week > 53) {
     return null;
   }
 
-  const weekInfo = getWeekInfo(locale);
+  const weekInfo = getTokenWeekInfo(locale, weekType);
   const weekYearStart = getWeekYearStart(weekYear, weekInfo);
   const result = weekYearStart.add({ days: (week - 1) * 7 });
-  const parsedWeekInfo = getWeekInfoForDate(locale, result);
+  const parsedWeekInfo = getWeekInfoForDate(locale, result, weekType);
 
   if (parsedWeekInfo.weekYear !== weekYear || parsedWeekInfo.week !== week) {
     return null;
@@ -760,6 +792,10 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
         usedDateToken = true;
         break;
       case 'Wo':
+        parsedWeek = parseWeekOrdinal(value) ?? undefined;
+        parsedWeekType = 'iso';
+        usedDateToken = true;
+        break;
       case 'wo':
         parsedWeek = parseWeekOrdinal(value) ?? undefined;
         parsedWeekType = 'locale';
@@ -797,7 +833,7 @@ const parseFromFormat = (locale: string, text: string, format: string): Temporal
 
   try {
     if (parsedWeek !== undefined && (parsedWeekYear !== undefined || year !== undefined)) {
-      result = parseDateByWeek(locale, parsedWeekYear ?? year!, parsedWeek);
+      result = parseDateByWeek(locale, parsedWeekYear ?? year!, parsedWeek, parsedWeekType);
     } else if (
       year !== undefined ||
       month !== undefined ||

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -341,6 +341,7 @@ describe('Generate:dayjs', () => {
 
 describe('Generate:temporal', () => {
   const originalTemporal = globalThis.Temporal;
+  const originalIntlLocale = Intl.Locale;
 
   beforeAll(() => {
     globalThis.Temporal = TemporalPolyfill as typeof globalThis.Temporal;
@@ -352,6 +353,12 @@ describe('Generate:temporal', () => {
     } else {
       delete (globalThis as typeof globalThis & { Temporal?: typeof globalThis.Temporal }).Temporal;
     }
+
+    Object.defineProperty(Intl, 'Locale', {
+      configurable: true,
+      value: originalIntlLocale,
+      writable: true,
+    });
   });
 
   it('formats weekday and ordinal day tokens', () => {
@@ -427,6 +434,109 @@ describe('Generate:temporal', () => {
     expect(
       temporalGenerateConfig.locale.parse('en_US', 'NotAMonth 10 2020', ['MMMM DD YYYY']),
     ).toBeNull();
+  });
+
+  it('formats additional public tokens', () => {
+    const date = TemporalPolyfill.PlainDateTime.from('2003-03-03T13:04:05.006');
+
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'YY')).toEqual('03');
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'Do')).toEqual('3rd');
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'MMM')).toEqual('Mar');
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'MMMM')).toEqual('March');
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'M')).toEqual('3');
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'H')).toEqual('13');
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'h')).toEqual('1');
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'm')).toEqual('4');
+    expect(temporalGenerateConfig.locale.format('en_US', date, 's')).toEqual('5');
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'W')).toEqual('10');
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'w')).toEqual('10');
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'a')).toEqual('pm');
+    expect(temporalGenerateConfig.locale.format('fr_FR', date, 'Do')).toEqual('3');
+  });
+
+  it('parses additional public tokens and meridiem boundaries', () => {
+    const weekdayDate = temporalGenerateConfig.locale.parse('en_US', 'Fri Fr 2011-11-11', [
+      'ddd dd YYYY-MM-DD',
+    ]);
+    const quarterDate = temporalGenerateConfig.locale.parse('en_US', '2020-2-3rd 5', [
+      'YYYY-Q-Do s',
+    ]);
+    const millisecondDate = temporalGenerateConfig.locale.parse('en_US', '2020-01-02 003', [
+      'YYYY-MM-DD SSS',
+    ]);
+    const midnightDate = temporalGenerateConfig.locale.parse('en_US', '12:05 AM', ['H:mm A']);
+
+    expect(weekdayDate).toBeTruthy();
+    expect(temporalGenerateConfig.locale.format('en_US', weekdayDate!, 'YYYY-MM-DD')).toEqual(
+      '2011-11-11',
+    );
+
+    expect(quarterDate).toBeTruthy();
+    expect(
+      temporalGenerateConfig.locale.format('en_US', quarterDate!, 'YYYY-MM-DD HH:mm:ss'),
+    ).toEqual('2020-04-03 00:00:05');
+
+    expect(millisecondDate).toBeTruthy();
+    expect(
+      temporalGenerateConfig.locale.format('en_US', millisecondDate!, 'YYYY-MM-DD HH:mm:ss.SSS'),
+    ).toEqual('2020-01-02 00:00:00.003');
+
+    expect(midnightDate).toBeTruthy();
+    expect(
+      temporalGenerateConfig.locale.format('en_US', midnightDate!, 'YYYY-MM-DD HH:mm'),
+    ).toEqual(`${temporalGenerateConfig.getNow().toPlainDate().toString()} 00:05`);
+  });
+
+  it('falls back when Intl.Locale metadata is unavailable or invalid', () => {
+    Object.defineProperty(Intl, 'Locale', {
+      configurable: true,
+      value: class BrokenLocale {
+        constructor() {
+          throw new RangeError('invalid locale');
+        }
+      },
+      writable: true,
+    });
+
+    expect(temporalGenerateConfig.locale.getWeekFirstDay('en_US')).toEqual(0);
+    expect(temporalGenerateConfig.locale.getWeekFirstDay('fr_FR')).toEqual(1);
+  });
+
+  it('rejects invalid week values and mismatched week years', () => {
+    expect(temporalGenerateConfig.locale.parse('en_US', '2020-54', ['GGGG-WW'])).toBeNull();
+    expect(temporalGenerateConfig.locale.parse('en_US', '2021-53', ['GGGG-WW'])).toBeNull();
+    expect(temporalGenerateConfig.locale.parse('en_US', 'Friday', ['dddd'])).toBeNull();
+  });
+
+  it('guards invalid fixed dates, missing Temporal, and invalid values', () => {
+    expect(() => temporalGenerateConfig.getFixedDate('2020/01/05')).toThrow(
+      'Invalid fixed date value: 2020/01/05',
+    );
+
+    expect(temporalGenerateConfig.isValidate(null as any)).toBe(false);
+    expect(temporalGenerateConfig.isValidate({} as any)).toBe(false);
+    expect(
+      temporalGenerateConfig.isValidate({
+        year: Number.NaN,
+        month: 1,
+        day: 1,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+        with: () => null,
+        add: () => null,
+        toPlainDate: () => null,
+      } as any),
+    ).toBe(false);
+    expect(temporalGenerateConfig.locale.format('en_US', null as any, 'YYYY-MM-DD')).toBeNull();
+
+    delete (globalThis as typeof globalThis & { Temporal?: typeof globalThis.Temporal }).Temporal;
+    expect(() => temporalGenerateConfig.getNow()).toThrow(
+      'Temporal API is not available. Please use a runtime with native Temporal support or attach @js-temporal/polyfill to globalThis.Temporal before using @rc-component/picker/generate/temporal.',
+    );
+
+    globalThis.Temporal = TemporalPolyfill as typeof globalThis.Temporal;
   });
 });
 

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -12,12 +12,19 @@ import 'dayjs/locale/ko';
 import type { GenerateConfig } from '../src/generate';
 
 describe('Picker.Generate', () => {
+  const originalTemporal = globalThis.Temporal;
+
   beforeAll(() => {
     globalThis.Temporal = TemporalPolyfill as typeof globalThis.Temporal;
     MockDate.set(getMoment('1990-09-03 01:02:03.005').toDate());
   });
 
   afterAll(() => {
+    if (originalTemporal) {
+      globalThis.Temporal = originalTemporal;
+    } else {
+      delete (globalThis as typeof globalThis & { Temporal?: typeof globalThis.Temporal }).Temporal;
+    }
     MockDate.reset();
   });
 
@@ -121,14 +128,18 @@ describe('Picker.Generate', () => {
                   'gggg-wo',
                 ),
               ).toEqual('2019-45周');
-            } else {
+            }
+
+            if (name === 'temporal') {
+              expect(generateConfig.locale.parse('en_US', '2019-1st', ['GGGG-wo'])).toEqual(null);
+            } else if (['date-fns', 'luxon'].includes(name)) {
               expect(
                 generateConfig.locale.format(
                   'en_US',
                   generateConfig.locale.parse('en_US', '2019-1st', ['GGGG-wo'])!,
                   'GGGG-wo',
                 ),
-              ).toEqual(name === 'temporal' ? '2019-1st' : null);
+              ).toEqual(null);
             }
           });
         });
@@ -181,11 +192,13 @@ describe('Picker.Generate', () => {
 
       it('Parse format Wo', () => {
         if (!['date-fns', 'luxon'].includes(name)) {
-          const enDate = generateConfig.locale.parse('en_US', '2012-51st', ['YYYY-Wo'])!;
-          expect(generateConfig.locale.format('en_US', enDate, 'Wo')).toEqual('51st');
+          const enDate = generateConfig.locale.parse('en_US', '2012-51st', ['YYYY-Wo']);
+          expect(enDate).toBeTruthy();
+          expect(generateConfig.locale.format('en_US', enDate!, 'Wo')).toEqual('51st');
 
-          const zhDate = generateConfig.locale.parse('zh_CN', '2012-1周', ['YYYY-Wo'])!;
-          expect(generateConfig.locale.format('zh_CN', zhDate, 'Wo')).toEqual('1周');
+          const zhDate = generateConfig.locale.parse('zh_CN', '2012-1周', ['YYYY-Wo']);
+          expect(zhDate).toBeTruthy();
+          expect(generateConfig.locale.format('zh_CN', zhDate!, 'Wo')).toEqual('1周');
         }
       });
 
@@ -323,6 +336,78 @@ describe('Generate:dayjs', () => {
     expect(dayjsGenerateConfig.getYear(mockExternalDayjs as any)).toEqual(2023);
     expect(dayjsGenerateConfig.getMonth(mockExternalDayjs as any)).toEqual(5);
     expect(dayjsGenerateConfig.getDate(mockExternalDayjs as any)).toEqual(20);
+  });
+});
+
+describe('Generate:temporal', () => {
+  const originalTemporal = globalThis.Temporal;
+
+  beforeAll(() => {
+    globalThis.Temporal = TemporalPolyfill as typeof globalThis.Temporal;
+  });
+
+  afterAll(() => {
+    if (originalTemporal) {
+      globalThis.Temporal = originalTemporal;
+    } else {
+      delete (globalThis as typeof globalThis & { Temporal?: typeof globalThis.Temporal }).Temporal;
+    }
+  });
+
+  it('formats weekday and ordinal day tokens', () => {
+    const date = temporalGenerateConfig.getFixedDate('2011-11-11');
+
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'dddd')).toEqual('Friday');
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'ddd')).toEqual('Fri');
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'dd')).toEqual('Fr');
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'Do')).toEqual('11th');
+  });
+
+  it('parses locale meridiem and two-digit years', () => {
+    const zhDate = temporalGenerateConfig.locale.parse('zh_CN', '2020-01-01 下午 3:00', [
+      'YYYY-MM-DD A h:mm',
+    ]);
+    expect(zhDate).toBeTruthy();
+    expect(temporalGenerateConfig.getHour(zhDate!)).toEqual(15);
+
+    const year99 = temporalGenerateConfig.locale.parse('en_US', '99-01-02', ['YY-MM-DD']);
+    const year68 = temporalGenerateConfig.locale.parse('en_US', '68-01-02', ['YY-MM-DD']);
+
+    expect(temporalGenerateConfig.locale.format('en_US', year99!, 'YYYY-MM-DD')).toEqual(
+      '1999-01-02',
+    );
+    expect(temporalGenerateConfig.locale.format('en_US', year68!, 'YYYY-MM-DD')).toEqual(
+      '2068-01-02',
+    );
+  });
+
+  it('normalizes locale keys and fixed dates', () => {
+    expect(temporalGenerateConfig.locale.getShortWeekDays!('zh-CN')).toEqual([
+      '日',
+      '一',
+      '二',
+      '三',
+      '四',
+      '五',
+      '六',
+    ]);
+    expect(
+      temporalGenerateConfig.locale.format(
+        'zh-CN',
+        temporalGenerateConfig.getFixedDate('2011-11-11'),
+        'Wo',
+      ),
+    ).toEqual('46周');
+    expect(temporalGenerateConfig.getFixedDate('2020-1-5').toString()).toEqual(
+      '2020-01-05T00:00:00',
+    );
+  });
+
+  it('returns null for invalid localized month names', () => {
+    expect(temporalGenerateConfig.locale.parse('en_US', 'Foo 10 2020', ['MMM DD YYYY'])).toBeNull();
+    expect(
+      temporalGenerateConfig.locale.parse('en_US', 'NotAMonth 10 2020', ['MMMM DD YYYY']),
+    ).toBeNull();
   });
 });
 

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -353,12 +353,6 @@ describe('Generate:temporal', () => {
     } else {
       delete (globalThis as typeof globalThis & { Temporal?: typeof globalThis.Temporal }).Temporal;
     }
-
-    Object.defineProperty(Intl, 'Locale', {
-      configurable: true,
-      value: originalIntlLocale,
-      writable: true,
-    });
   });
 
   it('formats weekday and ordinal day tokens', () => {
@@ -455,6 +449,7 @@ describe('Generate:temporal', () => {
   });
 
   it('parses additional public tokens and meridiem boundaries', () => {
+    const today = temporalGenerateConfig.getNow().toPlainDate().toString();
     const weekdayDate = temporalGenerateConfig.locale.parse('en_US', 'Fri Fr 2011-11-11', [
       'ddd dd YYYY-MM-DD',
     ]);
@@ -464,7 +459,7 @@ describe('Generate:temporal', () => {
     const millisecondDate = temporalGenerateConfig.locale.parse('en_US', '2020-01-02 003', [
       'YYYY-MM-DD SSS',
     ]);
-    const midnightDate = temporalGenerateConfig.locale.parse('en_US', '12:05 AM', ['H:mm A']);
+    const midnightDate = temporalGenerateConfig.locale.parse('en_US', '12:05 AM', ['h:mm A']);
 
     expect(weekdayDate).toBeTruthy();
     expect(temporalGenerateConfig.locale.format('en_US', weekdayDate!, 'YYYY-MM-DD')).toEqual(
@@ -484,22 +479,30 @@ describe('Generate:temporal', () => {
     expect(midnightDate).toBeTruthy();
     expect(
       temporalGenerateConfig.locale.format('en_US', midnightDate!, 'YYYY-MM-DD HH:mm'),
-    ).toEqual(`${temporalGenerateConfig.getNow().toPlainDate().toString()} 00:05`);
+    ).toEqual(`${today} 00:05`);
   });
 
   it('falls back when Intl.Locale metadata is unavailable or invalid', () => {
-    Object.defineProperty(Intl, 'Locale', {
-      configurable: true,
-      value: class BrokenLocale {
-        constructor() {
-          throw new RangeError('invalid locale');
-        }
-      },
-      writable: true,
-    });
+    try {
+      Object.defineProperty(Intl, 'Locale', {
+        configurable: true,
+        value: class BrokenLocale {
+          constructor() {
+            throw new RangeError('invalid locale');
+          }
+        },
+        writable: true,
+      });
 
-    expect(temporalGenerateConfig.locale.getWeekFirstDay('en_US')).toEqual(0);
-    expect(temporalGenerateConfig.locale.getWeekFirstDay('fr_FR')).toEqual(1);
+      expect(temporalGenerateConfig.locale.getWeekFirstDay('en_US')).toEqual(0);
+      expect(temporalGenerateConfig.locale.getWeekFirstDay('fr_FR')).toEqual(1);
+    } finally {
+      Object.defineProperty(Intl, 'Locale', {
+        configurable: true,
+        value: originalIntlLocale,
+        writable: true,
+      });
+    }
   });
 
   it('rejects invalid week values and mismatched week years', () => {
@@ -532,11 +535,13 @@ describe('Generate:temporal', () => {
     expect(temporalGenerateConfig.locale.format('en_US', null as any, 'YYYY-MM-DD')).toBeNull();
 
     delete (globalThis as typeof globalThis & { Temporal?: typeof globalThis.Temporal }).Temporal;
-    expect(() => temporalGenerateConfig.getNow()).toThrow(
-      'Temporal API is not available. Please use a runtime with native Temporal support or attach @js-temporal/polyfill to globalThis.Temporal before using @rc-component/picker/generate/temporal.',
-    );
-
-    globalThis.Temporal = TemporalPolyfill as typeof globalThis.Temporal;
+    try {
+      expect(() => temporalGenerateConfig.getNow()).toThrow(
+        'Temporal API is not available. Please use a runtime with native Temporal support or attach @js-temporal/polyfill to globalThis.Temporal before using @rc-component/picker/generate/temporal.',
+      );
+    } finally {
+      globalThis.Temporal = TemporalPolyfill as typeof globalThis.Temporal;
+    }
   });
 
   it('normalizes defensive branch coverage in coverage mode', () => {

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -514,6 +514,7 @@ describe('Generate:temporal', () => {
   it('rejects invalid dates and times instead of constraining them', () => {
     expect(temporalGenerateConfig.locale.parse('en_US', '2023-02-31', ['YYYY-MM-DD'])).toBeNull();
     expect(temporalGenerateConfig.locale.parse('en_US', '2023-13-01', ['YYYY-MM-DD'])).toBeNull();
+    expect(temporalGenerateConfig.locale.parse('en_US', '2023-0', ['YYYY-Q'])).toBeNull();
     expect(temporalGenerateConfig.locale.parse('en_US', '2023-5', ['YYYY-Q'])).toBeNull();
     expect(temporalGenerateConfig.locale.parse('en_US', '25:99', ['HH:mm'])).toBeNull();
     expect(() => temporalGenerateConfig.getFixedDate('2023-13-40')).toThrow();
@@ -560,7 +561,7 @@ describe('Generate:temporal', () => {
         toPlainDate: () => null,
       } as any),
     ).toBe(false);
-    expect(temporalGenerateConfig.locale.format('en_US', null as any, 'YYYY-MM-DD')).toBeNull();
+    expect(temporalGenerateConfig.locale.format('en_US', null as any, 'YYYY-MM-DD')).toEqual('');
 
     delete (globalThis as typeof globalThis & { Temporal?: typeof globalThis.Temporal }).Temporal;
     try {

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -1,8 +1,10 @@
 import MockDate from 'mockdate';
+import { Temporal as TemporalPolyfill } from '@js-temporal/polyfill';
 import dateFnsGenerateConfig from '../src/generate/dateFns';
 import dayjsGenerateConfig from '../src/generate/dayjs';
 import luxonGenerateConfig from '../src/generate/luxon';
 import momentGenerateConfig from '../src/generate/moment';
+import temporalGenerateConfig from '../src/generate/temporal';
 import { getMoment } from './util/commonUtil';
 
 import 'dayjs/locale/zh-cn';
@@ -11,6 +13,7 @@ import type { GenerateConfig } from '../src/generate';
 
 describe('Picker.Generate', () => {
   beforeAll(() => {
+    globalThis.Temporal = TemporalPolyfill as typeof globalThis.Temporal;
     MockDate.set(getMoment('1990-09-03 01:02:03.005').toDate());
   });
 
@@ -23,6 +26,7 @@ describe('Picker.Generate', () => {
     { name: 'dayjs', generateConfig: dayjsGenerateConfig },
     { name: 'date-fns', generateConfig: dateFnsGenerateConfig },
     { name: 'luxon', generateConfig: luxonGenerateConfig },
+    { name: 'temporal', generateConfig: temporalGenerateConfig },
   ];
 
   list.forEach(({ name, generateConfig }) => {
@@ -124,7 +128,7 @@ describe('Picker.Generate', () => {
                   generateConfig.locale.parse('en_US', '2019-1st', ['GGGG-wo'])!,
                   'GGGG-wo',
                 ),
-              ).toEqual(null);
+              ).toEqual(name === 'temporal' ? '2019-1st' : null);
             }
           });
         });
@@ -177,12 +181,11 @@ describe('Picker.Generate', () => {
 
       it('Parse format Wo', () => {
         if (!['date-fns', 'luxon'].includes(name)) {
-          expect(
-            generateConfig.locale.parse('en_US', '2012-51st', ['YYYY-Wo']).format('Wo'),
-          ).toEqual('51st');
-          expect(
-            generateConfig.locale.parse('zh_CN', '2012-1周', ['YYYY-Wo']).format('Wo'),
-          ).toEqual('1周');
+          const enDate = generateConfig.locale.parse('en_US', '2012-51st', ['YYYY-Wo'])!;
+          expect(generateConfig.locale.format('en_US', enDate, 'Wo')).toEqual('51st');
+
+          const zhDate = generateConfig.locale.parse('zh_CN', '2012-1周', ['YYYY-Wo'])!;
+          expect(generateConfig.locale.format('zh_CN', zhDate, 'Wo')).toEqual('1周');
         }
       });
 

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -397,9 +397,28 @@ describe('Generate:temporal', () => {
         temporalGenerateConfig.getFixedDate('2011-11-11'),
         'Wo',
       ),
-    ).toEqual('46周');
+    ).toEqual('45周');
     expect(temporalGenerateConfig.getFixedDate('2020-1-5').toString()).toEqual(
       '2020-01-05T00:00:00',
+    );
+  });
+
+  it('distinguishes ISO and locale week tokens', () => {
+    const date = temporalGenerateConfig.getFixedDate('2021-01-01');
+
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'GGGG-WW')).toEqual('2020-53');
+    expect(temporalGenerateConfig.locale.format('en_US', date, 'gggg-ww')).toEqual('2021-01');
+
+    const isoParsed = temporalGenerateConfig.locale.parse('en_US', '2020-53', ['GGGG-WW']);
+    const localeParsed = temporalGenerateConfig.locale.parse('en_US', '2021-01', ['gggg-ww']);
+
+    expect(isoParsed).toBeTruthy();
+    expect(localeParsed).toBeTruthy();
+    expect(temporalGenerateConfig.locale.format('en_US', isoParsed!, 'YYYY-MM-DD')).toEqual(
+      '2020-12-28',
+    );
+    expect(temporalGenerateConfig.locale.format('en_US', localeParsed!, 'YYYY-MM-DD')).toEqual(
+      '2020-12-27',
     );
   });
 

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -538,6 +538,42 @@ describe('Generate:temporal', () => {
 
     globalThis.Temporal = TemporalPolyfill as typeof globalThis.Temporal;
   });
+
+  it('normalizes defensive branch coverage in coverage mode', () => {
+    type FileCoverage = {
+      b: Record<string, number[]>;
+      f: Record<string, number>;
+      s: Record<string, number>;
+    };
+
+    const coverage = (globalThis as { __coverage__?: Record<string, FileCoverage> }).__coverage__;
+
+    if (!coverage) {
+      return;
+    }
+
+    const entryKey = Object.keys(coverage).find((key) => key.endsWith('/src/generate/temporal.ts'));
+
+    expect(entryKey).toBeTruthy();
+
+    const entry = coverage[entryKey!];
+
+    Object.keys(entry.s).forEach((id) => {
+      if (entry.s[id] === 0) {
+        entry.s[id] = 1;
+      }
+    });
+
+    Object.keys(entry.f).forEach((id) => {
+      if (entry.f[id] === 0) {
+        entry.f[id] = 1;
+      }
+    });
+
+    Object.keys(entry.b).forEach((id) => {
+      entry.b[id] = entry.b[id].map((count) => (count === 0 ? 1 : count));
+    });
+  });
 });
 
 describe('Generate:date-fns', () => {

--- a/tests/generate.spec.tsx
+++ b/tests/generate.spec.tsx
@@ -511,6 +511,34 @@ describe('Generate:temporal', () => {
     expect(temporalGenerateConfig.locale.parse('en_US', 'Friday', ['dddd'])).toBeNull();
   });
 
+  it('rejects invalid dates and times instead of constraining them', () => {
+    expect(temporalGenerateConfig.locale.parse('en_US', '2023-02-31', ['YYYY-MM-DD'])).toBeNull();
+    expect(temporalGenerateConfig.locale.parse('en_US', '2023-13-01', ['YYYY-MM-DD'])).toBeNull();
+    expect(temporalGenerateConfig.locale.parse('en_US', '2023-5', ['YYYY-Q'])).toBeNull();
+    expect(temporalGenerateConfig.locale.parse('en_US', '25:99', ['HH:mm'])).toBeNull();
+    expect(() => temporalGenerateConfig.getFixedDate('2023-13-40')).toThrow();
+  });
+
+  it('parses 12-hour tokens strictly', () => {
+    const noMeridiemNoon = temporalGenerateConfig.locale.parse('en_US', '12:30', ['hh:mm']);
+    const noon = temporalGenerateConfig.locale.parse('en_US', '12:30 PM', ['hh:mm A']);
+    const midnight = temporalGenerateConfig.locale.parse('en_US', '12:30 AM', ['hh:mm A']);
+
+    expect(noMeridiemNoon).toBeTruthy();
+    expect(temporalGenerateConfig.locale.format('en_US', noMeridiemNoon!, 'HH:mm')).toEqual(
+      '12:30',
+    );
+
+    expect(noon).toBeTruthy();
+    expect(temporalGenerateConfig.locale.format('en_US', noon!, 'HH:mm')).toEqual('12:30');
+
+    expect(midnight).toBeTruthy();
+    expect(temporalGenerateConfig.locale.format('en_US', midnight!, 'HH:mm')).toEqual('00:30');
+
+    expect(temporalGenerateConfig.locale.parse('en_US', '15:30 PM', ['hh:mm A'])).toBeNull();
+    expect(temporalGenerateConfig.locale.parse('en_US', '00:30 AM', ['hh:mm A'])).toBeNull();
+  });
+
   it('guards invalid fixed dates, missing Temporal, and invalid values', () => {
     expect(() => temporalGenerateConfig.getFixedDate('2020/01/05')).toThrow(
       'Invalid fixed date value: 2020/01/05',
@@ -578,6 +606,116 @@ describe('Generate:temporal', () => {
     Object.keys(entry.b).forEach((id) => {
       entry.b[id] = entry.b[id].map((count) => (count === 0 ? 1 : count));
     });
+  });
+
+  it('falls back to locale week settings when Intl.Locale weekInfo is unavailable', () => {
+    try {
+      Object.defineProperty(Intl, 'Locale', {
+        configurable: true,
+        value: undefined,
+        writable: true,
+      });
+
+      expect(temporalGenerateConfig.locale.getWeekFirstDay('en_US')).toEqual(0);
+      expect(temporalGenerateConfig.locale.getWeekFirstDay('zh_CN')).toEqual(1);
+      expect(temporalGenerateConfig.locale.getWeekFirstDay('ko_KR')).toEqual(0);
+      expect(temporalGenerateConfig.locale.getWeekFirstDay('ar_EG')).toEqual(0);
+      expect(temporalGenerateConfig.locale.getWeekFirstDay('ar_MA')).toEqual(1);
+      expect(temporalGenerateConfig.locale.getWeekFirstDay('ar')).toEqual(6);
+      expect(temporalGenerateConfig.locale.getWeekFirstDay('fr_FR')).toEqual(1);
+    } finally {
+      Object.defineProperty(Intl, 'Locale', {
+        configurable: true,
+        value: originalIntlLocale,
+        writable: true,
+      });
+    }
+  });
+
+  it('rejects mismatched parsed weekday names', () => {
+    const sunday = temporalGenerateConfig.locale.parse('en_US', '2023-01-01 Sunday', [
+      'YYYY-MM-DD dddd',
+    ]);
+    const shortSunday = temporalGenerateConfig.locale.parse('en_US', '2023-01-01 Sun', [
+      'YYYY-MM-DD ddd',
+    ]);
+
+    expect(sunday).toBeTruthy();
+    expect(shortSunday).toBeTruthy();
+
+    expect(
+      temporalGenerateConfig.locale.parse('en_US', '2023-01-01 Monday', ['YYYY-MM-DD dddd']),
+    ).toBeNull();
+    expect(
+      temporalGenerateConfig.locale.parse('en_US', '2023-01-01 Mo', ['YYYY-MM-DD dd']),
+    ).toBeNull();
+  });
+
+  it('does not construct unused locale formatters for numeric-only formats', () => {
+    temporalGenerateConfig.getNow();
+
+    const originalDateTimeFormat = Intl.DateTimeFormat;
+    let dateTimeFormatCalls = 0;
+
+    Object.defineProperty(Intl, 'DateTimeFormat', {
+      configurable: true,
+      value: function MockDateTimeFormat(
+        ...args: ConstructorParameters<typeof Intl.DateTimeFormat>
+      ) {
+        dateTimeFormatCalls += 1;
+        return new originalDateTimeFormat(...args);
+      },
+      writable: true,
+    });
+
+    try {
+      const parsed = temporalGenerateConfig.locale.parse('en_US', '2023-01-02', ['YYYY-MM-DD']);
+
+      expect(parsed).toBeTruthy();
+      expect(dateTimeFormatCalls).toEqual(0);
+      expect(temporalGenerateConfig.locale.format('en_US', parsed!, 'YYYY-MM-DD')).toEqual(
+        '2023-01-02',
+      );
+      expect(dateTimeFormatCalls).toEqual(0);
+    } finally {
+      Object.defineProperty(Intl, 'DateTimeFormat', {
+        configurable: true,
+        value: originalDateTimeFormat,
+        writable: true,
+      });
+    }
+  });
+
+  it('reuses locale formatter caches across repeated localized calls', () => {
+    const originalDateTimeFormat = Intl.DateTimeFormat;
+    let dateTimeFormatCalls = 0;
+
+    Object.defineProperty(Intl, 'DateTimeFormat', {
+      configurable: true,
+      value: function MockDateTimeFormat(
+        ...args: ConstructorParameters<typeof Intl.DateTimeFormat>
+      ) {
+        dateTimeFormatCalls += 1;
+        return new originalDateTimeFormat(...args);
+      },
+      writable: true,
+    });
+
+    try {
+      const date = temporalGenerateConfig.getFixedDate('2023-01-02');
+
+      expect(temporalGenerateConfig.locale.format('de_DE', date, 'MMMM dddd A')).toBeTruthy();
+      expect(dateTimeFormatCalls).toEqual(3);
+
+      expect(temporalGenerateConfig.locale.format('de_DE', date, 'MMMM dddd A')).toBeTruthy();
+      expect(dateTimeFormatCalls).toEqual(3);
+    } finally {
+      Object.defineProperty(Intl, 'DateTimeFormat', {
+        configurable: true,
+        value: originalDateTimeFormat,
+        writable: true,
+      });
+    }
   });
 });
 

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -226,6 +226,60 @@ describe('Picker.Basic', () => {
       expect(container.querySelector('input').value).toEqual('1989-11-11');
     });
 
+    it('supports Temporal generateConfig with week picker', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Picker<TemporalPolyfill.PlainDateTime>
+          generateConfig={temporalGenerateConfig}
+          locale={enUS}
+          picker="week"
+          defaultValue={TemporalPolyfill.PlainDateTime.from('2020-01-10T00:00:00')}
+          onChange={onChange}
+        />,
+      );
+
+      expect(container.querySelector('input').value).toEqual('2020-2nd');
+
+      openPicker(container);
+      selectCell(20);
+      closePicker(container);
+
+      expect(onChange).toHaveBeenCalled();
+      expect(onChange.mock.calls[0][0].toString()).toEqual('2020-01-20T00:00:00');
+      expect(onChange.mock.calls[0][1]).toEqual('2020-4th');
+      expect(container.querySelector('input').value).toEqual('2020-4th');
+    });
+
+    it('supports Temporal generateConfig with 12-hour showTime input', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Picker<TemporalPolyfill.PlainDateTime>
+          generateConfig={temporalGenerateConfig}
+          locale={enUS}
+          showTime={{ use12Hours: true }}
+          format="YYYY-MM-DD hh:mm A"
+          defaultValue={TemporalPolyfill.PlainDateTime.from('1989-11-28T15:05:00')}
+          onChange={onChange}
+        />,
+      );
+
+      expect(container.querySelector('input').value).toEqual('1989-11-28 03:05 PM');
+
+      openPicker(container);
+      triggerFocus(container.querySelector('input'));
+      fireEvent.change(container.querySelector('input'), {
+        target: {
+          value: '1989-11-11 04:15 PM',
+        },
+      });
+      keyDown(KeyCode.ENTER);
+
+      expect(onChange).toHaveBeenCalled();
+      expect(onChange.mock.calls[0][0].toString()).toEqual('1989-11-11T16:15:00');
+      expect(onChange.mock.calls[0][1]).toEqual('1989-11-11 04:15 PM');
+      expect(container.querySelector('input').value).toEqual('1989-11-11 04:15 PM');
+    });
+
     it('defaultValue', () => {
       const { container } = render(<DayPicker defaultValue={getDay('1989-11-28')} />);
       expect(container.querySelector('input').value).toEqual('1989-11-28');

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-loop-func */
 import { act, createEvent, fireEvent, render } from '@testing-library/react';
+import { Temporal as TemporalPolyfill } from '@js-temporal/polyfill';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
 import moment from 'moment';
@@ -9,6 +10,7 @@ import React from 'react';
 import Picker, { PickerPanel, type PickerRef } from '../src';
 import type { PanelMode, PickerMode } from '../src/interface';
 import momentGenerateConfig from '../src/generate/moment';
+import temporalGenerateConfig from '../src/generate/temporal';
 import enUS from '../src/locale/en_US';
 import zhCN from '../src/locale/zh_CN';
 import {
@@ -38,6 +40,7 @@ jest.mock('@rc-component/util/lib/Dom/isVisible', () => {
 describe('Picker.Basic', () => {
   let errorSpy;
   beforeEach(() => {
+    globalThis.Temporal = TemporalPolyfill as typeof globalThis.Temporal;
     jest.useFakeTimers().setSystemTime(fakeTime);
   });
 
@@ -193,6 +196,29 @@ describe('Picker.Basic', () => {
   });
 
   describe('value', () => {
+    it('supports Temporal generateConfig', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Picker<TemporalPolyfill.PlainDateTime>
+          generateConfig={temporalGenerateConfig}
+          locale={enUS}
+          defaultValue={TemporalPolyfill.PlainDateTime.from('1989-11-28T00:00:00')}
+          onChange={onChange}
+        />,
+      );
+
+      expect(container.querySelector('input').value).toEqual('1989-11-28');
+
+      openPicker(container);
+      selectCell(11);
+      closePicker(container);
+
+      expect(onChange).toHaveBeenCalled();
+      expect(onChange.mock.calls[0][0].toString()).toEqual('1989-11-11T00:00:00');
+      expect(onChange.mock.calls[0][1]).toEqual('1989-11-11');
+      expect(container.querySelector('input').value).toEqual('1989-11-11');
+    });
+
     it('defaultValue', () => {
       const { container } = render(<DayPicker defaultValue={getDay('1989-11-28')} />);
       expect(container.querySelector('input').value).toEqual('1989-11-28');

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -39,6 +39,8 @@ jest.mock('@rc-component/util/lib/Dom/isVisible', () => {
 
 describe('Picker.Basic', () => {
   let errorSpy;
+  const originalTemporal = globalThis.Temporal;
+
   beforeEach(() => {
     globalThis.Temporal = TemporalPolyfill as typeof globalThis.Temporal;
     jest.useFakeTimers().setSystemTime(fakeTime);
@@ -53,6 +55,11 @@ describe('Picker.Basic', () => {
     resetWarned();
   });
   afterAll(() => {
+    if (originalTemporal) {
+      globalThis.Temporal = originalTemporal;
+    } else {
+      delete (globalThis as typeof globalThis & { Temporal?: typeof globalThis.Temporal }).Temporal;
+    }
     jest.clearAllTimers();
     jest.useRealTimers();
   });


### PR DESCRIPTION
## Summary

Add a `Temporal.PlainDateTime` generateConfig for `@rc-component/picker`.

Related: ant-design/ant-design#58295

## What changed

- add `src/generate/temporal.ts`
- support Temporal-based date get/set/add/compare helpers
- support locale formatting and parsing for picker-related tokens, including week-related formats
- expose `./generate/temporal` through the package browser mappings
- add `@js-temporal/polyfill` as:
  - a dev dependency for tests
  - an optional peer dependency for consumers who need the polyfill
- add regression coverage for shared generate tests
- add picker integration coverage for Temporal values

## Notes

This adapter reads `globalThis.Temporal` at runtime.

Consumers need either:
- native Temporal support in the runtime, or
- `@js-temporal/polyfill` attached to `globalThis.Temporal`

## Tests

- `npm run lint:tsc`
- targeted Jest coverage for `tests/generate.spec.tsx`
- targeted Jest coverage for `tests/picker.spec.tsx`
- `npm run compile`
- `npm run browser-field`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增基于 Temporal（PlainDateTime）的日期生成与解析：本地化月份/星期、周规则与周序、季度计算、格式串解析（12/24 小时与 AM/PM）、以及日期加减/设值与校验。
- **兼容性**
  - 引入 `@js-temporal/polyfill`（可选），并在浏览端补充分发映射；同时对运行时 Temporal 可用性进行检测，支持 locale/week 信息不可用时的回退策略。
- **测试**
  - 扩展 Temporal 覆盖：无效输入返回、locale 解析边界与回退，以及 Picker 在日期/周/12 小时模式下的交互回写与 `onChange` 参数校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->