### PR TITLE
fix: preserve pending range selection on hover

### DIFF
--- a/src/PickerInput/Popup/PopupPanel.tsx
+++ b/src/PickerInput/Popup/PopupPanel.tsx
@@ -14,7 +14,6 @@ export type PopupPanelProps<DateType extends object = any> = MustProp<DateType> 
   FooterProps<DateType> & {
     multiplePanel?: boolean;
     range?: boolean;
-    cellHoverValue?: DateType[];
 
     onPickerValueChange: (date: DateType) => void;
   };
@@ -22,17 +21,7 @@ export type PopupPanelProps<DateType extends object = any> = MustProp<DateType> 
 export default function PopupPanel<DateType extends object = any>(
   props: PopupPanelProps<DateType>,
 ) {
-  const {
-    picker,
-    multiplePanel,
-    pickerValue,
-    onPickerValueChange,
-    needConfirm,
-    onSubmit,
-    range,
-    hoverValue,
-    cellHoverValue,
-  } = props;
+  const { picker, multiplePanel, pickerValue, onPickerValueChange, needConfirm, onSubmit } = props;
   const { prefixCls, generateConfig } = React.useContext(PickerContext);
 
   // ======================== Offset ========================
@@ -67,17 +56,8 @@ export default function PopupPanel<DateType extends object = any>(
   // ======================== Props =========================
   const pickerProps = {
     ...props,
-    hoverValue: null,
-    hoverRangeValue: null,
     hideHeader,
   };
-
-  if (range) {
-    pickerProps.hoverRangeValue = hoverValue;
-    pickerProps.hoverValue = cellHoverValue;
-  } else {
-    pickerProps.hoverValue = hoverValue;
-  }
 
   // ======================== Render ========================
   // Multiple

--- a/src/PickerInput/Popup/PopupPanel.tsx
+++ b/src/PickerInput/Popup/PopupPanel.tsx
@@ -14,6 +14,7 @@ export type PopupPanelProps<DateType extends object = any> = MustProp<DateType> 
   FooterProps<DateType> & {
     multiplePanel?: boolean;
     range?: boolean;
+    cellHoverValue?: DateType[];
 
     onPickerValueChange: (date: DateType) => void;
   };
@@ -30,6 +31,7 @@ export default function PopupPanel<DateType extends object = any>(
     onSubmit,
     range,
     hoverValue,
+    cellHoverValue,
   } = props;
   const { prefixCls, generateConfig } = React.useContext(PickerContext);
 
@@ -72,6 +74,7 @@ export default function PopupPanel<DateType extends object = any>(
 
   if (range) {
     pickerProps.hoverRangeValue = hoverValue;
+    pickerProps.hoverValue = cellHoverValue;
   } else {
     pickerProps.hoverValue = hoverValue;
   }

--- a/src/PickerInput/Popup/PopupPanel.tsx
+++ b/src/PickerInput/Popup/PopupPanel.tsx
@@ -21,7 +21,17 @@ export type PopupPanelProps<DateType extends object = any> = MustProp<DateType> 
 export default function PopupPanel<DateType extends object = any>(
   props: PopupPanelProps<DateType>,
 ) {
-  const { picker, multiplePanel, pickerValue, onPickerValueChange, needConfirm, onSubmit } = props;
+  const {
+    picker,
+    multiplePanel,
+    pickerValue,
+    onPickerValueChange,
+    needConfirm,
+    onSubmit,
+    range,
+    hoverValue,
+    hoverRangeValue,
+  } = props;
   const { prefixCls, generateConfig } = React.useContext(PickerContext);
 
   // ======================== Offset ========================
@@ -56,8 +66,15 @@ export default function PopupPanel<DateType extends object = any>(
   // ======================== Props =========================
   const pickerProps = {
     ...props,
+    hoverValue: null,
+    hoverRangeValue: null,
     hideHeader,
   };
+
+  pickerProps.hoverValue = hoverValue;
+  if (range) {
+    pickerProps.hoverRangeValue = hoverRangeValue;
+  }
 
   // ======================== Render ========================
   // Multiple

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -503,13 +503,14 @@ function RangePicker<DateType extends object = any>(
     return internalHoverValues || calendarValue;
   }, [calendarValue, internalHoverValues]);
 
-  // Keep the pending date as a single selected cell only when choosing the first value.
-  const keepCurrentSelection =
+  // "Weak" hover only highlights the hovered cell instead of composing a range.
+  // Use it while choosing the first value so the pending selection remains selected.
+  const showWeakHover =
     // Preset hover always previews the whole range.
     hoverSource === 'cell' &&
     // Once the other field has a value, range hover takes precedence.
     !calendarValue[(activeIndex + 1) % 2] &&
-    // Only a changed active value needs to remain selected.
+    // Only a changed active value needs weak hover.
     !isSameTimestamp(generateConfig, calendarValue[activeIndex], mergedValue[activeIndex]);
   const activeHoverValue = internalHoverValues?.[activeIndex];
 
@@ -651,8 +652,8 @@ function RangePicker<DateType extends object = any>(
       defaultOpenValue={toArray(showTime?.defaultOpenValue)[activeIndex]}
       onPickerValueChange={setCurrentPickerValue}
       // Hover
-      hoverValue={keepCurrentSelection && activeHoverValue ? [activeHoverValue] : null}
-      hoverRangeValue={keepCurrentSelection ? null : hoverValues}
+      hoverValue={showWeakHover && activeHoverValue ? [activeHoverValue] : null}
+      hoverRangeValue={showWeakHover ? null : hoverValues}
       onHover={onPanelHover}
       // Submit
       needConfirm={needConfirm}

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -24,6 +24,7 @@ import type {
 import type { PickerPanelProps } from '../PickerPanel';
 import PickerTrigger from '../PickerTrigger';
 import { pickTriggerProps } from '../PickerTrigger/util';
+import { isSameTimestamp } from '../utils/dateUtil';
 import { fillIndex, getFromDate, toArray } from '../utils/miscUtil';
 import PickerContext from './context';
 import useCellRender from './hooks/useCellRender';
@@ -331,7 +332,6 @@ function RangePicker<DateType extends object = any>(
     triggeredFields,
     triggerRangeValueChange,
     resetRangeValueChange,
-    currentFieldModified,
   ] = useRangeValueChange(
     enabledFieldCount,
     needConfirm,
@@ -503,7 +503,10 @@ function RangePicker<DateType extends object = any>(
     return internalHoverValues || calendarValue;
   }, [calendarValue, internalHoverValues]);
 
-  const keepCurrentSelection = needConfirm && currentFieldModified && hoverSource === 'cell';
+  const keepCurrentSelection =
+    needConfirm &&
+    hoverSource === 'cell' &&
+    !isSameTimestamp(generateConfig, calendarValue[activeIndex], mergedValue[activeIndex]);
   const activeHoverValue = internalHoverValues?.[activeIndex];
 
   // Clean up `internalHoverValues` when closed

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -504,7 +504,6 @@ function RangePicker<DateType extends object = any>(
   }, [calendarValue, internalHoverValues]);
 
   const keepCurrentSelection = needConfirm && currentFieldModified && hoverSource === 'cell';
-  const panelHoverValues = keepCurrentSelection ? calendarValue : hoverValues;
   const activeHoverValue = internalHoverValues?.[activeIndex];
 
   // Clean up `internalHoverValues` when closed
@@ -645,8 +644,8 @@ function RangePicker<DateType extends object = any>(
       defaultOpenValue={toArray(showTime?.defaultOpenValue)[activeIndex]}
       onPickerValueChange={setCurrentPickerValue}
       // Hover
-      hoverValue={panelHoverValues}
-      cellHoverValue={keepCurrentSelection && activeHoverValue ? [activeHoverValue] : null}
+      hoverValue={keepCurrentSelection && activeHoverValue ? [activeHoverValue] : null}
+      hoverRangeValue={keepCurrentSelection ? null : hoverValues}
       onHover={onPanelHover}
       // Submit
       needConfirm={needConfirm}

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -331,6 +331,7 @@ function RangePicker<DateType extends object = any>(
     triggeredFields,
     triggerRangeValueChange,
     resetRangeValueChange,
+    currentFieldModified,
   ] = useRangeValueChange(
     enabledFieldCount,
     needConfirm,
@@ -502,6 +503,10 @@ function RangePicker<DateType extends object = any>(
     return internalHoverValues || calendarValue;
   }, [calendarValue, internalHoverValues]);
 
+  const keepCurrentSelection = needConfirm && currentFieldModified && hoverSource === 'cell';
+  const panelHoverValues = keepCurrentSelection ? calendarValue : hoverValues;
+  const activeHoverValue = internalHoverValues?.[activeIndex];
+
   // Clean up `internalHoverValues` when closed
   React.useEffect(() => {
     if (!mergedOpen) {
@@ -640,7 +645,8 @@ function RangePicker<DateType extends object = any>(
       defaultOpenValue={toArray(showTime?.defaultOpenValue)[activeIndex]}
       onPickerValueChange={setCurrentPickerValue}
       // Hover
-      hoverValue={hoverValues}
+      hoverValue={panelHoverValues}
+      cellHoverValue={keepCurrentSelection && activeHoverValue ? [activeHoverValue] : null}
       onHover={onPanelHover}
       // Submit
       needConfirm={needConfirm}

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -505,8 +505,6 @@ function RangePicker<DateType extends object = any>(
 
   // Keep the pending date as a single selected cell only when choosing the first value.
   const keepCurrentSelection =
-    // Confirmation mode keeps the clicked date pending.
-    needConfirm &&
     // Preset hover always previews the whole range.
     hoverSource === 'cell' &&
     // Once the other field has a value, range hover takes precedence.

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -503,10 +503,17 @@ function RangePicker<DateType extends object = any>(
     return internalHoverValues || calendarValue;
   }, [calendarValue, internalHoverValues]);
 
+  const otherFieldValue = calendarValue[(activeIndex + 1) % 2];
+  const currentFieldChanged = !isSameTimestamp(
+    generateConfig,
+    calendarValue[activeIndex],
+    mergedValue[activeIndex],
+  );
+
+  // Keep the pending date as a single selected cell only while choosing the first value.
+  // Once the other field has a value, the range hover takes precedence.
   const keepCurrentSelection =
-    needConfirm &&
-    hoverSource === 'cell' &&
-    !isSameTimestamp(generateConfig, calendarValue[activeIndex], mergedValue[activeIndex]);
+    needConfirm && hoverSource === 'cell' && !otherFieldValue && currentFieldChanged;
   const activeHoverValue = internalHoverValues?.[activeIndex];
 
   // Clean up `internalHoverValues` when closed

--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -503,17 +503,16 @@ function RangePicker<DateType extends object = any>(
     return internalHoverValues || calendarValue;
   }, [calendarValue, internalHoverValues]);
 
-  const otherFieldValue = calendarValue[(activeIndex + 1) % 2];
-  const currentFieldChanged = !isSameTimestamp(
-    generateConfig,
-    calendarValue[activeIndex],
-    mergedValue[activeIndex],
-  );
-
-  // Keep the pending date as a single selected cell only while choosing the first value.
-  // Once the other field has a value, the range hover takes precedence.
+  // Keep the pending date as a single selected cell only when choosing the first value.
   const keepCurrentSelection =
-    needConfirm && hoverSource === 'cell' && !otherFieldValue && currentFieldChanged;
+    // Confirmation mode keeps the clicked date pending.
+    needConfirm &&
+    // Preset hover always previews the whole range.
+    hoverSource === 'cell' &&
+    // Once the other field has a value, range hover takes precedence.
+    !calendarValue[(activeIndex + 1) % 2] &&
+    // Only a changed active value needs to remain selected.
+    !isSameTimestamp(generateConfig, calendarValue[activeIndex], mergedValue[activeIndex]);
   const activeHoverValue = internalHoverValues?.[activeIndex];
 
   // Clean up `internalHoverValues` when closed

--- a/src/PickerInput/hooks/useRangeValueChange.ts
+++ b/src/PickerInput/hooks/useRangeValueChange.ts
@@ -59,7 +59,6 @@ export type UseRangeValueChangeReturn<FieldValue> = [
   triggeredFields: number[],
   triggerChange: TriggerChange<FieldValue>,
   reset: VoidFunction,
-  currentFieldModified: boolean,
 ];
 
 interface TriggeredField {
@@ -510,9 +509,6 @@ export default function useRangeValueChange<FieldValue = unknown>(
   lastValidIndexRef.current = currentIndex ?? lastValidIndexRef.current ?? 0;
 
   const triggeredFields = triggeredFieldsRef.current.map((field) => field.index);
-  const currentFieldModified = triggeredFieldsRef.current.some(
-    (field) => field.index === currentIndex && field.modified,
-  );
 
   return [
     currentIndex,
@@ -521,6 +517,5 @@ export default function useRangeValueChange<FieldValue = unknown>(
     triggeredFields,
     triggerChange,
     reset,
-    currentFieldModified,
   ];
 }

--- a/src/PickerInput/hooks/useRangeValueChange.ts
+++ b/src/PickerInput/hooks/useRangeValueChange.ts
@@ -59,6 +59,7 @@ export type UseRangeValueChangeReturn<FieldValue> = [
   triggeredFields: number[],
   triggerChange: TriggerChange<FieldValue>,
   reset: VoidFunction,
+  currentFieldModified: boolean,
 ];
 
 interface TriggeredField {
@@ -509,6 +510,9 @@ export default function useRangeValueChange<FieldValue = unknown>(
   lastValidIndexRef.current = currentIndex ?? lastValidIndexRef.current ?? 0;
 
   const triggeredFields = triggeredFieldsRef.current.map((field) => field.index);
+  const currentFieldModified = triggeredFieldsRef.current.some(
+    (field) => field.index === currentIndex && field.modified,
+  );
 
   return [
     currentIndex,
@@ -517,5 +521,6 @@ export default function useRangeValueChange<FieldValue = unknown>(
     triggeredFields,
     triggerChange,
     reset,
+    currentFieldModified,
   ];
 }

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -769,22 +769,25 @@ describe('Picker.Range', () => {
       });
     });
 
-    it('should keep the pending selection when hovering with confirmation', async () => {
-      const { container } = render(<DayRangePicker showTime />);
-      openPicker(container);
-      selectCell(11);
+    it.each([true, false])(
+      'should keep the pending selection when hovering with needConfirm=%s',
+      async (needConfirm) => {
+        const { container } = render(<DayRangePicker showTime needConfirm={needConfirm} />);
+        openPicker(container);
+        selectCell(11);
 
-      expect(findCell(11)).toHaveClass('rc-picker-cell-range-start');
+        expect(findCell(11)).toHaveClass('rc-picker-cell-range-start');
 
-      fireEvent.mouseEnter(findCell(22));
-      await waitFakeTimer();
+        fireEvent.mouseEnter(findCell(22));
+        await waitFakeTimer();
 
-      expect(container.querySelectorAll('input')[0]).toHaveValue('1990-09-22 00:00:00');
-      expect(findCell(11)).toHaveClass('rc-picker-cell-selected');
-      expect(findCell(11)).not.toHaveClass('rc-picker-cell-range-start');
-      expect(findCell(22)).toHaveClass('rc-picker-cell-hover');
-      expect(findCell(22)).not.toHaveClass('rc-picker-cell-range-start');
-    });
+        expect(container.querySelectorAll('input')[0]).toHaveValue('1990-09-22 00:00:00');
+        expect(findCell(11)).toHaveClass('rc-picker-cell-selected');
+        expect(findCell(11)).not.toHaveClass('rc-picker-cell-range-start');
+        expect(findCell(22)).toHaveClass('rc-picker-cell-hover');
+        expect(findCell(22)).not.toHaveClass('rc-picker-cell-range-start');
+      },
+    );
 
     it('should keep range hover after the first field is confirmed', async () => {
       const { container } = render(<DayRangePicker showTime />);

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -768,6 +768,22 @@ describe('Picker.Range', () => {
         expect(findCell(end)).not.toHaveClass('rc-picker-cell-range-end');
       });
     });
+
+    it('should keep the pending selection when hovering with confirmation', async () => {
+      const { container } = render(<DayRangePicker showTime />);
+      openPicker(container);
+      selectCell(11);
+
+      expect(findCell(11)).toHaveClass('rc-picker-cell-range-start');
+
+      fireEvent.mouseEnter(findCell(22));
+      await waitFakeTimer();
+
+      expect(container.querySelectorAll('input')[0]).toHaveValue('1990-09-22 00:00:00');
+      expect(findCell(11)).toHaveClass('rc-picker-cell-range-start');
+      expect(findCell(22)).toHaveClass('rc-picker-cell-hover');
+      expect(findCell(22)).not.toHaveClass('rc-picker-cell-range-start');
+    });
   });
 
   it('should close when user focus out', () => {

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -785,6 +785,21 @@ describe('Picker.Range', () => {
       expect(findCell(22)).toHaveClass('rc-picker-cell-hover');
       expect(findCell(22)).not.toHaveClass('rc-picker-cell-range-start');
     });
+
+    it('should keep range hover after the first field is confirmed', async () => {
+      const { container } = render(<DayRangePicker showTime />);
+      openPicker(container);
+      selectCell(11);
+      fireEvent.click(document.querySelector('.rc-picker-ok button'));
+      selectCell(22);
+
+      fireEvent.mouseEnter(findCell(25));
+      await waitFakeTimer();
+
+      expect(findCell(11)).toHaveClass('rc-picker-cell-range-start');
+      expect(findCell(15)).toHaveClass('rc-picker-cell-in-range');
+      expect(findCell(25)).toHaveClass('rc-picker-cell-range-end');
+    });
   });
 
   it('should close when user focus out', () => {

--- a/tests/range.spec.tsx
+++ b/tests/range.spec.tsx
@@ -780,7 +780,8 @@ describe('Picker.Range', () => {
       await waitFakeTimer();
 
       expect(container.querySelectorAll('input')[0]).toHaveValue('1990-09-22 00:00:00');
-      expect(findCell(11)).toHaveClass('rc-picker-cell-range-start');
+      expect(findCell(11)).toHaveClass('rc-picker-cell-selected');
+      expect(findCell(11)).not.toHaveClass('rc-picker-cell-range-start');
       expect(findCell(22)).toHaveClass('rc-picker-cell-hover');
       expect(findCell(22)).not.toHaveClass('rc-picker-cell-range-start');
     });


### PR DESCRIPTION
## Summary

- keep a modified RangePicker endpoint selected while its confirmation is pending
- render the hovered cell with an independent hover state while retaining the input preview
- preserve existing range and preset previews and add regression coverage

## Validation

- ut test --runInBand: 15 suites passed, 469 tests passed, 2 skipped
- ut lint:tsc
- ut lint: 0 errors, 16 existing hook warnings
- focused Prettier check and git diff --check

Fixes ant-design/ant-design#59070.

AI assistance disclosure: Codex was used to trace the hover state flow, add the regression test, implement the fix, run validation, and draft this description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 修复 RangePicker 启用时间选择时，选择开始日期后悬停结束日期，待确认的选中状态显示不正确的问题。
  * 优化范围选择中的悬停反馈：已有另一端日期时优先显示完整范围悬停效果。
  * 悬停结束日期时，开始日期与悬停日期的高亮样式及输入框预览值现可正确更新。
* **测试**
  * 增加了针对日期时间范围选择及悬停状态的覆盖测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->