### PR TITLE
fix: support Android IME mask input

### DIFF
--- a/src/PickerInput/Selector/Input.tsx
+++ b/src/PickerInput/Selector/Input.tsx
@@ -97,6 +97,9 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
   const inputRef = React.useRef<HTMLInputElement>(null);
   // When mousedown get focus, defer selection to mouseUp so click position is used
   const mouseDownRef = React.useRef(false);
+  // Android virtual keyboards may report `Unidentified` on keydown. In that
+  // case, use the following native input event to recover the intended key.
+  const nativeInputRef = React.useRef(false);
 
   React.useImperativeHandle(ref, () => ({
     nativeElement: holderRef.current,
@@ -139,18 +142,6 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
     setInputValue(text);
     onModify(text);
   });
-
-  // Directly trigger `onChange` if `format` is empty
-  const onInternalChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
-    // Hack `onChange` with format to do nothing
-    if (!format) {
-      const text = event.target.value;
-
-      onModify(text);
-      setInputValue(text);
-      onChange(text);
-    }
-  };
 
   const onFormatPaste: React.ClipboardEventHandler<HTMLInputElement> = (event) => {
     // Block paste until selection is set (after mouseUp when focus was by mousedown)
@@ -203,6 +194,7 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
 
   const onFormatBlur: React.FocusEventHandler<HTMLInputElement> = (event) => {
     setFocused(false);
+    nativeInputRef.current = false;
 
     onSharedBlur(event);
   };
@@ -224,17 +216,7 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
     onKeyDown?.(event);
   };
 
-  const onFormatKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (event) => {
-    // Block key input until selection is set (after mouseUp when focus was by mousedown)
-    if (mouseDownRef.current) {
-      event.preventDefault();
-      return;
-    }
-
-    onSharedKeyDown(event);
-
-    const { key } = event;
-
+  const triggerFormatKey = (key: string) => {
     // Save the cache with cell text
     let nextCellText: string = null;
 
@@ -338,6 +320,49 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
 
     // Always trigger selection sync after key down
     forceSelectionSync({});
+  };
+
+  const onFormatKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (event) => {
+    // Block key input until selection is set (after mouseUp when focus was by mousedown)
+    if (mouseDownRef.current) {
+      event.preventDefault();
+      return;
+    }
+
+    onSharedKeyDown(event);
+
+    const { key } = event;
+    nativeInputRef.current = key === 'Unidentified';
+
+    if (!nativeInputRef.current) {
+      triggerFormatKey(key);
+    }
+  };
+
+  // Directly trigger `onChange` if `format` is empty. Masked inputs normally
+  // use keydown, but Android IMEs expose the inserted text on the input event.
+  const onInternalChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    if (!format) {
+      const text = event.target.value;
+
+      onModify(text);
+      setInputValue(text);
+      onChange(text);
+      return;
+    }
+
+    if (nativeInputRef.current) {
+      nativeInputRef.current = false;
+
+      const nativeEvent = event.nativeEvent as InputEvent;
+      if (nativeEvent.inputType === 'deleteContentBackward') {
+        triggerFormatKey('Backspace');
+      } else if (nativeEvent.inputType === 'deleteContentForward') {
+        triggerFormatKey('Delete');
+      } else if (nativeEvent.data) {
+        triggerFormatKey(nativeEvent.data);
+      }
+    }
   };
 
   // ======================== Format ========================

--- a/tests/keyboard.spec.tsx
+++ b/tests/keyboard.spec.tsx
@@ -59,6 +59,62 @@ describe('Picker.Keyboard', () => {
     expect(onChange).toHaveBeenCalledWith(expect.anything(), '2000-03-03');
   });
 
+  it('accepts masked input from Android IME keyboards', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <DayPicker
+        format={{
+          format: 'YYYYMMDD',
+          type: 'mask',
+        }}
+        onChange={onChange}
+      />,
+    );
+    const input = container.querySelector('input');
+
+    triggerFocus(input);
+    '20000303'.split('').forEach((key) => {
+      fireEvent.keyDown(input, { key: 'Unidentified' });
+      fireEvent.input(input, {
+        target: { value: key },
+        inputType: 'insertText',
+        data: key,
+      });
+    });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), '20000303');
+  });
+
+  it('accepts masked range input from Android IME keyboards', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <DayRangePicker
+        format={{
+          format: 'YYYYMMDD',
+          type: 'mask',
+        }}
+        onChange={onChange}
+      />,
+    );
+    const inputs = container.querySelectorAll('input');
+
+    ['20000303', '20000305'].forEach((value, index) => {
+      triggerFocus(inputs[index]);
+      value.split('').forEach((key) => {
+        fireEvent.keyDown(inputs[index], { key: 'Unidentified' });
+        fireEvent.input(inputs[index], {
+          target: { value: key },
+          inputType: 'insertText',
+          data: key,
+        });
+      });
+      fireEvent.keyDown(inputs[index], { key: 'Enter' });
+    });
+
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), ['20000303', '20000305']);
+  });
+
   // Coverage case: replace these tests if a clearer interaction can cover the
   // same behavior. / 覆盖率用例：若有更清晰的交互覆盖相同行为，可直接替换。
   it('should submit typed value on Tab without trapping focus', () => {


### PR DESCRIPTION
## Summary

- recover masked input from the native `input` event when Android virtual keyboards report `event.key` as `Unidentified`
- reuse the existing mask-cell formatting path for inserted text and forward/backward deletion
- cover both single and range pickers with Android-style keydown/input sequences

## Why

Masked picker input currently relies on `keydown` to identify numeric keys. Android IMEs such as Gboard and SwiftKey can report `Unidentified`, so the mask handler ignores the character even though the following native input event contains it.

The fallback is narrowly gated to an immediately preceding `Unidentified` keydown. Ordinary keyboard input continues through the existing keydown path, avoiding duplicate processing.

Fixes #929.

## Validation

- `npm test -- --runInBand` — 15/15 suites, 470 passed, 2 skipped, 29 snapshots
- focused ESLint for the changed source and test files
- Prettier check and `git diff --check`
- `npm run lint:tsc` reaches only the existing deprecated Jest matcher type errors in `tests/picker.spec.tsx`; the exact base reproduces the same errors

AI assistance disclosure: Codex was used to trace the masked-input event flow, implement the fallback, and draft regression tests. I verified the failure on current master before the fix and ran the validation above on the submitted commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进 Android 虚拟键盘下的格式化输入处理，确保日期等掩码字段能够正确识别逐字符输入。
  * 修复 Android 输入法场景下日期选择器及日期范围选择器的输入和提交结果异常问题。

* **Tests**
  * 新增 Android 输入法输入日期及日期范围的覆盖测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->