### PR TITLE
fix: use current time in time picker disabledTime

### DIFF
--- a/src/PickerInput/RangePicker.tsx
+++ b/src/PickerInput/RangePicker.tsx
@@ -369,14 +369,16 @@ function RangePicker<DateType extends object = any>(
       ? (date: DateType) => {
           const range = getActiveRange(activeIndex);
           const fromDate = getFromDate(calendarValue, triggeredFields, activeIndex);
-          return disabledTime(date, range, {
+          const targetDate = picker === 'time' ? generateConfig.getNow() : date;
+
+          return disabledTime(targetDate, range, {
             from: fromDate,
           });
         }
       : undefined;
 
     return { ...showTime, disabledTime: proxyDisabledTime };
-  }, [showTime, activeIndex, calendarValue, triggeredFields]);
+  }, [showTime, activeIndex, calendarValue, triggeredFields, picker, generateConfig]);
 
   // ========================= Mode =========================
   const [modes, setModes] = useControlledState<[PanelMode, PanelMode]>([picker, picker], mode);

--- a/src/PickerInput/SinglePicker.tsx
+++ b/src/PickerInput/SinglePicker.tsx
@@ -356,6 +356,21 @@ function Picker<DateType extends object = any>(
     [mergedOpen],
   );
 
+  // ======================= ShowTime =======================
+  /** Used for Popup panel */
+  const mergedShowTime = React.useMemo<SharedTimeProps<DateType>>(() => {
+    if (!showTime) {
+      return null;
+    }
+
+    const { disabledTime } = showTime;
+    const proxyDisabledTime = disabledTime
+      ? (date: DateType) => disabledTime(picker === 'time' ? generateConfig.getNow() : date)
+      : undefined;
+
+    return { ...showTime, disabledTime: proxyDisabledTime };
+  }, [showTime, picker, generateConfig]);
+
   // ======================= Validate =======================
   const [submitInvalidates, onSelectorInvalid] = useFieldsInvalidate(
     calendarValue,
@@ -561,7 +576,7 @@ function Picker<DateType extends object = any>(
       // MISC
       {...panelProps}
       showNow={mergedShowNow}
-      showTime={showTime}
+      showTime={mergedShowTime}
       // Disabled
       disabledDate={disabledDate}
       // Focus

--- a/src/PickerInput/hooks/useInvalidate.ts
+++ b/src/PickerInput/hooks/useInvalidate.ts
@@ -33,8 +33,9 @@ export default function useInvalidate<DateType extends object = any>(
 
       if ((picker === 'date' || picker === 'time') && showTime) {
         const range = info && info.activeIndex === 1 ? 'end' : 'start';
+        const targetDate = picker === 'time' ? generateConfig.getNow() : date;
         const { disabledHours, disabledMinutes, disabledSeconds, disabledMilliseconds } =
-          showTime.disabledTime?.(date, range, { from: outsideInfo.from }) || {};
+          showTime.disabledTime?.(targetDate, range, { from: outsideInfo.from }) || {};
 
         const {
           disabledHours: legacyDisabledHours,

--- a/tests/disabledTime.spec.tsx
+++ b/tests/disabledTime.spec.tsx
@@ -15,6 +15,13 @@ import {
 
 const fakeTime = getDay('1990-09-03 00:00:00').valueOf();
 
+function getHourTexts() {
+  return Array.from(
+    document.querySelector('.rc-picker-time-panel-column').querySelectorAll('li'),
+    (cell) => cell.textContent,
+  );
+}
+
 describe('Picker.DisabledTime', () => {
   beforeEach(() => {
     resetWarned();
@@ -44,6 +51,39 @@ describe('Picker.DisabledTime', () => {
     ).toHaveLength(59);
   });
 
+  it('uses current time for disabledTime on TimePicker', () => {
+    jest.setSystemTime(getDay('1990-09-03 12:00:00').valueOf());
+    const disabledTime = jest.fn((now: Dayjs) => ({
+      disabledHours: () => [now.hour()],
+    }));
+
+    render(<DayPicker open picker="time" hideDisabledOptions disabledTime={disabledTime} />);
+
+    expect(getHourTexts()).not.toContain('12');
+    expect(getHourTexts()).toContain('14');
+
+    const callCountBeforeSelect = disabledTime.mock.calls.length;
+    selectCell('14');
+
+    expect(disabledTime.mock.calls.length).toBeGreaterThan(callCountBeforeSelect);
+    disabledTime.mock.calls.forEach(([now]) => {
+      expect(now.hour()).toBe(12);
+    });
+    expect(getHourTexts()).not.toContain('12');
+    expect(getHourTexts()).toContain('14');
+  });
+
+  it('uses selected date for disabledTime on DatePicker with showTime', () => {
+    const disabledTime = jest.fn((date: Dayjs) => ({
+      disabledHours: () => [date.hour() + 1],
+    }));
+    const selectedDate = getDay('1989-11-28 14:00:00');
+
+    render(<DayPicker open showTime defaultValue={selectedDate} disabledTime={disabledTime} />);
+
+    expect(disabledTime.mock.calls.some(([date]) => date.isSame(selectedDate, 'day'))).toBeTruthy();
+  });
+
   it('disabledTime on TimeRangePicker', () => {
     const { container } = render(
       <DayRangePicker
@@ -69,6 +109,32 @@ describe('Picker.DisabledTime', () => {
         'ul.rc-picker-time-panel-column li.rc-picker-time-panel-cell-disabled',
       ),
     ).toHaveLength(2);
+  });
+
+  it('uses current time for disabledTime on TimeRangePicker', () => {
+    jest.setSystemTime(getDay('1990-09-03 12:00:00').valueOf());
+    const disabledTime = jest.fn((now: Dayjs) => ({
+      disabledHours: () => [now.hour()],
+    }));
+
+    const { container } = render(
+      <DayRangePicker picker="time" hideDisabledOptions disabledTime={disabledTime} />,
+    );
+
+    openPicker(container);
+
+    expect(getHourTexts()).not.toContain('12');
+    expect(getHourTexts()).toContain('14');
+
+    const callCountBeforeSelect = disabledTime.mock.calls.length;
+    selectCell('14');
+
+    expect(disabledTime.mock.calls.length).toBeGreaterThan(callCountBeforeSelect);
+    disabledTime.mock.calls.forEach(([now]) => {
+      expect(now.hour()).toBe(12);
+    });
+    expect(getHourTexts()).not.toContain('12');
+    expect(getHourTexts()).toContain('14');
   });
 
   it('disabledTime', async () => {


### PR DESCRIPTION
Fix https://github.com/ant-design/ant-design/issues/48276

## Problem

For a pure time picker, `disabledTime` receives the panel's draft value after an hour is selected instead of the current time.

This can cause the selected hour to become disabled or disappear when `hideDisabledOptions` is enabled.

## Solution

Use `generateConfig.getNow()` when invoking `disabledTime` for pure time pickers in both SinglePicker and RangePicker, including value validation.

DatePicker with `showTime` continues to receive the selected date so date-dependent rules are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复时间选择器中禁用时间判断使用选中日期的问题，现改为基于当前时间计算。
  * 时间范围选择器的禁用时间行为同步更新。
  * 日期选择器搭配时间选择时，仍基于所选日期进行禁用时间判断。
  * 优化未配置时间选择选项时的弹出面板处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->