### PR TITLE
fix(locale): correct fr_BE date selection prompt

### DIFF
--- a/src/locale/fr_BE.ts
+++ b/src/locale/fr_BE.ts
@@ -13,7 +13,7 @@ const locale: Locale = {
   month: 'Mois',
   year: 'Année',
   timeSelect: "Sélectionner l'heure",
-  dateSelect: "Sélectionner l'heure",
+  dateSelect: 'Sélectionner la date',
   monthSelect: 'Choisissez un mois',
   yearSelect: 'Choisissez une année',
   decadeSelect: 'Choisissez une décennie',

--- a/tests/locale.spec.ts
+++ b/tests/locale.spec.ts
@@ -1,0 +1,8 @@
+import frBE from '../src/locale/fr_BE';
+
+describe('Locale', () => {
+  it('uses the French date prompt for fr_BE dateSelect', () => {
+    expect(frBE.dateSelect).toBe('Sélectionner la date');
+    expect(frBE.dateSelect).not.toBe(frBE.timeSelect);
+  });
+});


### PR DESCRIPTION
## Summary

- change the Belgian French `dateSelect` prompt from the duplicated time prompt to `Sélectionner la date`
- add a focused locale regression that verifies the date prompt and time prompt stay distinct

## Verification

- exact base: `16084b6a1593d8815a6ae65cba4e6f7ce8d48c9a`
- regression before the fix: `tests/locale.spec.ts` received `Sélectionner l’heure` instead of `Sélectionner la date`
- `pnpm test --runInBand` — 16 suites, 469 passed, 2 skipped, 29 snapshots passed
- `pnpm lint` — 0 errors, 16 pre-existing hook warnings
- `pnpm compile` — ESM/CJS declarations and Less compilation passed
- `git diff --check` — passed

`pnpm lint:tsc` reports 10 removed Jest matcher aliases such as `toBeCalled` in the existing `tests/picker.spec.tsx`. I reproduced the identical errors in an isolated worktree at the unmodified exact base, so they are not introduced by this locale change.

Fixes #430

AI assistance disclosure: Codex was used to confirm the current locale value, compare the established French translation, and draft the regression. The mismatch was reproduced on the exact base and all listed checks were run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误修复**
  * 修正比利时法语本地化中的日期选择提示，将“选择时间”更正为“选择日期”。
* **测试**
  * 新增验证，确保日期选择与时间选择提示文案正确区分。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->