### PR TITLE
fix(locale): use Taiwan week terminology

### DIFF
--- a/src/locale/zh_TW.ts
+++ b/src/locale/zh_TW.ts
@@ -11,7 +11,7 @@ const locale: Locale = {
   ok: '確定',
   timeSelect: '選擇時間',
   dateSelect: '選擇日期',
-  weekSelect: '選擇周',
+  weekSelect: '選擇週',
   clear: '清除',
   week: '週',
   month: '月',

--- a/tests/locale-zh-tw.spec.ts
+++ b/tests/locale-zh-tw.spec.ts
@@ -1,0 +1,8 @@
+import zhTW from '../src/locale/zh_TW';
+
+describe('zh_TW locale', () => {
+  it('uses the Taiwan week term consistently', () => {
+    expect(zhTW.weekSelect).toBe('選擇週');
+    expect(zhTW.weekSelect).toContain('週');
+  });
+});


### PR DESCRIPTION
## Summary

- replace the Mainland Chinese week character in the Traditional Chinese week-selection prompt
- keep `weekSelect` consistent with the existing `week: 週` label
- add a focused locale regression

The `zh_TW` locale currently mixes `選擇周` with `週` in the same object. Taiwan usage consistently uses `週`, so the picker prompt should read `選擇週`.

## Verification

- Exact-base causal check: the new locale regression was the only failing assertion with `weekSelect: 選擇周`
- Fixed full suite: 16 suites passed, 469 tests passed, 2 skipped, 29 snapshots passed
- `npm run tsc`
- `npm run lint` — 0 errors, 16 pre-existing hook warnings
- `npm run compile` — ESM, CJS, declarations, and CSS passed
- `prettier --check src/locale/zh_TW.ts tests/locale-zh-tw.spec.ts`
- `git diff --check`

I checked every current open PR and its changed files before implementation. #987 also adds independent time-panel labels to `zh_TW.ts`, but it does not modify `weekSelect`; this patch is semantically separate, with only a possible trivial same-file rebase overlap.

AI assistance disclosure: Codex was used to audit locale consistency and open-PR overlap, add the regression, and run verification. I reviewed the wording, causal failure, and final diff before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文案更新**
  * 修正繁体中文界面中的“选择周”文案为“選擇週”，用字更加准确。

* **测试**
  * 新增验证，确保该文案持续使用正确的繁体字。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->