### PR TITLE
fix: preserve picker focus at navigation boundaries

### DIFF
--- a/src/PickerInput/hooks/useFocusEvents.ts
+++ b/src/PickerInput/hooks/useFocusEvents.ts
@@ -50,9 +50,10 @@ export function isTargetInContainers(
  * 处理 field 的聚焦与失焦事件。
  *
  * Always forward the actual element focus events. Only the internal Picker
- * blur is skipped when `relatedTarget` still belongs to the Picker.
- * 始终转发元素实际发生的焦点事件。仅当 `relatedTarget` 仍属于 Picker 时，
- * 跳过 Picker 内部的整体失焦逻辑。
+ * blur is skipped when `relatedTarget` still belongs to the Picker or the
+ * focused panel control becomes disabled.
+ * 始终转发元素实际发生的焦点事件。当 `relatedTarget` 仍属于 Picker，或面板中
+ * 获得焦点的控件变为禁用时，跳过 Picker 的整体失焦逻辑。
  */
 export default function useFocusEvents(
   isInternalElement: IsInternalElement,
@@ -71,8 +72,12 @@ export default function useFocusEvents(
     onFocus?.(index, event);
   });
 
-  const onFieldBlur = useEvent((index: number, _source: FocusSource, event: PickerFocusEvent) => {
-    if (!isInternalElement(event.relatedTarget)) {
+  const onFieldBlur = useEvent((index: number, source: FocusSource, event: PickerFocusEvent) => {
+    const isDisabledTarget = source === 'panel' && event.target.hasAttribute('disabled');
+
+    if (isDisabledTarget) {
+      event.currentTarget.focus({ preventScroll: true });
+    } else if (!isInternalElement(event.relatedTarget)) {
       setFocusedIndex(null);
       onConfirmedBlur?.(index, event);
     }

--- a/tests/picker.spec.tsx
+++ b/tests/picker.spec.tsx
@@ -1690,6 +1690,33 @@ describe('Picker.Basic', () => {
     testPropsName('defaultOpenValue');
   });
 
+  it('keeps open when a disabled navigation button blurs', async () => {
+    const onBlur = jest.fn();
+    const { container } = render(
+      <DayPicker
+        defaultPickerValue={dayjs('2019-09-03')}
+        minDate={dayjs('2019-08-01')}
+        onBlur={onBlur}
+      />,
+    );
+
+    openPicker(container);
+
+    const prevButton = document.querySelector<HTMLButtonElement>('.rc-picker-header-prev-btn');
+    const panelContainer = document.querySelector<HTMLElement>('.rc-picker-panel-container');
+
+    triggerFocus(prevButton);
+    fireEvent.click(prevButton);
+    expect(prevButton).toBeDisabled();
+
+    fireEvent.blur(prevButton, { relatedTarget: null });
+    await waitFakeTimer();
+
+    expect(onBlur).toHaveBeenCalled();
+    expect(document.activeElement).toBe(panelContainer);
+    expect(isOpen()).toBeTruthy();
+  });
+
   it('auto switch pickerValue - maxDate', () => {
     const { container } = render(<DayPicker maxDate={dayjs('1989-01-01')} />);
 


### PR DESCRIPTION
## Summary

- keep the picker open when a focused panel control becomes disabled
- treat the resulting blur as internal and move focus to the panel container
- add regression coverage for the disabled-target blur path

## Root cause

Chrome 152 defers the blur caused by disabling the focused button. React therefore receives the blur after the DOM commit with a null relatedTarget, causing the picker to treat the focus as having left the popup.

## Testing

- Full test suite: 469 passed
- TypeScript check
- ESLint
- Chrome 152.0.7977.82 browser verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修复日期选择器设置 `minDate` 后，点击上一页按钮可能导致焦点异常的问题。
  - 当面板中的控件因限制变为禁用状态时，焦点会保持在选择器面板内，选择器不会意外关闭。
  - 优化失焦处理，确保相关失焦事件正常触发，同时避免不必要的整体失焦行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->