### PR TITLE
fix: preserve alternate format input while typing

### DIFF
--- a/src/PickerInput/Selector/Input.tsx
+++ b/src/PickerInput/Selector/Input.tsx
@@ -33,6 +33,7 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
   showActiveCls?: boolean;
   suffixIcon?: React.ReactNode;
   value?: string;
+  preserveInputOnValueChange?: (inputValue: string, value: string) => boolean;
   onChange: (value: string) => void;
   onSubmit: VoidFunction;
   /** Meaning current is from the hover cell getting the placeholder text */
@@ -65,6 +66,7 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
     preserveInvalidOnBlur = false,
     invalid,
     clearIcon,
+    preserveInputOnValueChange,
     // Pass to input
     ...restProps
   } = props;
@@ -81,16 +83,28 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
   // ======================== Value =========================
   const [focused, setFocused] = React.useState(false);
   const [internalInputValue, setInputValue] = React.useState<string>(value);
+  const inputValueRef = React.useRef(value);
   const [focusCellText, setFocusCellText] = React.useState<string>('');
   const [focusCellIndex, setFocusCellIndex] = React.useState<number>(null);
   const [forceSelectionSyncMark, forceSelectionSync] = React.useState<object>(null);
 
   const inputValue = internalInputValue || '';
+  const updateInputValue = useEvent((nextValue: string) => {
+    inputValueRef.current = nextValue;
+    setInputValue(nextValue);
+  });
+
+  const shouldPreserveInput = useEvent(
+    (nextValue: string) =>
+      (focused || active) && preserveInputOnValueChange?.(inputValueRef.current || '', nextValue),
+  );
 
   // Sync value if needed
   React.useEffect(() => {
-    setInputValue(value);
-  }, [value]);
+    if (!shouldPreserveInput(value)) {
+      updateInputValue(value);
+    }
+  }, [value, shouldPreserveInput, updateInputValue]);
 
   // ========================= Refs =========================
   const holderRef = React.useRef<HTMLDivElement>(null);
@@ -133,10 +147,11 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
    * Triggered by paste, keyDown and focus to show format
    */
   const triggerInputChange = useEvent((text: string) => {
+    inputValueRef.current = text;
     if (validateFormat(text)) {
       onChange(text);
     }
-    setInputValue(text);
+    updateInputValue(text);
     onModify(text);
   });
 
@@ -147,7 +162,7 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
       const text = event.target.value;
 
       onModify(text);
-      setInputValue(text);
+      updateInputValue(text);
       onChange(text);
     }
   };
@@ -211,7 +226,7 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
   // Check if blur need reset input value
   useLockEffect(active, () => {
     if (!active && !preserveInvalidOnBlur) {
-      setInputValue(value);
+      updateInputValue(value);
     }
   });
 

--- a/src/PickerInput/Selector/hooks/useInputProps.ts
+++ b/src/PickerInput/Selector/hooks/useInputProps.ts
@@ -151,6 +151,11 @@ export default function useInputProps<DateType extends object = any>(
 
       value: getProp(valueTexts) || '',
 
+      preserveInputOnValueChange: (text: string, nextValue: string) => {
+        const parsed = validateFormat(text);
+        return !!parsed && getText(parsed) === nextValue;
+      },
+
       invalid: getProp(invalid),
 
       placeholder: getProp(placeholder),

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -920,6 +920,39 @@ describe('Picker.Basic', () => {
     expect(document.querySelector('input').value).toEqual('20000101');
   });
 
+  it('allows typing a four-digit year when a shorter format also matches', () => {
+    const onChange = jest.fn();
+    const { container, rerender } = render(
+      <DayPicker format={['DD-MM-YYYY', 'DD-MM-YY']} onChange={onChange} />,
+    );
+    const input = container.querySelector('input');
+
+    openPicker(container);
+    const text = '01-12-2024';
+    for (let index = 1; index <= text.length; index += 1) {
+      fireEvent.change(input, { target: { value: text.slice(0, index) } });
+
+      if (index === '01-12-20'.length) {
+        expect(input).toHaveValue('01-12-20');
+      }
+    }
+
+    expect(input).toHaveValue('01-12-2024');
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), '01-12-2024');
+
+    triggerFocus(input);
+    fireEvent.change(input, { target: { value: '01-12-20' } });
+    rerender(
+      <DayPicker
+        format={['DD-MM-YYYY', 'DD-MM-YY']}
+        value={getDay('1999-09-09')}
+        onChange={onChange}
+      />,
+    );
+    expect(input).toHaveValue('09-09-1999');
+  });
+
   it('custom format', () => {
     const { container } = render(
       <DayPicker


### PR DESCRIPTION
## Summary

- keep the focused raw input when an alternate format parses to the same value that the picker just formatted
- allow a longer format to continue receiving characters after a shorter format becomes valid
- continue syncing the input immediately when a panel or controlled update selects a different date

## Regression

With `format={['DD-MM-YYYY', 'DD-MM-YY']}`, exact base `16084b6a1593d8815a6ae65cba4e6f7ce8d48c9a` rewrites the typed prefix `01-12-20` to `01-12-2020`, preventing normal continuation to a four-digit year.

The new regression types `01-12-2024` character by character, asserts that the ambiguous short prefix remains untouched, submits the completed value, and then verifies that a controlled update to a different date still replaces the input.

## Validation

- full test suite: 15 suites, 469 passed, 2 skipped, 29 snapshots passed
- complete Picker scope: 110 passed, 1 skipped, 5 snapshots passed
- complete RangePicker scope: 123 passed, 1 skipped, 6 snapshots passed
- ESM, CJS, and declaration build passed
- source ESLint: 0 errors, 16 existing hook warnings
- focused Prettier and diff checks passed

## Overlap audit

Current open PRs #1005, #1006, #986, and #947 touch one or more of the same selector files for Android IME handling, manual clearing, or keyboard semantics. None addresses alternate-format input normalization or the `YY` / `YYYY` boundary. This PR stays scoped to that distinct state-synchronization behavior.

Fixes #956.
Related to #911.

AI assistance disclosure: Codex was used to trace the input/value synchronization path, construct the causal regression, run the validation matrix, audit open changed-file overlap, and draft this description. I verified the base failure, head behavior, test results, diff, and signed commit before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增输入内容保留选项，可在外部值变化时根据条件保留用户当前输入。
  - 优化日期输入解析，支持同时配置四位和两位年份格式。
- **问题修复**
  - 改善受控日期选择器的输入同步，避免有效输入在重新渲染时被不必要地覆盖。
  - 修复部分匹配日期格式时的输入显示与变更触发问题。
- **测试**
  - 新增多日期格式、部分输入及受控值更新场景的覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->