### PR TITLE
fix: support manual input clearing

### DIFF
--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -665,7 +665,15 @@ function RangePicker<DateType extends object = any>(
   // ========================================================
 
   // ======================== Change ========================
-  const onSelectorChange = (date: DateType, index: number) => {
+  const onSelectorChange = (date: DateType | null, index: number) => {
+    if (!date) {
+      resetRangeValueChange();
+      triggerSubmitChange(allowEmpty[index] ? fillCalendarValue(null, index) : null);
+      triggerOpen(false, { force: true });
+      onClear?.();
+      return;
+    }
+
     triggerRangeValueChange(index, 'input', date);
   };
 

--- a/src/PickerInput/Selector/Input.tsx
+++ b/src/PickerInput/Selector/Input.tsx
@@ -148,7 +148,7 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
 
     // Empty text is a valid clear action when the picker is clearable.
     // Handle it before the mask logic, which normally ignores invalid text.
-    if (clearable && !text && value) {
+    if (clearable && !text) {
       setInputValue(text);
       onChange(text);
       return;

--- a/src/PickerInput/Selector/Input.tsx
+++ b/src/PickerInput/Selector/Input.tsx
@@ -46,6 +46,7 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
   invalid?: boolean;
 
   clearIcon?: React.ReactNode;
+  clearable?: boolean;
 }
 
 const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
@@ -65,6 +66,7 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
     preserveInvalidOnBlur = false,
     invalid,
     clearIcon,
+    clearable,
     // Pass to input
     ...restProps
   } = props;
@@ -142,10 +144,18 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
 
   // Directly trigger `onChange` if `format` is empty
   const onInternalChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    const text = event.target.value;
+
+    // Empty text is a valid clear action when the picker is clearable.
+    // Handle it before the mask logic, which normally ignores invalid text.
+    if (clearable && !text && value) {
+      setInputValue(text);
+      onChange(text);
+      return;
+    }
+
     // Hack `onChange` with format to do nothing
     if (!format) {
-      const text = event.target.value;
-
       onModify(text);
       setInputValue(text);
       onChange(text);

--- a/src/PickerInput/Selector/RangeSelector.tsx
+++ b/src/PickerInput/Selector/RangeSelector.tsx
@@ -30,7 +30,7 @@ export interface RangeSelectorProps<DateType = any> extends SelectorProps<DateTy
   separator?: React.ReactNode;
 
   value?: [DateType?, DateType?];
-  onChange: (date: DateType, index?: number) => void;
+  onChange: (date: DateType | null, index?: number) => void;
 
   disabled: [boolean, boolean];
 

--- a/src/PickerInput/Selector/SingleSelector/index.tsx
+++ b/src/PickerInput/Selector/SingleSelector/index.tsx
@@ -131,7 +131,12 @@ function SingleSelector<DateType extends object = any>(
   const rootProps = useRootProps(restProps);
 
   // ======================== Change ========================
-  const onSingleChange = (date: DateType) => {
+  const onSingleChange = (date: DateType | null) => {
+    if (!date) {
+      onClear();
+      return;
+    }
+
     onChange([date], 'input');
   };
 

--- a/src/PickerInput/Selector/hooks/useInputProps.ts
+++ b/src/PickerInput/Selector/hooks/useInputProps.ts
@@ -27,6 +27,7 @@ export default function useInputProps<DateType extends object = any>(
     | 'autoComplete'
     | 'open'
     | 'picker'
+    | 'clearIcon'
   > & {
     id?: string | string[];
     value?: DateType[];
@@ -73,6 +74,7 @@ export default function useInputProps<DateType extends object = any>(
     allHelp,
 
     picker,
+    clearIcon,
   } = props;
 
   // ======================== Parser ========================
@@ -161,6 +163,8 @@ export default function useInputProps<DateType extends object = any>(
 
       disabled: getProp(disabled),
 
+      clearable: !!clearIcon,
+
       onFocus: (event) => {
         onFocus(event, index);
       },
@@ -181,6 +185,12 @@ export default function useInputProps<DateType extends object = any>(
         if (parsed) {
           onInvalid(false, index);
           onChange(parsed, index);
+          return;
+        }
+
+        if (!text && clearIcon) {
+          onInvalid(false, index);
+          onChange(null, index);
           return;
         }
 

--- a/src/PickerInput/Selector/hooks/useInputProps.ts
+++ b/src/PickerInput/Selector/hooks/useInputProps.ts
@@ -1,4 +1,4 @@
-import { pickAttrs, warning } from '@rc-component/util';
+import { isReactRenderable, pickAttrs, warning } from '@rc-component/util';
 import * as React from 'react';
 import type { SelectorProps } from '../../../interface';
 import { formatValue } from '../../../utils/dateUtil';
@@ -76,6 +76,8 @@ export default function useInputProps<DateType extends object = any>(
     picker,
     clearIcon,
   } = props;
+
+  const canClear = isReactRenderable(clearIcon);
 
   // ======================== Parser ========================
   const parseDate = (str: string, formatStr: string) => {
@@ -163,7 +165,7 @@ export default function useInputProps<DateType extends object = any>(
 
       disabled: getProp(disabled),
 
-      clearable: !!clearIcon,
+      clearable: canClear,
 
       onFocus: (event) => {
         onFocus(event, index);
@@ -188,7 +190,7 @@ export default function useInputProps<DateType extends object = any>(
           return;
         }
 
-        if (!text && clearIcon) {
+        if (!text && canClear) {
           onInvalid(false, index);
           onChange(null, index);
           return;

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -291,6 +291,43 @@ describe('Picker.Basic', () => {
       });
     });
 
+    it('clears a selected value when the input text is removed', () => {
+      const onChange = jest.fn();
+      const onClear = jest.fn();
+      const { container } = render(
+        <DayPicker
+          defaultValue={getDay('2000-11-11')}
+          format={{ format: 'YYYY-MM-DD', type: 'mask' }}
+          onChange={onChange}
+          onClear={onClear}
+        />,
+      );
+
+      openPicker(container);
+      fireEvent.change(container.querySelector('input'), { target: { value: '' } });
+
+      expect(onChange).toHaveBeenCalledWith(null, null);
+      expect(onClear).toHaveBeenCalledTimes(1);
+      expect(container.querySelector('input')).toHaveValue('');
+      expect(isOpen()).toBeFalsy();
+    });
+
+    it('does not manually clear when allowClear is false', async () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <DayPicker defaultValue={getDay('2000-11-11')} onChange={onChange} allowClear={false} />,
+      );
+      const input = container.querySelector('input');
+
+      openPicker(container);
+      fireEvent.change(input, { target: { value: '' } });
+      fireEvent.blur(input);
+      await waitFakeTimer();
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(input).toHaveValue('2000-11-11');
+    });
+
     // https://github.com/ant-design/ant-design/issues/49400
     it('should not throw errow when input end year first', () => {
       const { container } = render(<DayRangePicker picker="year" />);

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -344,6 +344,42 @@ describe('Picker.Basic', () => {
       expect(isOpen()).toBeFalsy();
     });
 
+    [true, false, { clearIcon: 0 }].forEach((allowClear) => {
+      it(`clears invalid mask text without a selected value: ${JSON.stringify(allowClear)}`, async () => {
+        const onClear = jest.fn();
+        const onChange = jest.fn();
+        const { container } = render(
+          <DayPicker
+            format={{ format: 'YYYY-MM-DD', type: 'mask' }}
+            allowClear={allowClear}
+            onClear={onClear}
+            onChange={onChange}
+          />,
+        );
+        const input = container.querySelector('input');
+        triggerFocus(input);
+        for (const key of '20240231') {
+          fireEvent.keyDown(input, { key });
+        }
+        expect(input).toHaveValue('2024-02-31');
+        expect(onChange).not.toHaveBeenCalled();
+        expect(onClear).not.toHaveBeenCalled();
+
+        input.setSelectionRange(0, input.value.length);
+        fireEvent.change(input, { target: { value: '' } });
+
+        expect(onClear).toHaveBeenCalledTimes(allowClear === false ? 0 : 1);
+        expect(onChange).not.toHaveBeenCalled();
+        if (allowClear !== false) {
+          expect(input).toHaveValue('YYYY-MM-DD');
+          expect(isOpen()).toBeFalsy();
+          triggerBlur(input);
+          await waitFakeTimer();
+          expect(input).toHaveValue('');
+        }
+      });
+    });
+
     it('does not manually clear when allowClear is false', async () => {
       const onChange = jest.fn();
       const { container } = render(

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -247,6 +247,48 @@ describe('Picker.Range', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it('clears the range when an input value is manually removed', () => {
+    const onChange = jest.fn();
+    const onClear = jest.fn();
+    const { container } = render(
+      <DayRangePicker
+        defaultValue={[getDay('1990-09-11'), getDay('1990-09-23')]}
+        onChange={onChange}
+        onClear={onClear}
+      />,
+    );
+
+    openPicker(container);
+    fireEvent.change(container.querySelectorAll('input')[0], { target: { value: '' } });
+
+    expect(onChange).toHaveBeenCalledWith(null, null);
+    expect(onClear).toHaveBeenCalledTimes(1);
+    matchValues(container, '', '');
+    expect(isOpen()).toBeFalsy();
+  });
+
+  it('keeps the other range value when the cleared field allows empty', () => {
+    const onChange = jest.fn();
+    const onClear = jest.fn();
+    const end = getDay('1990-09-23');
+    const { container } = render(
+      <DayRangePicker
+        defaultValue={[getDay('1990-09-11'), end]}
+        allowEmpty={[true, false]}
+        onChange={onChange}
+        onClear={onClear}
+      />,
+    );
+
+    openPicker(container);
+    fireEvent.change(container.querySelectorAll('input')[0], { target: { value: '' } });
+
+    expect(onChange).toHaveBeenCalledWith([null, end], ['', '1990-09-23']);
+    expect(onClear).toHaveBeenCalledTimes(1);
+    matchValues(container, '', '1990-09-23');
+    expect(isOpen()).toBeFalsy();
+  });
+
   describe('disabled', () => {
     it('should no panel open with disabled', () => {
       const { baseElement } = render(<DayRangePicker disabled />);


### PR DESCRIPTION
Manual deletion now follows the existing clear action for clearable single and range inputs, including masked text with no valid selected date. Clearing capability uses `isReactRenderable` on the normalized clear icon, independently of whether the button is currently visible. Range clearing preserves the opposite endpoint only when the edited field allows empty; `allowClear={false}` retains its prior behavior.

Closes #946. Related to ant-design/ant-design#52473.

Validation on signed/GitHub-Verified head `f29a7b7adee3597211a681cd16a61d0214d0d29e`, after merging master `58a1d980b69f15e1bb962b05e66f74f803a6b895`:
- Full suite: 16 suites, 490 passing, 2 skipped, 29 snapshots.
- TypeScript, ESM/CJS/declaration and Less compilation, ESLint (zero errors), Prettier and diff checks pass.
- New regression: with no selected date, type invalid masked `2024-02-31`, select all, and delete. Before the follow-up fix, both enabled-clear cases fail with zero `onClear` calls; the disabled-clear control passes. After the fix all three pass, including `clearIcon: 0`, the focused mask placeholder, and empty text after blur.

AI assistance: Codex was used for implementation and local verification. The exact-head GitHub Actions run https://github.com/react-component/picker/actions/runs/34459884080 passes lint, TypeScript, compile, and the coverage test suite (16 suites / 490 passed / 2 skipped / 29 snapshots). Vercel deployment requires upstream team authorization; CodeRabbit review remains pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持清空单日期和日期范围选择器的输入值。
  * 清空时可根据配置保留范围中的部分日期。
  * 清空操作会正确触发变更与清除回调，并关闭选择面板。
  * 日期范围选择器在部分选择状态下提供更准确的悬停高亮。

* **问题修复**
  * 修复可清除选择器无法正确处理空输入的问题。
  * 禁用清除功能时，清空并失焦不会错误地提交变更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
